### PR TITLE
Use rlp 2.1.0 due to issue with building

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "promisify-child-process": "^2.1.2",
     "ramda": "^0.25.0",
     "recursive-rename": "^2.0.0",
-    "rlp": "^2.0.0",
+    "rlp": "2.1.0",
     "semver": "^5.6.0",
     "serialize-javascript": "^1.5.0",
     "sha.js": "^2.4.11",


### PR DESCRIPTION
Use rlp 2.1.0 due to issue with building latest version(require dev-dependency BN.js)