### PR TITLE
Add prototype of reverse iframe approach to example aepp

### DIFF
--- a/examples/connect-two-ae/identity/src/components/Home.vue
+++ b/examples/connect-two-ae/identity/src/components/Home.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="w-full p-4 flex justify-center flex-col bg-grey h-screen">
+  <div
+    v-if="!runningInFrame"
+    class="w-full p-4 flex justify-center flex-col bg-grey h-screen"
+  >
     <h1 class="mb-4">Wallet Aepp</h1>
 
     <div class="border">
@@ -45,6 +48,7 @@ import MemoryAccount from 'AE_SDK_MODULES/account/memory'
 export default {
   data () {
     return {
+      runningInFrame: window.parent !== window,
       pub: 'ak_6A2vcm1Sz6aqJezkLCssUXcyZTX7X8D5UwbuS2fRJr9KkYpRU', // Your public key
       priv: 'a7a695f999b1872acb13d5b63a830a8ee060ba688a478a08c6e65dfad8a01cd70bb4ed7927f97b51e1bcb5e1340d12335b2a2b12c8bc5221d63c4bcb39d41e61', // Your private key
       client: null,
@@ -74,7 +78,8 @@ export default {
       onContract: this.confirmDialog
     })
 
-    this.$refs.aepp.src = this.aeppUrl
+    if (!this.runningInFrame) this.$refs.aepp.src = this.aeppUrl
+    else window.parent.postMessage({ jsonrpc: '2.0', method: 'ready' }, '*')
 
     this.height = await this.client.height()
     this.balance = await this.client.balance(this.pub).catch(() => 0)


### PR DESCRIPTION
The last commit of this PR contains a prototype of 'reverse-iframe' approach that we are going to implement in the desktop version of Base app and make it compatible with hybrid voting aepp.

This implementation doesn't require any changes in SDK, though would be better to integrate them into sdk somehow to make dapps building easier. 

ps: I was too lazy to rebase it on top of develop branch, so it contains changes from #347, I believe what that PR will get merged earlier than this one.