### PR TITLE
Webpack postMessage interference

### DIFF
--- a/es/rpc/client.js
+++ b/es/rpc/client.js
@@ -49,7 +49,7 @@ const RpcClient = stampit(AsyncInit, {
     const callbacks = {}
 
     function receive ({data}) {
-      if (typeof data !== 'object') {
+      if (typeof data !== 'object' || data.type === 'webpackOk') {
         return
       }
 


### PR DESCRIPTION
This tiny change helps Devs (using ES6 modules) avoid webpack-dev-server postMessage interference.