### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [2.3.0-next]
+### Added
+- Add `channel` `withdraw` and `deposit` methods
+
+### Changed
+- Change default `gasPrice` in `Contract` stamp and `Tx` stamp to `1e9`
+- Fix `contract` tx `fee` calculation
+- Refactor error handling in `sendTransaction` function
+- Change default `gasPrice` to `1e9`
+- Change `Fee` byte_size to 1
+
+### Removed
+- none
+
+### Breaking Changes
+- none
+
+### Notes and known Issues
+- none
+
+
 ## [2.2.1-next]
 ### Added
 - Add `deserialization` schema for `Channel` transactions(`channelCreate`, `channelCloseMutual`, `channelDeposit`, `channelWithdraw`, `channelSettle`) 
@@ -484,3 +505,4 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 [2.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/2.0.0...2.1.0
 [2.1.1-0.1.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.1.0...2.1.1-0.1.0-next
 [2.2.1-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.1.1-0.1.0-next...2.2.1-next
+[2.3.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.2.1-next...2.3.0-next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [2.3.0-next]
 ### Added
+- `Minerva` comparability
+- Add `Mnemonic` wallet implementation `es/utils/hd-wallet`
+
+### Changed
+- Change Channel `legacy` API to `JSON RPC`
+- Change default `gasPrice` to `1e6`
+- Change `minFee` calculation, multiply min fee by `1e9`
+
+### Removed
+- none
+
+### Breaking Changes
+- none
+
+### Notes and known Issues
+- Change supported node version range to `1.4.0 <= version < 3.0.0`
+- This release contain changes from: [2.3.0-next](), [2.2.1-next](), [2.1.1-0.1.0-next](), [2.1.0]()
+
+## [2.3.0-next]
+### Added
 - Add `channel` `withdraw` and `deposit` methods
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Notes and known Issues
 - Change supported node version range to `1.4.0 <= version < 3.0.0`
-- This release contain changes from: [2.3.0-next](), [2.2.1-next](), [2.1.1-0.1.0-next](), [2.1.0]()
+- This release contain changes from: [2.3.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.3.0-next), [2.2.1-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.2.1-next), [2.1.1-0.1.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.1-0.1.0-next), [2.1.0](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.0)
 
 ## [2.3.0-next]
 ### Added
@@ -526,3 +526,4 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 [2.1.1-0.1.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.1.0...2.1.1-0.1.0-next
 [2.2.1-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.1.1-0.1.0-next...2.2.1-next
 [2.3.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.2.1-next...2.3.0-next
+[2.3.0]: https://github.com/aeternity/aepp-sdk-js/compare/2.3.0-next...2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [2.3.0-next]
+## [2.3.0]
 ### Added
 - `Minerva` comparability
 - Add `Mnemonic` wallet implementation `es/utils/hd-wallet`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "2.2.1-next",
+  "version": "2.3.0-next",
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "browser": "dist/aepp-sdk.browser.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "2.3.0-next",
+  "version": "2.3.0",
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "browser": "dist/aepp-sdk.browser.js",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -14,7 +14,6 @@
  *  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  *  PERFORMANCE OF THIS SOFTWARE.
  */
-
 import Ae from '../../es/ae/universal'
 import * as Crypto from '../../es/utils/crypto'
 import { BigNumber } from 'bignumber.js'


### PR DESCRIPTION
## [2.3.0-next]
### Added
- `Minerva` comparability
- Add `Mnemonic` wallet implementation `es/utils/hd-wallet`

### Changed
- Change Channel `legacy` API to `JSON RPC`
- Change default `gasPrice` to `1e6`
- Change `minFee` calculation, multiply min fee by `1e9`

### Removed
- none

### Breaking Changes
- none

### Notes and known Issues
- Change supported node version range to `1.4.0 <= version < 3.0.0`
- This release contain changes from: [2.3.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.3.0-next), [2.2.1-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.2.1-next), [2.1.1-0.1.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.1-0.1.0-next), [2.1.0](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.0)
