### PR TITLE
Add sign and verify for personal messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /dist
 /.envrc
 /yarn-error.log
+.idea

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -87,6 +87,21 @@ function verify (str, signature, publicKey) {
   return nacl.sign.detached.verify(new Uint8Array(str), signature, publicKey)
 }
 
+function personalMessageToBinary (message) {
+  const p = Buffer.from('‎Æternity Signed Message:\n', 'utf8')
+  const msg = Buffer.from(message, 'utf8')
+  if (msg.length >= 0xFD) throw new Error('message too long')
+  return Buffer.concat([Buffer.from([p.length]), p, Buffer.from([msg.length]), msg])
+}
+
+function signPersonalMessage (message, privateKey) {
+  return sign(personalMessageToBinary(message), privateKey)
+}
+
+function verifyPersonalMessage (str, signature, publicKey) {
+  return verify(personalMessageToBinary(str), signature, publicKey)
+}
+
 export default {
   hash,
   encodeBase58Check,
@@ -122,6 +137,9 @@ export default {
 
   sign,
   verify,
+
+  signPersonalMessage,
+  verifyPersonalMessage,
 
   decodeTx (txHash) {
     let decodedTx = decodeBase58Check(txHash.split('$')[1])

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -86,4 +86,38 @@ describe('crypto', () => {
       assert.isTrue(result)
     })
   })
+
+  describe('personal messages', () => {
+    const message = 'test'
+    const messageSignatureAsHex = '0d969f938571d1436106af659bc1893e7efeda685d7f096be39d0f2c68f712e4e9ba7551df31350a4a6d07943fbfc1cbe0acfe8271cd2dcdaac3274168e53901'
+    const messageSignature = Buffer.from(messageSignatureAsHex, 'hex')
+
+    const messageNonASCII = 'tæst'
+    const messageNonASCIISignatureAsHex = '0aad557b424b33f4a2e415339d7ee143dea1f00c4a7c6c8680e1f70ff21e42b17e0e3729420daaed962999e089a18d099d39dc4a5ab4598d2b062106b59f1d01'
+    const messageNonASCIISignature = Buffer.from(messageNonASCIISignatureAsHex, 'hex')
+
+    describe('sign', () => {
+      it('should produce correct signature of message', () => {
+        const s = Crypto.signPersonalMessage(message, privateKey)
+        expect(s).to.eql(messageSignature)
+      })
+
+      it('should produce correct signature of message with non-ASCII chars', () => {
+        const s = Crypto.signPersonalMessage(messageNonASCII, privateKey)
+        expect(s).to.eql(messageNonASCIISignature)
+      })
+    })
+
+    describe('verify', () => {
+      it('should verify message', () => {
+        const result = Crypto.verifyPersonalMessage(message, messageSignature, publicKey)
+        assert.isTrue(result)
+      })
+
+      it('should verify message with non-ASCII chars', () => {
+        const result = Crypto.verifyPersonalMessage(messageNonASCII, messageNonASCIISignature, publicKey)
+        assert.isTrue(result)
+      })
+    })
+  })
 })

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -15,73 +15,74 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 
+import { describe, it } from 'mocha'
 import { assert, expect } from 'chai'
 import Crypto from '../src/utils/crypto'
 
 // These keys are fixations for the encryption lifecycle tests and will
 // not be used for signing
 const privateKeyAsHex = '4d881dd1917036cc231f9881a0db978c8899dd76a817252418606b02bf6ab9d22378f892b7cc82c2d2739e994ec9953aa36461f1eb5a4a49a5b0de17b3d23ae8'
-const publicKey = 'ak$Gd6iMVsoonGuTF8LeswwDDN2NF5wYHAoTRtzwdEcfS32LWoxm'
+const privateKey = Buffer.from(privateKeyAsHex, 'hex')
+const publicKeyWithPrefix = 'ak$Gd6iMVsoonGuTF8LeswwDDN2NF5wYHAoTRtzwdEcfS32LWoxm'
+const publicKey = Buffer.from(Crypto.decodeBase58Check(publicKeyWithPrefix.split('$')[1]))
 
-const txBinary = [248, 76, 12, 1, 160, 35, 120, 248, 146, 183, 204, 130, 194, 210, 115, 158, 153, 78, 201, 149, 58, 163, 100, 97, 241, 235, 90, 74, 73, 165, 176, 222, 23, 179, 210, 58, 232, 160, 63, 40, 35, 12, 40, 65, 38, 215, 218, 236, 136, 133, 42, 120, 160, 179, 18, 191, 241, 162, 198, 203, 209, 173, 89, 136, 202, 211, 158, 59, 12, 122, 1, 1, 1, 132, 84, 101, 115, 116]
-const signature = [95, 146, 31, 37, 95, 194, 36, 76, 58, 49, 167, 156, 127, 131, 142, 248, 25, 121, 139, 109, 59, 243, 203, 205, 16, 172, 115, 143, 254, 236, 33, 4, 43, 46, 16, 190, 46, 46, 140, 166, 76, 39, 249, 54, 38, 27, 93, 159, 58, 148, 67, 198, 81, 206, 106, 237, 91, 131, 27, 14, 143, 178, 130, 2]
+const txBinaryAsArray = [248, 76, 12, 1, 160, 35, 120, 248, 146, 183, 204, 130, 194, 210, 115, 158, 153, 78, 201, 149, 58, 163, 100, 97, 241, 235, 90, 74, 73, 165, 176, 222, 23, 179, 210, 58, 232, 160, 63, 40, 35, 12, 40, 65, 38, 215, 218, 236, 136, 133, 42, 120, 160, 179, 18, 191, 241, 162, 198, 203, 209, 173, 89, 136, 202, 211, 158, 59, 12, 122, 1, 1, 1, 132, 84, 101, 115, 116]
+const txBinary = Buffer.from(txBinaryAsArray)
+const signatureAsArray = [95, 146, 31, 37, 95, 194, 36, 76, 58, 49, 167, 156, 127, 131, 142, 248, 25, 121, 139, 109, 59, 243, 203, 205, 16, 172, 115, 143, 254, 236, 33, 4, 43, 46, 16, 190, 46, 46, 140, 166, 76, 39, 249, 54, 38, 27, 93, 159, 58, 148, 67, 198, 81, 206, 106, 237, 91, 131, 27, 14, 143, 178, 130, 2]
+const signature = Buffer.from(signatureAsArray)
 
 describe('crypto', () => {
   describe('generateKeyPair', () => {
     it('generates an account key pair', () => {
-      let keyPair = Crypto.generateKeyPair()
+      const keyPair = Crypto.generateKeyPair()
       assert.ok(keyPair)
       assert.isTrue(keyPair.pub.startsWith('ak$'))
       assert.isAtLeast(keyPair.pub.length, 52)
       assert.isAtMost(keyPair.pub.length, 53)
     })
   })
+
   describe('encryptPassword', () => {
     describe('generate a password encrypted key pair', () => {
-      let keyPair = Crypto.generateKeyPair(true)
-      let password = 'verysecret'
+      const keyPair = Crypto.generateKeyPair(true)
+      const password = 'verysecret'
 
       it('works for private keys', () => {
-        let privateBinary = keyPair.priv
+        const privateBinary = keyPair.priv
 
-        let encryptedPrivate = Crypto.encryptPrivateKey(password, privateBinary)
-        let decryptedPrivate = Crypto.decryptPrivateKey(password, encryptedPrivate)
-        assert.equal(
-          Buffer.from(decryptedPrivate).toString('hex'),
-          Buffer.from(privateBinary).toString('hex')
-        )
+        const encryptedPrivate = Crypto.encryptPrivateKey(password, privateBinary)
+        const decryptedPrivate = Crypto.decryptPrivateKey(password, encryptedPrivate)
+        assert.deepEqual(decryptedPrivate, privateBinary)
       })
       it('works for public keys', () => {
-        let publicBinary = keyPair.pub
-        let encryptedPublic = Crypto.encryptPublicKey(password, publicBinary)
-        let decryptedPublic = Crypto.decryptPubKey(password, encryptedPublic)
-        assert.equal(
-          Buffer.from(decryptedPublic).toString('hex'),
-          Buffer.from(publicBinary).toString('hex')
-        )
+        const publicBinary = keyPair.pub
+        const encryptedPublic = Crypto.encryptPublicKey(password, publicBinary)
+        const decryptedPublic = Crypto.decryptPubKey(password, encryptedPublic)
+        assert.deepEqual(decryptedPublic, publicBinary)
       })
     })
   })
+
   describe('encodeBase', () => {
     it('can be encoded and decoded', () => {
-      let input = 'helloword010101023'
-      let inputBuffer = Buffer.from(input)
-      let encoded = Crypto.encodeBase58Check(inputBuffer)
-      let decoded = Crypto.decodeBase58Check(encoded)
+      const input = 'helloword010101023'
+      const inputBuffer = Buffer.from(input)
+      const encoded = Crypto.encodeBase58Check(inputBuffer)
+      const decoded = Crypto.decodeBase58Check(encoded)
       assert.equal(input, decoded)
     })
   })
+
   describe('sign', () => {
-    it('should produce correct signature', async () => {
-      let privateKey = Buffer.from(privateKeyAsHex, 'hex')
-      let s = Crypto.sign(Buffer.from(txBinary), privateKey)
-      expect(s).to.eql(Buffer.from(signature))
+    it('should produce correct signature', () => {
+      const s = Crypto.sign(txBinary, privateKey)
+      expect(s).to.eql(signature)
     })
   })
+
   describe('verify', () => {
-    it('should verify tx with correct signature', async () => {
-      let pub = Buffer.from(Crypto.decodeBase58Check(publicKey.split('$')[1]))
-      let result = Crypto.verify(Buffer.from(txBinary), Buffer.from(signature), pub)
+    it('should verify tx with correct signature', () => {
+      const result = Crypto.verify(txBinary, signature, publicKey)
       assert.isTrue(result)
     })
   })

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -15,7 +15,7 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 
-import { assert } from 'chai'
+import { assert, expect } from 'chai'
 import Crypto from '../src/utils/crypto'
 
 // These keys are fixations for the encryption lifecycle tests and will
@@ -23,7 +23,6 @@ import Crypto from '../src/utils/crypto'
 const privateKeyAsHex = '4d881dd1917036cc231f9881a0db978c8899dd76a817252418606b02bf6ab9d22378f892b7cc82c2d2739e994ec9953aa36461f1eb5a4a49a5b0de17b3d23ae8'
 const publicKey = 'ak$Gd6iMVsoonGuTF8LeswwDDN2NF5wYHAoTRtzwdEcfS32LWoxm'
 
-const validUnsignedTx = 'tx$2uE4tuGbXmmXCAxBgykHq8JwrHf38xXtBE8NaUhjahLUaAdquBsspqpGmyEC9QE9gv5Zu4oTMcvoxCiKLDzipkUqBWCVB9Liuk73fqANjiAEtjUv2PsRC7hrRG4qjB6m1d4UVyrag815kodXygDUCaNXgfeqjGbffJy7sBwGd6cruDqYRLxpALxaCZEdY14T3DTvxWDnXGM2pR3Z4o9HujQY9PbDrk8XuuG9gKYFMmxvSRPje34ZXRxkeXicmGfn9TF63PYQhM4EjvAZXsfL2ZdAB8zCQpCVGwFWmuTxSL9yDoZmCwK9gP7g7G2AnsrJZjdv2UZKY6rrHwZLEgpdkADfKvHT9cjvuXcQfBfFRW17PP3fmiPpXaG4BpaiTuf4Cj79egcx2Wo6gB9rBqKndSQeCvUb8a25D2XoR7yyVjF6to2hPnw'
 const txBinary = [248, 76, 12, 1, 160, 35, 120, 248, 146, 183, 204, 130, 194, 210, 115, 158, 153, 78, 201, 149, 58, 163, 100, 97, 241, 235, 90, 74, 73, 165, 176, 222, 23, 179, 210, 58, 232, 160, 63, 40, 35, 12, 40, 65, 38, 215, 218, 236, 136, 133, 42, 120, 160, 179, 18, 191, 241, 162, 198, 203, 209, 173, 89, 136, 202, 211, 158, 59, 12, 122, 1, 1, 1, 132, 84, 101, 115, 116]
 const signature = [95, 146, 31, 37, 95, 194, 36, 76, 58, 49, 167, 156, 127, 131, 142, 248, 25, 121, 139, 109, 59, 243, 203, 205, 16, 172, 115, 143, 254, 236, 33, 4, 43, 46, 16, 190, 46, 46, 140, 166, 76, 39, 249, 54, 38, 27, 93, 159, 58, 148, 67, 198, 81, 206, 106, 237, 91, 131, 27, 14, 143, 178, 130, 2]
 
@@ -72,13 +71,11 @@ describe('crypto', () => {
       assert.equal(input, decoded)
     })
   })
-  describe('sign and verify', () => {
-    it('should work together', async () => {
+  describe('sign', () => {
+    it('should produce correct signature', async () => {
       let privateKey = Buffer.from(privateKeyAsHex, 'hex')
-      let signature = Crypto.sign(validUnsignedTx, privateKey)
-      let pub = Buffer.from(Crypto.decodeBase58Check(publicKey.split('$')[1]))
-      let verified = Crypto.verify(validUnsignedTx, signature, pub)
-      assert.isTrue(verified)
+      let s = Crypto.sign(Buffer.from(txBinary), privateKey)
+      expect(s).to.eql(Buffer.from(signature))
     })
   })
   describe('verify', () => {


### PR DESCRIPTION
For the Voting app, it is necessary to implement methods for signing and verifying of personal messages. But I can't find anything that describes how this messages should be signed on Aeternity. I propose to use the approach similar to Bitcoin and Ethereum approaches.
In https://github.com/ethereum/go-ethereum/issues/14794 proposed to use `varint` from Bitcoin to store message length, I suppose to implement it later in case if this whole approach is acceptable.
Depends on #32 