### PR TITLE
Get full channel state support

### DIFF
--- a/es/channel/handlers.js
+++ b/es/channel/handlers.js
@@ -162,7 +162,7 @@ export async function awaitingOffChainTx (channel, message, state) {
 export function awaitingOffChainUpdate (channel, message, state) {
   if (message.method === 'channels.update') {
     changeState(channel, message.params.data.state)
-    state.resolve({ accepted: true, state: message.params.data.state })
+    state.resolve({ accepted: true, signedTx: message.params.data.state })
     return { handler: channelOpen }
   }
   if (message.method === 'channels.conflict') {
@@ -224,7 +224,7 @@ export function awaitingShutdownOnChainTx (channel, message, state) {
 
 export function awaitingLeave (channel, message, state) {
   if (message.method === 'channels.leave') {
-    state.resolve({ channelId: message.params.channel_id, state: message.params.data.state })
+    state.resolve({ channelId: message.params.channel_id, signedTx: message.params.data.state })
     return { handler: channelClosed }
   }
   if (message.method === 'channels.error') {
@@ -262,7 +262,7 @@ export function awaitingWithdrawCompletion (channel, message, state) {
   }
   if (message.method === 'channels.update') {
     changeState(channel, message.params.data.state)
-    state.resolve({ accepted: true, state: message.params.data.state })
+    state.resolve({ accepted: true, signedTx: message.params.data.state })
     return { handler: channelOpen }
   }
   if (message.method === 'channels.conflict') {
@@ -300,7 +300,7 @@ export function awaitingDepositCompletion (channel, message, state) {
   }
   if (message.method === 'channels.update') {
     changeState(channel, message.params.data.state)
-    state.resolve({ accepted: true, state: message.params.data.state })
+    state.resolve({ accepted: true, signedTx: message.params.data.state })
     return { handler: channelOpen }
   }
   if (message.method === 'channels.conflict') {
@@ -329,7 +329,7 @@ export function awaitingNewContractCompletion (channel, message, state) {
     state.resolve({
       accepted: true,
       address: encodeContractAddress(owner, round),
-      state: message.params.data.state
+      signedTx: message.params.data.state
     })
     return { handler: channelOpen }
   }
@@ -350,7 +350,7 @@ export async function awaitingCallContractUpdateTx (channel, message, state) {
 export function awaitingCallContractCompletion (channel, message, state) {
   if (message.method === 'channels.update') {
     changeState(channel, message.params.data.state)
-    state.resolve({ accepted: true, state: message.params.data.state })
+    state.resolve({ accepted: true, signedTx: message.params.data.state })
     return { handler: channelOpen }
   }
   if (message.method === 'channels.conflict') {

--- a/test/integration/channel.js
+++ b/test/integration/channel.js
@@ -119,7 +119,7 @@ describe('Channel', function () {
       async (tx) => await initiator.signTransaction(tx)
     )
     result.accepted.should.equal(true)
-    result.state.should.be.a('string')
+    result.signedTx.should.be.a('string')
     sinon.assert.notCalled(initiatorSign)
     sinon.assert.calledOnce(responderSign)
     sinon.assert.calledWithExactly(responderSign, sinon.match('update_ack'), sinon.match.string)
@@ -188,7 +188,7 @@ describe('Channel', function () {
       async (tx) => initiator.signTransaction(tx),
       { onOnChainTx, onOwnWithdrawLocked, onWithdrawLocked }
     )
-    result.should.eql({ accepted: true, state: initiatorCh.state() })
+    result.should.eql({ accepted: true, signedTx: (await initiatorCh.state()).signedTx })
     sinon.assert.calledOnce(onOnChainTx)
     sinon.assert.calledWithExactly(onOnChainTx, sinon.match.string)
     sinon.assert.calledOnce(onOwnWithdrawLocked)
@@ -227,7 +227,7 @@ describe('Channel', function () {
       async (tx) => initiator.signTransaction(tx),
       { onOnChainTx, onOwnDepositLocked, onDepositLocked }
     )
-    result.should.eql({ accepted: true, state: initiatorCh.state() })
+    result.should.eql({ accepted: true, signedTx: (await initiatorCh.state()).signedTx })
     sinon.assert.calledOnce(onOnChainTx)
     sinon.assert.calledWithExactly(onOnChainTx, sinon.match.string)
     sinon.assert.calledOnce(onOwnDepositLocked)
@@ -278,9 +278,9 @@ describe('Channel', function () {
     await Promise.all([waitForChannel(initiatorCh), waitForChannel(responderCh)])
     const result = await initiatorCh.leave()
     result.channelId.should.be.a('string')
-    result.state.should.be.a('string')
+    result.signedTx.should.be.a('string')
     existingChannelId = result.channelId
-    offchainTx = result.state
+    offchainTx = result.signedTx
   })
 
   it('can reestablish a channel', async () => {
@@ -327,7 +327,7 @@ describe('Channel', function () {
       vmVersion: 3,
       abiVersion: 1
     }, async (tx) => await initiator.signTransaction(tx))
-    result.should.eql({ accepted: true, address: result.address, state: initiatorCh.state() })
+    result.should.eql({ accepted: true, address: result.address, signedTx: (await initiatorCh.state()).signedTx })
     contractAddress = result.address
     contractEncodeCall = (method, args) => initiator.contractEncodeCallDataAPI(identityContract, method, args)
   })
@@ -353,8 +353,8 @@ describe('Channel', function () {
       contract: contractAddress,
       abiVersion: 1
     }, async (tx) => await initiator.signTransaction(tx))
-    result.should.eql({ accepted: true, state: initiatorCh.state() })
-    callerNonce = Number(unpackTx(initiatorCh.state()).tx.encodedTx.tx.round)
+    result.should.eql({ accepted: true, signedTx: (await initiatorCh.state()).signedTx })
+    callerNonce = Number(unpackTx((await initiatorCh.state()).signedTx).tx.encodedTx.tx.round)
   })
 
   it('can call a contract and reject', async () => {


### PR DESCRIPTION
Implements #289

Breaking changes:

- `channel.state()` now returns offchain state instead of last co-signed offchain transaction
- `channel.update(...).state` has been renamed to `signedTx`
- `channel.withdraw(...).state` has been renamed to `signedTx`
- `channel.deposit(...).state` has been renamed to `signedTx`
- `channel.leave().state` has been renamed to `signedTx`
- `channel.createContract(...).state` has been renamed to `signedTx`
- `channel.callContract(...).state` has been renamed to `signedTx`