### PR TITLE
Fix import of RLP package

### DIFF
--- a/es/utils/crypto.js
+++ b/es/utils/crypto.js
@@ -22,7 +22,7 @@
  */
 
 import bs58check from 'bs58check'
-import RLP from 'rlp'
+import * as RLP from 'rlp'
 import { blake2b } from 'blakejs'
 import nacl from 'tweetnacl'
 import aesjs from 'aes-js'


### PR DESCRIPTION
This fixes the error that I have in the Base app when I'm trying to use aepp-sdk@1.1.2:
```
VM3844 crypto.js:499 Uncaught TypeError: Cannot read property 'decode' of undefined
    at Module.eval (VM3844 crypto.js:499)
    at eval (VM3844 crypto.js:590)
    at Module../node_modules/@aeternity/aepp-sdk/es/utils/crypto.js (VM3699 app.js:1229)
    at __webpack_require__ (VM3699 app.js:768)
    at fn (VM3699 app.js:131)
    at Module.eval (VM3839 index.js:6)
    at eval (VM3839 index.js:111)
    at Module../node_modules/@aeternity/aepp-sdk/es/account/index.js (VM3699 app.js:917)
    at __webpack_require__ (VM3699 app.js:768)
    at fn (VM3699 app.js:131)
```