### PR TITLE
Add internal URLs back

### DIFF
--- a/lib/providers/http/index.js
+++ b/lib/providers/http/index.js
@@ -39,11 +39,12 @@ class AeHttpProvider {
    * @param version HTTP API version
    * @param secured Use the https protocol if set to `true`
    */
-  constructor(host, port, {version = CURRENT_API_VERSION, secured = false} = {}) {
+  constructor(host, port, {version = CURRENT_API_VERSION, secured = false, internal = false} = {}) {
     this.host = host || 'localhost'
     this.port = port || 3003
     this.version = version
     this.protocol = secured ? 'https' : 'http'
+    this.internal = internal ? 'internal/' : ''
 
     this.base = new Base(this)
     this.aens = new AENS(this)
@@ -52,7 +53,7 @@ class AeHttpProvider {
     this.tx = new Transactions(this)
     this.contracts = new Contracts(this)
 
-    this.baseUrl = `${this.protocol}://${this.host}:${this.port}/${this.version}/`
+    this.baseUrl = `${this.protocol}://${this.host}:${this.port}/${this.internal}${this.version}/`
   }
 
   // noinspection JSUnusedGlobalSymbols


### PR DESCRIPTION
Add back `/internal`, to be able to test basic functionalities like: _getBalance_