### PR TITLE
crypto tests: Set minimum address length to 51

### DIFF
--- a/test/unit/crypto.js
+++ b/test/unit/crypto.js
@@ -38,7 +38,7 @@ describe('crypto', () => {
       const keyPair = Crypto.generateKeyPair()
       assert.ok(keyPair)
       assert.isTrue(keyPair.publicKey.startsWith('ak_'))
-      assert.isAtLeast(keyPair.publicKey.length, 52)
+      assert.isAtLeast(keyPair.publicKey.length, 51)
       assert.isAtMost(keyPair.publicKey.length, 53)
     })
   })


### PR DESCRIPTION
As I know from https://github.com/aeternity/aepp-identity/pull/147 Epoch address length in between 51 and 53 chars.
Fixes failure of this test: https://ci.aepps.com/blue/organizations/jenkins/aepp-sdk-js/detail/PR-116/3/tests
