### PR TITLE
RpcServer: Avoid storing of window in instance properties

### DIFF
--- a/es/rpc/client.js
+++ b/es/rpc/client.js
@@ -32,10 +32,6 @@ function post (method) {
   }
 }
 
-function destroyClient () {
-  this.self.removeEventListener('message', this.handler, false)
-}
-
 /**
  * RPC client Stamp
  * @function
@@ -79,19 +75,18 @@ const RpcClient = stampit(AsyncInit, {
 
       return ret
     }
-    this.handler = receive
 
-    self.addEventListener('message', this.handler, false)
-    this.self = self
+    const handler = receive
+    self.addEventListener('message', handler, false)
+    this.destroyClient = () =>
+      self.removeEventListener('message', handler, false)
+
     this.session = await this.post('hello')
   },
   props: {
-    handler: null,
-    self: null
+    handler: null
   },
-  methods: {
-    destroyClient
-  },
+  methods: {},
   composers ({ stamp, composables }) {
     // Combine Ae and Contract methods
     const methods = [

--- a/es/rpc/server.js
+++ b/es/rpc/server.js
@@ -25,10 +25,6 @@ function createSession () {
   return id
 }
 
-function destroyServer () {
-  this.self.removeEventListener('message', this.handler, false)
-}
-
 function hello () {
   return Promise.resolve(this.createSession())
 }
@@ -59,18 +55,16 @@ async function receive ({ data, origin, source }) {
 
 const RpcServer = stampit({
   init ({ self = window }) {
-    this.self = self
-    this.handler = this.receive.bind(this)
-    this.self.addEventListener('message', this.handler, false)
+    const handler = this.receive.bind(this)
+    self.addEventListener('message', handler, false)
+    this.destroyServer = () =>
+      self.removeEventListener('message', handler, false)
   },
   methods: {
     receive,
-    createSession,
-    destroyServer
+    createSession
   },
   props: {
-    handler: null,
-    self: null,
     rpcSessions: {}
   },
   deepProps: {


### PR DESCRIPTION
Without this I can't put the instance of sdk in Vuex store because of error:
```
vue.runtime.esm.js:1964 Uncaught (in promise) RangeError: Maximum call stack size exceeded
    at Function.keys (<anonymous>)
    at _traverse (vue.runtime.esm.js:1964)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
    at _traverse (vue.runtime.esm.js:1966)
```

Probably, the same adjustments should be made in RPC client.