### PR TITLE
Release/3.1.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-TAG=v2.2.0
+TAG=v2.3.0
 COMPILER_TAG=v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# [3.1.0](https://github.com/aeternity/aepp-sdk-js/compare/2.4.0...3.1.0) (2019-04-24)
+
+
+### Bug Fixes
+
+* **ACI:** Fix address type transformation when decoding data ([#335](https://github.com/aeternity/aepp-sdk-js/issues/335)) ([e37cdfc](https://github.com/aeternity/aepp-sdk-js/commit/e37cdfc))
+
+
+### Features
+
+* **ACI:** Add `contract`, `address`, `record` types argument/result transformation ([#349](https://github.com/aeternity/aepp-sdk-js/issues/349)) ([0599d7d](https://github.com/aeternity/aepp-sdk-js/commit/0599d7d))
+* **ACI:** Update due to compiler API changes ([#331](https://github.com/aeternity/aepp-sdk-js/issues/331)) ([e047f3b](https://github.com/aeternity/aepp-sdk-js/commit/e047f3b))
+* **Aepp:** Add Compiler to Aepp rpc methods. Update example app ([#312](https://github.com/aeternity/aepp-sdk-js/issues/312)) ([9c72521](https://github.com/aeternity/aepp-sdk-js/commit/9c72521))
+* **Compiler:** Add decode CallData by source/bytecode ([#354](https://github.com/aeternity/aepp-sdk-js/issues/354)) ([761f36b](https://github.com/aeternity/aepp-sdk-js/commit/761f36b))
+* **RPC:** Add getNodeInfo and getNetworkId to AEPP stamp through RPC ([#359](https://github.com/aeternity/aepp-sdk-js/issues/359)) ([2ddeea8](https://github.com/aeternity/aepp-sdk-js/commit/2ddeea8))
+* **State Channels:** Add cleanContractCalls method ([#338](https://github.com/aeternity/aepp-sdk-js/issues/338)) ([778159a](https://github.com/aeternity/aepp-sdk-js/commit/778159a))
+* **State Channels:** Ping every 10 seconds to persist connection ([#324](https://github.com/aeternity/aepp-sdk-js/issues/324)) ([6d0e156](https://github.com/aeternity/aepp-sdk-js/commit/6d0e156)), closes [#276](https://github.com/aeternity/aepp-sdk-js/issues/276) [#299](https://github.com/aeternity/aepp-sdk-js/issues/299) [#300](https://github.com/aeternity/aepp-sdk-js/issues/300) [#303](https://github.com/aeternity/aepp-sdk-js/issues/303) [#302](https://github.com/aeternity/aepp-sdk-js/issues/302) [#279](https://github.com/aeternity/aepp-sdk-js/issues/279) [#275](https://github.com/aeternity/aepp-sdk-js/issues/275) [#276](https://github.com/aeternity/aepp-sdk-js/issues/276) [#299](https://github.com/aeternity/aepp-sdk-js/issues/299) [#300](https://github.com/aeternity/aepp-sdk-js/issues/300)
+
+
+
 # [3.0.0](https://github.com/aeternity/aepp-sdk-js/compare/2.4.0...3.0.0) (2019-04-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,49 @@
-# Change Log
-All notable changes to this project will be documented in this file. This change
-log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+# [3.0.0](https://github.com/aeternity/aepp-sdk-js/compare/2.4.0...3.0.0) (2019-04-17)
 
-## [2.4.1]
-### Added
-- feat(ACI): Add transform decoded data for 'address' type
-- feat(Aepp): Add Compiler to Aepp rpc methods. Update example app
-- feat(Channel): Add call contract static support
-- feat(Channel): Add get contract state support
-- feat(Channel): Get full channel state support
-- docs(*): Adjust ACI, Contract and Usage
-### Changed
-- refactor(Http): Handle no response in http stamp error handler
-- fix(Crypto): Fix crypto `formatAddress`
-- fix(Crypto): Move ADDRESS_FORMAT to crypto
 
- ### Removed
-- none
+### Bug Fixes
 
- ### Breaking Changes
-- State Channel:
+* **ACI:** Fix address type transformation when decoding data ([#335](https://github.com/aeternity/aepp-sdk-js/issues/335)) ([e37cdfc](https://github.com/aeternity/aepp-sdk-js/commit/e37cdfc))
+
+
+### Features
+
+* **TX_BUILDER:** Channel tx serializations 
+* **TxValidator:** Add minGasPrice validation to contract transactions
+* **ACI:** Update due to compiler API changes ([#331](https://github.com/aeternity/aepp-sdk-js/issues/331)) ([e047f3b](https://github.com/aeternity/aepp-sdk-js/commit/e047f3b))
+* **Aepp:** Add Compiler to Aepp rpc methods. Update example app ([#312](https://github.com/aeternity/aepp-sdk-js/issues/312)) ([9c72521](https://github.com/aeternity/aepp-sdk-js/commit/9c72521))
+* **State Channels:** Add cleanContractCalls method ([#338](https://github.com/aeternity/aepp-sdk-js/issues/338)) ([778159a](https://github.com/aeternity/aepp-sdk-js/commit/778159a))
+
+
+### BREAKING CHANGES
+
+* **ACI** Remove 2.0.0 compiler compatibility
+
+
+
+# [2.4.1](https://github.com/aeternity/aepp-sdk-js/compare/2.4.0...2.4.1) (2019-04-17)
+
+
+### Features
+
+* **ACI:** Add transform decoded data for 'address' type
+* **AEPP:** Add Compiler to Aepp rpc methods. Update example app
+* **Channel:** Add call contract static support
+* **Channel:** Add get contract state support
+* **Channel:** Get full channel state support
+* **DOCS:** Adjust ACI, Contract and Usage
+
+
+### Bug Fixes
+
+* **HTTP:** Handle no response in http stamp error handler
+* **Crypto:** Fix crypto `formatAddress`
+* **Crypto:** Move ADDRESS_FORMAT to crypto
+
+
+### BREAKING CHANGES
+
+* **Channels:**
   - `channel.state()` now returns offchain state instead of last co-signed offchain transaction
   - `channel.update(...).state` has been renamed to `signedTx`
   - `channel.withdraw(...).state` has been renamed to `signedTx`
@@ -28,635 +52,601 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
   - `channel.createContract(...).state` has been renamed to `signedTx`
   - `channel.callContract(...).state` has been renamed to `signedTx`
 
- ### Notes and known Issues
-- none
+
+# [2.4.0](https://github.com/aeternity/aepp-sdk-js/compare/2.3.2...2.4.0) (2019-04-17)
 
 
-## [2.4.0]
-### Added
-- Install and configure `commitizen`
-- Add `formatAddress` function to `Crypto`
-- Add Contract Compiler API stamp to `es/contract` (now using instead contract node API)
-- Add basic `http` client stamp (`es/utils/http`)
-- ACI stamp (New Contract interface base on contract ACI schema)
-Usage:
-```
-const contractIns = await client.getContractInstance(contractSourceCode)
-console.log(contract)
- {
-   interface: String, // Contract interface source code
-   aci: String, // Contract interface json schema
-   source: String, // Contract source code
-   compiled: String, // Compiled contract code
-   deployInfo: { address: contractAddress } // Object with deploy transaction,
-   // Function
-   compile: () => this, // Compile contract,
-   deploy: (init = [], options = { skipArgsConvert: false }) => this, // Deploy contract (compile before if needed)
-   call: (fn, params = [], options = { skipArgsConvert: false, skipTransformDecoded: false, callStatic: false } => CallRersult: Object // Call contract function
- }
-```
+### Features
+
+* **Chore:** Install and configure `commitizen`
+* **Crypto:** Add `formatAddress` function to `Crypto`
+* **Contract:** Add Contract Compiler API stamp to `es/contract` (now using instead contract node API)
+* **Utils:** Add basic `http` client stamp (`es/utils/http`)
+* **Contract:** ACI stamp (New Contract interface base on contract ACI schema)
+    ```
+    const contractIns = await client.getContractInstance(contractSourceCode)
+    console.log(contract)
+     {
+       interface: String, // Contract interface source code
+       aci: String, // Contract interface json schema
+       source: String, // Contract source code
+       compiled: String, // Compiled contract code
+       deployInfo: { address: contractAddress } // Object with deploy transaction,
+       // Function
+       compile: () => this, // Compile contract,
+       deploy: (init = [], options = { skipArgsConvert: false }) => this, // Deploy contract (compile before if needed)
+       call: (fn, params = [], options = { skipArgsConvert: false, skipTransformDecoded: false, callStatic: false } => CallRersult: Object // Call contract function
+     }
+    ```
+* **Account:** Extend  `Account.address()` with `accountFormatter` now you can do
+    ```
+    export const ADDRESS_FORMAT = {
+      sophia: 1, // return address like `0xHEX_ADDRESS`
+      api: 2, // return address like `ak_9LJ8ne9tks78hTD2Tp571f7w2MJmzQMRsiZxKCkMA2d2Sbrc4`
+    }
+    
+    //
+    
+    export { ADDRESS_FORMAT } from 'es/account'
+    await account.address(format: ADDRESS_FORMAT) // default ADDRESS_FORMAT.api
+    ```
+* **Channel:** Improve channel rpc usage
+* **Channel:** Improve channel tests and error handling
+* **Channel:** Improve state channel params handling
+* **Chain:** Add ability to get `account/balance` on specific block `hash/height`
+* **Universal:** Add `{ compilerUrl }` to `Universal, Contract, Wallet` stamp initialization
+
+
+### Bug Fixes
+
+* **Contract:** decode node error coming from contract `call` and `callStatic`
+* **Chain:** Throw native error instead of object in chain `chain.sendTransaction`
+* **Crypto:** fix arguments parsing in `Crypto.sing`
+* **Crypto:** Fix `name hash` function arguments parsing in `Crypto`
+
+
+ ### BREAKING CHANGES
+ * **Contract:** Remove `ContractNodeAPI` stamp
+ * **Contract:** Change Contract stamp API
+    ```
+    1) Use Compiler instead of node API for encode/decode call-data and compile.
+    2) Change Contract interface:
+     - contractCallStatic (address, abi = 'sophia-address', name, { top, args = '()', call, options = {} } = {}) -> (source, address, name, args = [], { top, options = {} } = {}))
+     - contractCall (code, abi, address, name, { args = '()', options = {}, call } = {}) -> (source, address, name, args = [], options = {})
+     - contractDeploy (code, abi, { initState = '()', options = {} } = {}) -> (code, source, initState = [], options = {})
+     - contractEncodeCall (code, abi, name, args, call) -> (source, name, args) // 'source' is -> Contract source code or ACI interface source
+    ```
+
+
+## [2.3.2](https://github.com/aeternity/aepp-sdk-js/compare/2.3.1...2.3.2) (2019-03-04)
+
+
+### Features
+
+* **Contract:** Change default `gasPrice` from `1e6` to `1e9z
+* **AEPP:** Fix `AEPP` example app
+* **Build:** Force `image` pull before `builds`
+
+
+# [2.3.1](https://github.com/aeternity/aepp-sdk-js/compare/2.3.0...2.3.1) (2019-02-22)
+
+
+### Features
+
+* **Oracle:** `Oracle` fee calculation
+* **Tx:** `getAccountNonce` function to `tx` stamp
+* **TX_BUILDER:** Change `FEE_BYTE_SIZE` from 1 to 8 bytes in `fee` calculation
+* **TX_BUILDER:** Improve error handling in `tx` builder
+
+
+# [2.3.0](https://github.com/aeternity/aepp-sdk-js/compare/2.3.0-next...2.3.0) (2019-02-22)
+
+
+### Features
+
+* **Node:** `Minerva` comparability
+* **Utils:** `Mnemonic` wallet implementation `es/utils/hd-wallet`
+* **Oracle:** Change Channel `legacy` API to `JSON RPC`
+* **Oracle:** Change default `gasPrice` to `1e6`
+* **Oracle:** Change `minFee` calculation, multiply min fee by `1e9`
+
+### BREAKING CHANGES
+
+* **Node:** Change supported node version range to `1.4.0 <= version < 3.0.0`
+* This release contain changes from: [2.3.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.3.0-next), [2.2.1-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.2.1-next), [2.1.1-0.1.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.1-0.1.0-next), [2.1.0](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.0)
+
+
+
+# [2.3.0-next](https://github.com/aeternity/aepp-sdk-js/compare/2.2.1-next...2.3.0-next) (2019-02-21)
+
+
+### Features
+
+* **Channel:** `channel` `withdraw` and `deposit` methods
+* **TX_BUILDER:** Change default `gasPrice` in `Contract` stamp and `Tx` stamp to `1e9`
+* **TX:** Fix `contract` tx `fee` calculation
+* **Chain:** Refactor error handling in `sendTransaction` function
+* **Contract:** Change default `gasPrice` to `1e9`
+* **TX_BUILDER:** Change `Fee` byte_size to 1
+
+
+
+# [2.2.1-next](https://github.com/aeternity/aepp-sdk-js/compare/2.1.1-0.1.0-next...2.2.1-next) (2019-02-21)
+
+
+### Feature
+
+* **TX_BUILDER:** Add `deserialization` schema for `Channel` transactions(`channelCreate`, `channelCloseMutual`, `channelDeposit`, `channelWithdraw`, `channelSettle`) 
+* **Chain:** Add `rawTx` and `verifyTx` to error from poll function(when you wait for transaction will mined)
+* **Chore:** Depend on `bip39` from npm instead of git repo
+* **Channel:** Change Channel `legacy` API to `JSON RPC`
+* **TX_BUILDER:** Change `minFee` calculation, multiply min fee by 10^9
+
+
+# [2.1.1-0.1.0-next](https://github.com/aeternity/aepp-sdk-js/compare/2.1.0...2.1.1-0.1.0-next) (2019-02-21)
+
+
+### Bug Fixes
+* **Chore:** Fix linter errors
+
+
+
+# [2.1.0](https://github.com/aeternity/aepp-sdk-js/compare/2.0.0...2.1.0) (2019-02-21)
+
+
+### Features
+
+* **Node:** `Minerva` comparability
+* **Utils:** Add `Mnemonic` wallet implementation `es/utils/hd-wallet`
+
+
+### BREAKING CHANGES
+
+* **Node:** Change supported node version range to `1.4.0 <= version < 3.0.0`
+
+
+
+# [2.0.0](https://github.com/aeternity/aepp-sdk-js/compare/1.3.2...2.0.0) (2019-02-21)
+
+
+### Features
+
+* **TX_BUILDER:** Add `unpackedTx`, `txType` and `signature` to `validate` transaction function
+* **Contract:** Add `top` param to contract `static call(dry-run)`
+* **Contract:** Add errors handling for `dry-run`
+* **Docs:** Add `keystore` docs
+* **Ae:** Add `verify` options to `send` function which verify tx before broadcasting and throw error if tx is invalid
+* **Rpc:** Add `dryRun` to `RPC` methods
+* **Rpc:** Add `Oracle` transaction creation to `Aepp` rpc
+* **Docs:** Add `tx builder` docs
+* **Docs:** Add doc's for `utils/bytes` and tx builder `schema`
+* **TX_BUILDER:** refactor `calculateFee` function in `TxBuilder`(use BigNumber)
+* **TX_BUILDER:** Extend response of `Oracle`, `Aens`, `Contrat` with `rawTx`
+* **Ae:** Change response of `send` function now it's and object with transaction data(hash, rawTxHash, ...)
+* **Chain:** Move `Contract` and `Oracle` API wrapper's to `Chain` stamp
+* **Chore:** Rename `epoch` in `CHANGELOG`, `README`, `HACKING`
+
+
+### Bug Fixes
+
+* **Rpc:** `RpcServer`: Avoid storing of `window` in `instance` properties
+* **Chain:** Disable `balance formatting` by default
+* **Chain:** Move `verification of transaction` to `chain` stamp
+* **Node:** Retrieve `node` version from `/api`
+* **Chore:** Fix unpack tx example in `bin/aecrypto.js`
+* **Chore:** Remove unused function's from `crypto.js`
+
+
+### BREAKING CHANGES
+
+* **TX:** Remove old transaction builder `es/tx/js.js` (Please use `es/tx/builder` instead)
+* **Chore:** Rename `es/epoch.js` to `es/node.js`
+* **Chore:** Rename `Oracle`, `Contract`, `Chain` API wrapper files from `epoch` to `node`
+* **Chore:** Rename `Contract` api wrapper method's
+
+
+
+## [1.3.2](https://github.com/aeternity/aepp-sdk-js/compare/1.3.1...1.3.2) (2019-02-01)
+
+
+### Features
+
+* **Ae:** Add `destroyInstance` function to `Ae` stamp which remove all listeners for RPC event's
+* **Docs:** Add docs for `TransactionValidator` and `TxBuilder` stamp's
+* **Build:** Add `TxBuilderHelper` to bundle
+* **Chore:** Contract call static now using `dry-run` API
+* **Test:** Improve test's for Transaction verification
+
 
 ### Changed
-- Extend  `Account.address()` with `accountFormatter` now you can do
-```
-export const ADDRESS_FORMAT = {
-  sophia: 1, // return address like `0xHEX_ADDRESS`
-  api: 2, // return address like `ak_9LJ8ne9tks78hTD2Tp571f7w2MJmzQMRsiZxKCkMA2d2Sbrc4`
-}
 
-//
-
-export { ADDRESS_FORMAT } from 'es/account'
-await account.address(format: ADDRESS_FORMAT) // default ADDRESS_FORMAT.api
-```
-- decode node error coming from contract `call` and `callStatic`
-- Throw native error instead of object in chain `chain.sendTransaction`
-- fix arguments parsing in `Crypto.sing`
-- Add `{ compilerUrl }` to `Universal, Contract, Wallet` stamp initialization
-- Add ability to get `account/balance` on specific block `hash/height`
-- Fix `name hash` function arguments parsing in `Crypto`
-- Improve channel rpc usage
-- Improve channel tests and error handling
-- Improve state channel params handling
-
- ### Removed
-- `ContractNodeAPI` stamp
-
- ### Breaking Changes
-- Contract stamp API
-```
-1) Use Compiler instead of node API for encode/decode call-data and compile.
-2) Change Contract interface:
- - contractCallStatic (address, abi = 'sophia-address', name, { top, args = '()', call, options = {} } = {}) -> (source, address, name, args = [], { top, options = {} } = {}))
- - contractCall (code, abi, address, name, { args = '()', options = {}, call } = {}) -> (source, address, name, args = [], options = {})
- - contractDeploy (code, abi, { initState = '()', options = {} } = {}) -> (code, source, initState = [], options = {})
- - contractEncodeCall (code, abi, name, args, call) -> (source, name, args) // 'source' is -> Contract source code or ACI interface source
-```
-
- ### Notes and known Issues
-- none
-
-## [2.3.2]
-### Added
-- none
-
-### Changed
-- Change default `gasPrice` from `1e6` to `1e9z
-- Fix `AEPP` example app
-- Force `image` pull before `builds`
-
- ### Removed
-- none
-
- ### Breaking Changes
-- none
-
- ### Notes and known Issues
-- none
-
-## [2.3.1]
-### Added
-- `Oracle` fee calculation
-- `getAccountNonce` function to `tx` stamp
-
-### Changed
-- Change `FEE_BYTE_SIZE` from 1 to 8 bytes in `fee` calculation
-- Improve error handling in `tx` builder
-
- ### Removed
-- none
-
- ### Breaking Changes
-- none
-
- ### Notes and known Issues
-- none
-
-## [2.3.0]
-### Added
-- `Minerva` comparability
-- Add `Mnemonic` wallet implementation `es/utils/hd-wallet`
-
- ### Changed
-- Change Channel `legacy` API to `JSON RPC`
-- Change default `gasPrice` to `1e6`
-- Change `minFee` calculation, multiply min fee by `1e9`
-
- ### Removed
-- none
-
- ### Breaking Changes
-- none
-
- ### Notes and known Issues
-- Change supported node version range to `1.4.0 <= version < 3.0.0`
-- This release contain changes from: [2.3.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.3.0-next), [2.2.1-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.2.1-next), [2.1.1-0.1.0-next](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.1-0.1.0-next), [2.1.0](https://github.com/aeternity/aepp-sdk-js/releases/tag/2.1.0)
-
- ## [2.3.0-next]
-### Added
-- Add `channel` `withdraw` and `deposit` methods
-
- ### Changed
-- Change default `gasPrice` in `Contract` stamp and `Tx` stamp to `1e9`
-- Fix `contract` tx `fee` calculation
-- Refactor error handling in `sendTransaction` function
-- Change default `gasPrice` to `1e9`
-- Change `Fee` byte_size to 1
-
- ### Removed
-- none
-
- ### Breaking Changes
-- none
-
- ### Notes and known Issues
-- none
-
-## [2.2.1-next]
-### Added
-- Add `deserialization` schema for `Channel` transactions(`channelCreate`, `channelCloseMutual`, `channelDeposit`, `channelWithdraw`, `channelSettle`) 
-- Add `rawTx` and `verifyTx` to error from poll function(when you wait for transaction will mined)
-
-### Changed
-- Change Channel `legacy` API to `JSON RPC`
-- Change `minFee` calculation, multiply min fee by 10^9
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- Depend on `bip39` from npm instead of git repo 
+* **Docs:** Adjust doc's for `Contract` and `Aens` stamp's
+* **Chore:** Fix decoding of address from contract call
 
 
-## [2.1.1-0.1.0-next]
-### Added
-- none
 
-### Changed
-- Fix linter errors
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- none
-
-## [2.1.0]
-### Added
-- `Minerva` comparability
-- Add `Mnemonic` wallet implementation `es/utils/hd-wallet`
-
-### Changed
-- Change supported node version range to `1.4.0 <= version < 3.0.0`
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- Broken build(linter errors) - fixed in next release
+## [1.3.1](https://github.com/aeternity/aepp-sdk-js/compare/1.3.0...1.3.1) (2019-01-29)
 
 
-## [2.0.0]
-### Added
-- Add `unpackedTx`, `txType` and `signature` to `validate` transaction function
-- Add `top` param to contract `static call(dry-run)`
-- Add errors handling for `dry-run`
-- Add `keystore` docs
-- Add `verify` options to `send` function which verify tx before broadcasting and throw error if tx is invalid
-- Add `dryRun` to `RPC` methods
-- Add `Oracle` transaction creation to `Aepp` rpc
-- Add `tx builder` docs
-- Add doc's for `utils/bytes` and tx builder `schema`
+### Features
 
-### Changed
-- refactor `calculateFee` function in `TxBuilder`(use BigNumber)
-- `RpcServer`: Avoid storing of `window` in `instance` properties
-- Disable `balance formatting` by default
-- Extend response of `Oracle`, `Aens`, `Contrat` with `rawTx`
-- Change response of `send` function now it's and object with transaction data(hash, rawTxHash, ...)
-- Move `verification of transaction` to `chain` stamp
-- Move `Contract` and `Oracle` API wrapper's to `Chain` stamp
-- Rename `epoch` in `CHANGELOG`, `README`, `HACKING`
-- Retrieve `node` version from `/api`
-- Fix unpack tx example in `bin/aecrypto.js`
-
-### Removed
-- Remove unused function's from `crypto.js`
-
-### Breaking Changes
-- Remove old transaction builder `es/tx/js.js` (Please use `es/tx/builder` instead)
-- Rename `es/epoch.js` to `es/node.js`
-- Rename `Oracle`, `Contract`, `Chain` API wrapper files from `epoch` to `node`
-- Rename `Contract` api wrapper method's
-
-### Notes and known Issues
-- none
+* **Build:** Remove KeyStore from bundle due to build issue(for now you can export it only using tree-shaking `import * as Keystore from '@aeternity/aepp-sdk/utils/keystore'`)
 
 
-## [1.3.2]
-### Added
-- Add `destroyInstance` function to `Ae` stamp which remove all listeners for RPC event's
-- Add docs for `TransactionValidator` and `TxBuilder` stamp's
-- Add `TxBuilderHelper` to bundle
-### Changed
-- Adjust doc's for `Contract` and `Aens` stamp's
-- Fix decoding of address from contract call
-- Contract call static now using `dry-run` API
-- Improve test's for Transaction verification
 
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- none
+# [1.3.0](https://github.com/aeternity/aepp-sdk-js/compare/1.2.1...1.3.0) (2019-01-29)
 
 
-## [1.3.1]
+### Features
 
-### Changed
-- Remove KeyStore from bundle due to build issue(for now you can export it only using tree-shaking `import * as Keystore from '@aeternity/aepp-sdk/utils/keystore'`)
+* **Channel:** Add support for State Channels
+* **TX_BUILDER:** New transaction builder going through schema(build, unpack)
+* **TX_VALIDATOR:** Add new stamp `TransactionValidator` which can verify your transaction
+* **Chore:** Rename epoch to aeternity node(docker configs, some docs)
+* **Tx:** Use new tx builder in TX stamp
+* **Contract:** Set default values for amount and deposit to 0 for `contract` transaction
+* **Rpc:** Improve RPC server
 
-
-## [1.3.0]
-### Added
-- Add support for State Channels
-- New transaction builder going through schema(build, unpack)
-- Add new stamp `TransactionValidator` which can verify your transaction
-### Changed
-- Rename epoch to aeternity node(docker configs, some docs)
-- Use new tx builder in TX stamp
-- Set default values for amount and deposit to 0 for `contract` transaction
-- Improve RPC server
-### Removed
-- none
-
-### Breaking Changes
-- none
 
 ### Notes and known Issues
 - Old transaction builder `es/tx/js.js` will be removed in next major release.
 
-## [1.2.1]
-### Added
-- amount formatter
-- amount format balance `client.balance('AK_PUBLICKEY', { format: true })`
-- Oracle and Contracts API to Aepp stamp
 
-### Changed
-- Use `prepare` instead of `postinstall-build` (thanks @davidyuk)
-- Fix Import RLP package (thanks @davidyuk)
-- Fix for NetworkId propagation and override
-- TxJS is not a stamp anymore, and instead: it exports helper functions
-- Refreshed Docs: README.md + docs/usage.md
 
-### Removed
-- TxJs stamp (not a stamp anymore)
+## [1.2.1](https://github.com/aeternity/aepp-sdk-js/compare/1.1.2...1.2.1) (2018-12-21)
+
+
+### Features
+
+* **Chain:** amount formatter
+* **Chain:** amount format balance `client.balance('AK_PUBLICKEY', { format: true })`
+* **Aepp:** Oracle and Contracts API to Aepp stamp
+* **Chore:** Use `prepare` instead of `postinstall-build` (thanks @davidyuk)
+* **Docs:** Refreshed Docs: README.md + docs/usage.md
+
+
+### Bug Fixes
+
+* **Chr:** Fix Import RLP package (thanks @davidyuk)
+* **Rpc:** Fix for NetworkId propagation and override
+* **Tx:** TxJS is not a stamp anymore, and instead: it exports helper functions
+
+
+### BREAKING CHANGES
+
+* **Tx:** TxJs stamp (not a stamp anymore)
+* **Chain:** balance now answer a formatted string composed of `AMOUNT + ' ' + unit` (eg. `10 exa` for 10 AE)
+
+### Notes and known Issues
+
+* **Chore:** `10 exa` should be `10 ae`
+* **Chain:** format shouldn't be a flag, but a request for `unit` eg. `{ format: `ae` }`
+
+
+
+## [1.1.2](https://github.com/aeternity/aepp-sdk-js/compare/1.1.1...1.1.2) (2018-12-15)
+
+
+### Feature
+
+* **Chore:** isAddressValid check
+* **Tx:** Tx Fee formulas
+
+
+### Bug Fixes
+
+* **Rpc:** Fixed networkId propagation (and overriding on init of Flavors)
+* **Crypto:** Fixed encodeBase58Check by feeding Buffered input
+
+
+### BREAKING CHANGES
+
+* **Chore:** Compatibility with Node >= 1.0.0 and <= 1.1.0
+
+
+
+## [1.1.1](https://github.com/aeternity/aepp-sdk-js/compare/1.1.0...1.1.1) (2018-12-11)
+
+
+### Features
+
+* **Rpc:** Added a command to remove images after CI testing
+
+
+### Bug Fixes
+
+* **Rpc:** Fix Testing
+* **Rpc:** Fixed Oracle error for Wallet flavor
+
+
+
+# [1.1.0](https://github.com/aeternity/aepp-sdk-js/compare/1.0.1...1.1.0) (2018-12-11)
+
+
+### Features
+
+* **Oracle:** Oracles functionality and flavor
+* **Aepp:** Simple example of aepp-in-aepp (see `/examples` folder)
+
+### Bug Fixes
+
+* **Tx:** Fixed issue with big numbers and `TX`
+
+
+
+## [1.0.1](https://github.com/aeternity/aepp-sdk-js/compare/1.0.0...1.0.1) (2018-11-30)
+
+
+
+### Features
+
+* **Node:** ability to support Node range(s) using semver package (see https://www.npmjs.com/package/semver#ranges)
+
+
+### BREAKING CHANGES
+
+* **Node:** Support for Node >= 1.0.0 and < 2.0.0
+
+
+
+## [1.0.0](https://github.com/aeternity/aepp-sdk-js/compare/0.25.0-0.1.1...1.0.0) (2018-11-30)
+
+
+
+### Features
+
+* **Contract:** Contract native Transactions
+
+
+### Bug Fixes
+
+* **BigNumber:** Rolled back to bignumbers.js for easier fix with axios.get/post
+
+
+### BREAKING CHANGES
+
+* **Node:** Support for Node < 1.0.0
+* **Build:** New NETWORK_ID (also used in docker/sdk.env for CI tests)
+* **Protocol:** Encoding of transaction (and other objects) [changed from base58check to base64check](https://github.com/aeternity/protocol/blob/master/node/api/api_encoding.md)
+
+
+### Notes and known Issues
+
+* **Channel:** State Channels have been excluded for problems with CI, will be included in next release
+
+
+
+## [0.25.0-0.1.1](https://github.com/aeternity/aepp-sdk-js/compare/0.25.0-0.1.0...0.25.0-0.1.1) (2018-11-30)
+
+
+### Notes and known Issues
+
+* **Chore:** See [0.25.0-0.1.0]
+
+
+
+## [0.25.0-0.1.0](https://github.com/aeternity/aepp-sdk-js/compare/0.25.0-0.1.0-next...0.25.0-0.1.0) (2018-11-30)
+
+
+### Features
+
+* **Utils** Parsing of `fee` using `bignum.js`
+* **Account** Add `networkId` as param to `Account` flavor(default: `ae_mainnet`)
+* **Tx** Implement native build of `AENS` transaction.
+* **Keystore** Update keystore for new [requirements](https://www.pivotaltracker.com/n/projects/2124891/stories/155155204)
+
+
+### BREAKING CHANGES
+
+* **CLI** [AE CLI](https://github.com/aeternity/aecli-js) and [AE PROJECT CLI](https://github.com/aeternity/aeproject) moved to separate repos and packages
+* **Node** Support for < 0.25.0
+
+
+
+## [0.25.0-0.1.0-next](https://github.com/aeternity/aepp-sdk-js/compare/0.24.0-0.2.0...0.25.0-0.1.0-next) (2018-11-30)
+
+
+### Features
+
+* **Contract** Contract type checked call (Ability to call contract using contract address)
+* **Contract** Use ES methods instead of Ramda, where possible
+
+### Bug Fixes
+
+* **Contract** Fixed keystore by adding a salt param for derivedKey function
+
 
 ### Breaking Changes
-- TxJs stamp (not a stamp anymore)
-- balance now answer a formatted string composed of `AMOUNT + ' ' + unit` (eg. `10 exa` for 10 AE)
 
-### Notes and known Issues
-- `10 exa` should be `10 ae`
-- format shouldn't be a flag, but a request for `unit` eg. `{ format: `ae` }`
+* **Contract** Support for < 0.25.0
+* **Contract** Aens use domain `.test` instead of `.aet` (see [here](https://github.com/aeternity/aepp-sdk-js/commit/9c252f937f7ea501c4aaacbbef53c4c1833e48e4#diff-8ef3b328d008ef3dbb72a0bca42eba37L24))
+* **Contract** Use NETWORK_ID for signing (see [here](https://github.com/aeternity/aepp-sdk-js/commit/9c252f937f7ea501c4aaacbbef53c4c1833e48e4#diff-ffb275ebb09085c85c59f140998199e0R28))
 
 
 
-## [1.1.2]
-### Added
-- isAddressValid check
-
-### Changed
-- Compatibility with Node >= 1.0.0 and <= 1.1.0
-- Fixed networkId propagation (and overriding on init of Flavors)
-- Tx Fee formulas
-- Fixed encodeBase58Check by feeding Buffered input
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- none
-
-
-## [1.1.1]
-### Added
-- none
-
-### Changed
-- Fix Testing
-- Added a command to remove images after CI testing
-- Fixed Oracle error for Wallet flavor
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- none
-
-## [1.1.0]
-### Added
-- Oracles functionality and flavor
-- Simple example of aepp-in-aepp (see `/examples` folder)
-
-### Changed
-- Fixed issue with big numbers and `TX`
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- none
-
-## [1.0.1]
-### Added
-- ability to support Node range(s) using semver package (see https://www.npmjs.com/package/semver#ranges)
-
-### Changed
-- Support for Node >= 1.0.0 and < 2.0.0
-
-### Removed
-- none
-
-### Breaking Changes
-- none
-
-### Notes and known Issues
-- none
+# [0.24.0-0.2.0](https://github.com/aeternity/aepp-sdk-js/compare/v0.24.0-0.1.0...v0.24.0-0.2.0) (2018-10-30)
 
 
 
-## [1.0.0]
-### Added
-- Contract native Transactions
+### Features
 
-### Changed
-- Rolled back to bignumbers.js for easier fix with axios.get/post
-
-### Removed
-- Support for Node < 1.0.0
-
-### Breaking Changes
-- New NETWORK_ID (also used in docker/sdk.env for CI tests)
--  Encoding of transaction (and other objects) [changed from base58check to base64check](https://github.com/aeternity/protocol/blob/master/node/api/api_encoding.md)
-
-### Notes and known Issues
-- State Channels have been excluded for problems with CI, will be included in next release
+* **Rpc** RPC Client improvements
+* **Rpc** `onContract` Guard
+* **CLI**  born
+* **CLI** `Host` parameter became `Url`. (`-u` for hostname, `-U` for internal)
+* **CLI** New keystore following these specifications: https://www.pivotaltracker.com/n/projects/2124891/stories/155155204
 
 
-## [0.25.0-0.1.1]
-### Added
-- see [0.25.0-0.1.0]
+### BREAKING CHANGES
 
-### Changed
-- Change bignumbers.js with [bn.js](https://github.com/indutny/bn.js/) due to binding errors in browser's package
-
-### Removed
-- see [0.25.0-0.1.0]
-
-### Breaking Changes
-- see [0.25.0-0.1.0]
-
-### Notes and known Issues
-- none, see [0.25.0-0.1.0]
-
-## [0.25.0-0.1.0]
-### Added
-- Parsing of `fee` using `bignum.js`
-- Add `networkId` as param to `Account` flavor(default: `ae_mainnet`)
-- Implement native build of `AENS` transaction.
-
-### Changed
-- Update keystore for new [requirements](https://www.pivotaltracker.com/n/projects/2124891/stories/155155204)
--
-### Removed
-- Support for < 0.25.0
-- [AE CLI](https://github.com/aeternity/aecli-js) and [AE PROJECT CLI](https://github.com/aeternity/aeproject) moved to separate repos and packages
-
-### Breaking Changes
-- Use NETWORK_ID for signing (see [here](https://github.com/aeternity/aepp-sdk-js/commit/9c252f937f7ea501c4aaacbbef53c4c1833e48e4#diff-ffb275ebb09085c85c59f140998199e0R28))
-- Keystore format [changes](https://www.pivotaltracker.com/n/projects/2124891/stories/155155204)
-
-### Notes and known Issues
-- none
-
-
-## [0.25.0-0.1.0-next]
-### Added
-- Contract type checked call (Ability to call contract using contract address)
-
-### Changed
-- Use ES methods instead of Ramda, where possible
-- Fixed keystore by adding a salt param for derivedKey function
-
-### Removed
-- Support for < 0.25.0
-- [AE CLI](https://github.com/aeternity/aecli-js) and [AE PROJECT CLI](https://github.com/aeternity/aeproject) moved to separate repos and packages
-
-### Breaking Changes
-- Aens use domain `.test` instead of `.aet` (see [here](https://github.com/aeternity/aepp-sdk-js/commit/9c252f937f7ea501c4aaacbbef53c4c1833e48e4#diff-8ef3b328d008ef3dbb72a0bca42eba37L24))
-- Use NETWORK_ID for signing (see [here](https://github.com/aeternity/aepp-sdk-js/commit/9c252f937f7ea501c4aaacbbef53c4c1833e48e4#diff-ffb275ebb09085c85c59f140998199e0R28))
+* **Chore** The `Cli` flavor is now `Universal`
+* **Chore** the keypair keys changed from `{ pub, priv }` to `{ publicKey, secretKey }` for consistency with other systems using them (eg. AirGap and [HD Wallet](https://github.com/aeternity/hd-wallet-js))
 
 ### Notes and known Issues
 
-
-## [0.24.0-0.2.0]
-### Added
-- RPC Client improvements
-- (RPC) `onContract` Guard
-- (AE PROJECT CLI) born
-
-### Changed
-- (CLI) New keystore following these specifications: https://www.pivotaltracker.com/n/projects/2124891/stories/155155204
-- (CLI) `Host` parameter became `Url`. (`-u` for hostname, `-U` for internal)
-
-### Breaking Changes
-- The `Cli` flavor is now `Universal`
-- the keypair keys changed from `{ pub, priv }` to `{ publicKey, secretKey }` for consistency with other systems using them (eg. AirGap and [HD Wallet](https://github.com/aeternity/hd-wallet-js))
-
-### Notes and known Issues
-- CLI and AE PROJECT CLI will move to a separate package
+* **Chore** CLI and AE PROJECT CLI will move to a separate package
 
 
 
-## [0.24.0-0.1.0]
-### Added
-- Full support of [Node-0.24.0](https://github.com/aeternity/aeternity/releases/tag/v0.24.0)
-- (CLI) Develop `decode base58` address command in `crypto` module
-- (CLI) Add `nonce` param to all tx command's
-- (CLI) Add `gas` param to `deploy` and `call` commands
-- Add ability to create `spend` transaction natively
-- Implement `ethereum keystore` using `AES-126-CTR` and `SCRYPT` as key derivation function
 
-### Changed
-- (CLI) Change `--privateKey` to `flag` on `ACCOUNT ADDRESS` command
-- Change `node version` in `Dockerfile`
-- API endpoints to meet new Node specifications
-- Update `docco` config and change `rename` package to `recursive-rename`
-- Improved documentation
-
-### Removed
-- Support for < 0.24.0
-
-### Notes and known Issues
-- `ethereum keystore` usage will be removed in the next release
-- CLI will move to a separate package
+# [0.24.0-0.1.0](https://github.com/aeternity/aepp-sdk-js/compare/0.22.0-0.1.0-beta.1...v0.24.0-0.1.0) (2018-10-23)
 
 
-## [0.22.0-0.1.0-beta.1]
-### Added
-- Add **CLI** implementation
-- nameId function for commitment hash calculations
+### Features
 
-### Changed
-- API endpoints to meet new Node specifications
-- Add Nonce calculation on SDK side
-- Add check for MAX_GAS in call and deploy contract
-- change hash prefix separator from $ to _
-- Add keywords ('SDK', 'CLI') to package.json
-- Link aecli to `./bin/aecli.js` in package.json (After "npm link" you can use CLI globally)
-- Wait until pre-claim transaction block was mined before send claim transaction
-- Updated `webpack`, `webpack-cli` and added new dev deps accordingly
-- Add Node Compatibility Check
-- Add SDK nonce calculations
-- Fixes commitment hash calculations in naming system, to be `Hash(nameId(name) + name_salt)` instead of `Hash(Hash(name + name_salt))`.
+* **Node** Full support of [Node-0.24.0](https://github.com/aeternity/aeternity/releases/tag/v0.24.0)
+* **CLI**  Develop `decode base58` address command in `crypto` module
+* **CLI** Add `nonce` param to all tx command's
+* **CLI** Add `gas` param to `deploy` and `call` commands
+* **Tx** Add ability to create `spend` transaction natively
+* **Keystore** Implement `ethereum keystore` using `AES-126-CTR` and `SCRYPT` as key derivation function
+* **CLI** Change `--privateKey` to `flag` on `ACCOUNT ADDRESS` command
+* **Build** Change `node version` in `Dockerfile`
+* **Node** API endpoints to meet new Node specifications
+* **Chore** Update `docco` config and change `rename` package to `recursive-rename`
+* **Docs** Improved documentation
 
-### Removed
-- Support for < 0.22.0
 
-## [0.18.0-0.1.1]
-### Added
-- Lots of new documentation (prose and API)
-- Fancy badges to README
-- Transitive dev dependencies for standard-loader not covered by pnpm
-- CI Dockerfile to include pnpm
-- Fancy-shmancy diagram in README
-- Generated documentation files since they are linked in static docs
+### BREAKING CHANGES
 
-### Changed
-- Switch from Yarn to pnpm for building
-- Structure of documentation
-- Generate Markdown from Docco
+* **Node** Support for < 0.24.0
+* **Keystore** `ethereum keystore` usage will be removed in the next release
+* **CLI** CLI will move to a separate package
 
-## [0.18.0-0.1.0]
-### Added
-- Support for Node 0.18.0 (changed endpoints)
-- Wallet/Aepp RPC support
-- Contract call result decoding support
-- Per-module API documentation (Markdown based on JSDoc)
-- More API documentation (still incomplete)
-- SDK entrypoint factories (in `/es/ae/universal.js`)
 
-### Removed
-- Support for < 0.18.0 (changed endpoints)
 
-### Changed
-- Module load path (src -> es)
-- Lower mining rate (5s) in docker-compose
+# [0.22.0-0.1.0-beta.1](https://github.com/aeternity/aepp-sdk-js/compare/v0.18.0-0.1.1...0.22.0-0.1.0-beta.1) (2018-10-02)
 
-### Fixed
-- Symmetric key encryption/decryption
+### Features
 
-## [0.15.0-0.1.0]
-### Removed
-- Legacy Swagger file loading
-- Compatibility with < 0.15.0
+* **CLI** Add **CLI** implementation
+* **Crypto** nameId function for commitment hash calculations
+* **Node** API endpoints to meet new Node specifications
+* **Tx** Add Nonce calculation on SDK side
+* **Contract** Add check for MAX_GAS in call and deploy contract
+* **Chore** change hash prefix separator from $ to _
+* **Chore** Add keywords ('SDK', 'CLI') to package.json
+* **CLI** Link aecli to `./bin/aecli.js` in package.json (After "npm link" you can use CLI globally)
+* **Aens** Wait until pre-claim transaction block was mined before send claim transaction
+* **Build** Updated `webpack`, `webpack-cli` and added new dev deps accordingly
+* **Node** Add Node Compatibility Check
 
-### Fixed
-- Contract unit state initialization
-- Missing required parameter for name transfers (workaround for
-  [Swagger file bug])
+### Bug Fixes
 
-[Swagger file bug]: https://www.pivotaltracker.com/n/projects/2124891
+* **Crypto** Fixes commitment hash calculations in naming system, to be `Hash(nameId(name) + name_salt)` instead of `Hash(Hash(name + name_salt))`.
 
-## [0.14.0-0.1.0]
-### Added
-- New, opinionated top-level API
+### BREAKING CHANGES
 
-### Changed
-- Rest of legacy API now uses new API as well
-- Generated API now encapsulated in `api` object
-- Automatic case conversion for remote parameter names
-- Remaining tests to use new API
-- Adapted new method of obtaining transaction hash, breaks compatibility (see
+* **Node** Support for < 0.22.0
+
+
+
+# [0.18.0-0.1.1](https://github.com/aeternity/aepp-sdk-js/compare/v0.18.0-0.1.0...v0.18.0-0.1.1) (2018-07-31)
+
+### Features
+
+* **Docs** Lots of new documentation (prose and API)
+* **Docs** Fancy badges to README
+* **Build** Transitive dev dependencies for standard-loader not covered by pnpm
+* **Build** CI Dockerfile to include pnpm
+* **Docs** Fancy-shmancy diagram in README
+* **Docs**Generated documentation files since they are linked in static docs
+* **Build** Switch from Yarn to pnpm for building
+* **Docs** Structure of documentation
+* **Docs** Generate Markdown from Docco
+
+
+
+# [0.18.0-0.1.0](https://github.com/aeternity/aepp-sdk-js/compare/v0.15.0-0.1.0...v0.18.0-0.1.0) (2018-07-24)
+
+
+### Features
+
+* **Node** Support for Node 0.18.0 (changed endpoints)
+* **RPC** Wallet/Aepp RPC support
+* **Contract** Contract call result decoding support
+* **Docs** Per-module API documentation (Markdown based on JSDoc)
+* **Docs** More API documentation (still incomplete)
+* **Build** SDK entrypoint factories (in `/es/ae/universal.js`)
+* **Build** Module load path (src -> es)
+* **Chore** Lower mining rate (5s) in docker-compose
+
+
+### Bug Fixes
+
+* **Crypto** Symmetric key encryption/decryption
+
+
+### BREAKING CHANGES
+
+* **Node** Support for < 0.18.0 (changed endpoints)
+
+
+
+
+# [0.15.0-0.1.0](https://github.com/aeternity/aepp-sdk-js/compare/v0.14.0-0.1.0...v0.15.0-0.1.0) (2018-06-12)
+
+
+### Features
+
+* **Node** Legacy Swagger file loading
+* **Node** Compatibility with < 0.15.0
+
+
+### Bug Fixes
+
+* **Contract** Contract unit state initialization
+* **Node** Missing required parameter for name transfers (workaround for
+  [Swagger file bug](https://www.pivotaltracker.com/n/projects/2124891))
+
+
+
+# [0.14.0-0.1.0](https://github.com/aeternity/aepp-sdk-js/compare/v0.13.0-0.1.1...v0.14.0-0.1.0) (2018-06-11)
+
+
+### Features
+
+* **API** New, opinionated top-level API
+* **API** Rest of legacy API now uses new API as well
+* **API** Generated API now encapsulated in `api` object
+* **API** Automatic case conversion for remote parameter names
+* **API** Remaining tests to use new API
+* **API** Adapted new method of obtaining transaction hash, breaks compatibility (see
   below)
 
-### Removed
-- Oracle API (for the time being)
-- Legacy API and tests
-- Compatibility with older versions of Node which provide the transaction hash
+
+### Bug Fixes
+
+* **API** [GH-49]: Handle existing path components correctly
+
+
+### BREAKING CHANGES
+* **API** Remove Oracle API (for the time being)
+* **API** Remove Legacy API and tests
+* **API** Remove Compatibility with older versions of Node which provide the transaction hash
   the old way
 
-### Fixed
-- [GH-49]: Handle existing path components correctly
 
-## [0.13.0-0.1.0]
-### Added
-- This change log file
 
-### Changed
-- Switch to curve ed25519 (from secp256k1) to align with Node protocol changes
-- Generate basic API directly from Swagger files, also validate input data
-- Compiled library now self-contained with all dependencies
-- Use Webpack 4 based cross-platform (Node/Web) compilation
-- Package description now reads `SDK for the æternity blockchain`
-- Authors are now taken from `AUTHORS` instead of `package.json`
-- Moved code examples from README to separate file in docs
+# [0.13.0-0.1.1](https://github.com/aeternity/aepp-sdk-js/compare/v0.13.0-0.1.0...v0.13.0-0.1.1) (2018-05-24)
 
-### Removed
-- Defunct scripts; will be brought back later
 
-### Fixed
-- More consistent code examples
+### Features
 
-[0.13.0-0.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.10.0-0.1.0...v0.13.0-0.1.0
-[0.14.0-0.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.13.0-0.1.0...v0.14.0-0.1.0
-[0.15.0-0.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.14.0-0.1.0...v0.15.0-0.1.0
-[0.18.0-0.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.15.0-0.1.0...v0.18.0-0.1.0
-[0.18.0-0.1.1]: https://github.com/aeternity/aepp-sdk-js/compare/v0.18.0-0.1.0...v0.18.0-0.1.1
-[0.22.0-0.1.0-beta.1]: https://github.com/aeternity/aepp-sdk-js/compare/v0.18.0-0.1.1...v0.22.0-0.1.0-beta.1
-[0.24.0-0.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.22.0-0.1.0-beta.1...v0.24.0-0.1.0
-[0.24.0-0.2.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.24.0-0.1.0...v0.24.0-0.2.0
-[0.25.0-0.1.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/v0.24.0-0.2.0...v0.25.0-0.1.0-next
-[0.25.0-0.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.25.0-0.1.0-next...v0.25.0-0.1.0
-[0.25.0-0.1.1]: https://github.com/aeternity/aepp-sdk-js/compare/v0.25.0-0.1.0...v0.25.0-0.1.1
-[1.0.0]: https://github.com/aeternity/aepp-sdk-js/compare/v0.25.0-0.1.0...1.0.0
-[1.0.1]: https://github.com/aeternity/aepp-sdk-js/compare/1.0.0...1.0.1
-[1.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/1.0.0...1.1.0
-[1.1.1]: https://github.com/aeternity/aepp-sdk-js/compare/1.1.0...1.1.1
-[1.1.2]: https://github.com/aeternity/aepp-sdk-js/compare/1.1.1...1.1.2
-[1.2.1]: https://github.com/aeternity/aepp-sdk-js/compare/1.1.2...1.2.1
-[1.3.0]: https://github.com/aeternity/aepp-sdk-js/compare/1.2.1...1.3.0
-[1.3.1]: https://github.com/aeternity/aepp-sdk-js/compare/1.3.0...1.3.1
-[1.3.2]: https://github.com/aeternity/aepp-sdk-js/compare/1.3.1...1.3.2
-[2.0.0]: https://github.com/aeternity/aepp-sdk-js/compare/1.3.2...2.0.0
-[2.1.0]: https://github.com/aeternity/aepp-sdk-js/compare/2.0.0...2.1.0
-[2.1.1-0.1.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.1.0...2.1.1-0.1.0-next
-[2.2.1-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.1.1-0.1.0-next...2.2.1-next
-[2.3.0-next]: https://github.com/aeternity/aepp-sdk-js/compare/2.2.1-next...2.3.0-next
-[2.3.0]: https://github.com/aeternity/aepp-sdk-js/compare/2.3.0-next...2.3.0
-[2.3.1]: https://github.com/aeternity/aepp-sdk-js/compare/2.3.0...2.3.1
-[2.3.2]: https://github.com/aeternity/aepp-sdk-js/compare/2.3.1...2.3.2
-[2.4.0]: https://github.com/aeternity/aepp-sdk-js/compare/2.3.2...2.4.0
-[2.4.1]: https://github.com/aeternity/aepp-sdk-js/compare/2.4.0...2.4.1
+* **Node** Switch to curve ed25519 (from secp256k1) to align with Node protocol changes
+* **Node** Generate basic API directly from Swagger files, also validate input data
+* **Build** Compiled library now self-contained with all dependencies
+* **Build** Use Webpack 4 based cross-platform (Node/Web) compilation
+* **Docs** Package description now reads `SDK for the æternity blockchain`
+* **Chore** Authors are now taken from `AUTHORS` instead of `package.json`
+* **Docs** Moved code examples from README to separate file in docs
+
+
+### BREAKING CHANGES
+
+* **Node** Defunct scripts; will be brought back later
+
+
+### Bug Fixes
+
+* **Chore** More consistent code examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * **Compiler:** Add decode CallData by source/bytecode ([#354](https://github.com/aeternity/aepp-sdk-js/issues/354)) ([761f36b](https://github.com/aeternity/aepp-sdk-js/commit/761f36b))
 * **RPC:** Add getNodeInfo and getNetworkId to AEPP stamp through RPC ([#359](https://github.com/aeternity/aepp-sdk-js/issues/359)) ([2ddeea8](https://github.com/aeternity/aepp-sdk-js/commit/2ddeea8))
 * **State Channels:** Add cleanContractCalls method ([#338](https://github.com/aeternity/aepp-sdk-js/issues/338)) ([778159a](https://github.com/aeternity/aepp-sdk-js/commit/778159a))
-* **State Channels:** Ping every 10 seconds to persist connection ([#324](https://github.com/aeternity/aepp-sdk-js/issues/324)) ([6d0e156](https://github.com/aeternity/aepp-sdk-js/commit/6d0e156)), closes [#276](https://github.com/aeternity/aepp-sdk-js/issues/276) [#299](https://github.com/aeternity/aepp-sdk-js/issues/299) [#300](https://github.com/aeternity/aepp-sdk-js/issues/300) [#303](https://github.com/aeternity/aepp-sdk-js/issues/303) [#302](https://github.com/aeternity/aepp-sdk-js/issues/302) [#279](https://github.com/aeternity/aepp-sdk-js/issues/279) [#275](https://github.com/aeternity/aepp-sdk-js/issues/275) [#276](https://github.com/aeternity/aepp-sdk-js/issues/276) [#299](https://github.com/aeternity/aepp-sdk-js/issues/299) [#300](https://github.com/aeternity/aepp-sdk-js/issues/300)
+* **State Channels:** Ping every 10 seconds to persist connection ([#324](https://github.com/aeternity/aepp-sdk-js/issues/324)) ([6d0e156](https://github.com/aeternity/aepp-sdk-js/commit/6d0e156))
 
 
 

--- a/docs/api/account.md
+++ b/docs/api/account.md
@@ -12,6 +12,7 @@ import Account from '@aeternity/aepp-sdk/es/account'
 * [@aeternity/aepp-sdk/es/account](#module_@aeternity/aepp-sdk/es/account)
     * [Account([options])](#exp_module_@aeternity/aepp-sdk/es/account--Account) ⇒ `Object` ⏏
         * [.signTransaction(tx)](#module_@aeternity/aepp-sdk/es/account--Account+signTransaction) ⇒ `String`
+        * [.getNetworkId()](#module_@aeternity/aepp-sdk/es/account--Account+getNetworkId) ⇒ `String`
         * *[.sign(data)](#module_@aeternity/aepp-sdk/es/account--Account+sign) ⇒ `String`*
         * *[.address()](#module_@aeternity/aepp-sdk/es/account--Account+address) ⇒ `String`*
 
@@ -50,6 +51,15 @@ Sign encoded transaction
 | --- | --- | --- |
 | tx | `String` | Transaction to sign |
 
+<a id="module_@aeternity/aepp-sdk/es/account--Account+getNetworkId"></a>
+
+#### account.getNetworkId() ⇒ `String`
+Obtain networkId for signing
+
+**Kind**: instance method of [`Account`](#exp_module_@aeternity/aepp-sdk/es/account--Account)  
+**Returns**: `String` - NetworkId  
+**Category**: async  
+**rtype**: `() => networkId: String`
 <a id="module_@aeternity/aepp-sdk/es/account--Account+sign"></a>
 
 #### *account.sign(data) ⇒ `String`*

--- a/docs/api/chain.md
+++ b/docs/api/chain.md
@@ -28,6 +28,7 @@ import Chain from '@aeternity/aepp-sdk/es/chain'
                 * *[.getMicroBlockHeader()](#module_@aeternity/aepp-sdk/es/chain--Chain+getMicroBlockHeader) ⇒ `Object`*
                 * *[.getAccount(address, [options])](#module_@aeternity/aepp-sdk/es/chain--Chain+getAccount) ⇒ `Object`*
                 * *[.txDryRun(txs, accounts, hashOrHeight)](#module_@aeternity/aepp-sdk/es/chain--Chain+txDryRun) ⇒ `Object`*
+                * *[.getInfo()](#module_@aeternity/aepp-sdk/es/chain--Chain+getInfo) ⇒ `Object`*
         * _static_
             * [.waitMined(bool)](#module_@aeternity/aepp-sdk/es/chain--Chain.waitMined) ⇒ `Stamp`
 
@@ -242,6 +243,15 @@ Transaction dry-run
 | accounts | `Array` | Array of account's |
 | hashOrHeight | `String` \| `Number` | hash or height of block on which to make dry-run |
 
+<a id="module_@aeternity/aepp-sdk/es/chain--Chain+getInfo"></a>
+
+#### *chain.getInfo() ⇒ `Object`*
+Get Node Info
+
+**Kind**: instance abstract method of [`Chain`](#exp_module_@aeternity/aepp-sdk/es/chain--Chain)  
+**Returns**: `Object` - Result  
+**Category**: async  
+**rtype**: `() => result: Object`
 <a id="module_@aeternity/aepp-sdk/es/chain--Chain.waitMined"></a>
 
 #### Chain.waitMined(bool) ⇒ `Stamp`

--- a/docs/api/channel/index.md
+++ b/docs/api/channel/index.md
@@ -10,65 +10,74 @@ import Channel from '@aeternity/aepp-sdk/es/channel/index'
 ```
 
 * [@aeternity/aepp-sdk/es/channel/index](#module_@aeternity/aepp-sdk/es/channel/index)
-    * [Channel([options])](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel) ⇒ `Object` ⏏
+    * [Channel(options)](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel) ⇒ `Promise.&lt;Object&gt;` ⏏
         * [~on(event, callback)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..on)
-        * [~status()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..status) ⇒ `string`
-        * [~state()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..state) ⇒ `object`
-        * [~id()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..id) ⇒ `string`
-        * [~update(from, to, amount, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..update) ⇒ `Promise.&lt;object&gt;`
-        * [~poi(addresses)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..poi) ⇒ `Promise.&lt;string&gt;`
-        * [~balances(accounts)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..balances) ⇒ `Promise.&lt;object&gt;`
-        * [~leave()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..leave) ⇒ `Promise.&lt;object&gt;`
-        * [~shutdown(sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..shutdown) ⇒ `Promise.&lt;string&gt;`
-        * [~withdraw(amount, sign, [callbacks])](#module_@aeternity/aepp-sdk/es/channel/index--Channel..withdraw) ⇒ `Promise.&lt;object&gt;`
-        * [~deposit(amount, sign, [callbacks])](#module_@aeternity/aepp-sdk/es/channel/index--Channel..deposit) ⇒ `Promise.&lt;object&gt;`
-        * [~createContract(options, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..createContract) ⇒ `Promise.&lt;object&gt;`
-        * [~callContract(options, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..callContract) ⇒ `Promise.&lt;object&gt;`
-        * [~callContractStatic(options)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..callContractStatic) ⇒ `Promise.&lt;object&gt;`
-        * [~getContractCall(options)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractCall) ⇒ `Promise.&lt;object&gt;`
-        * [~getContractState(contract)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractState) ⇒ `Promise.&lt;object&gt;`
+        * [~disconnect()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..disconnect)
+        * [~status()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..status) ⇒ `String`
+        * [~state()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..state) ⇒ `Promise.&lt;Object&gt;`
+        * [~id()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..id) ⇒ `String`
+        * [~update(from, to, amount, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..update) ⇒ `Promise.&lt;Object&gt;`
+        * [~poi(addresses)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..poi) ⇒ `Promise.&lt;String&gt;`
+        * [~balances(accounts)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..balances) ⇒ `Promise.&lt;Object&gt;`
+        * [~leave()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..leave) ⇒ `Promise.&lt;Object&gt;`
+        * [~shutdown(sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..shutdown) ⇒ `Promise.&lt;String&gt;`
+        * [~withdraw(amount, sign, [callbacks])](#module_@aeternity/aepp-sdk/es/channel/index--Channel..withdraw) ⇒ `Promise.&lt;Object&gt;`
+        * [~deposit(amount, sign, [callbacks])](#module_@aeternity/aepp-sdk/es/channel/index--Channel..deposit) ⇒ `Promise.&lt;Object&gt;`
+        * [~createContract(options, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..createContract) ⇒ `Promise.&lt;Object&gt;`
+        * [~callContract(options, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..callContract) ⇒ `Promise.&lt;Object&gt;`
+        * [~callContractStatic(options)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..callContractStatic) ⇒ `Promise.&lt;Object&gt;`
+        * [~getContractCall(options)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractCall) ⇒ `Promise.&lt;Object&gt;`
+        * [~getContractState(contract)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractState) ⇒ `Promise.&lt;Object&gt;`
         * [~cleanContractCalls()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..cleanContractCalls) ⇒ `Promise`
         * [~sendMessage(message, recipient)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..sendMessage)
 
 <a id="exp_module_@aeternity/aepp-sdk/es/channel/index--Channel"></a>
 
-### Channel([options]) ⇒ `Object` ⏏
+### Channel(options) ⇒ `Promise.&lt;Object&gt;` ⏏
 Channel
 
 **Kind**: Exported function  
-**Returns**: `Object` - Channel instance  
+**Returns**: `Promise.&lt;Object&gt;` - Channel instance  
 **rtype**: `Channel`
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| [options] | `Object` | <code>{}</code> | Initializer object |
-| options.url | `String` |  | Channel url (for example: "ws://localhost:3001/channel") |
-| options.role | `String` |  | Participant role ("initiator" or "responder") |
-| options.initiatorId | `String` |  | Initiator's public key |
-| options.responderId | `String` |  | Responder's public key |
-| options.pushAmount | `Number` |  | Initial deposit in favour of the responder by the initiator |
-| options.initiatorAmount | `Number` |  | Amount of tokens the initiator has committed to the channel |
-| options.responderAmount | `Number` |  | Amount of tokens the responder has committed to the channel |
-| options.channelReserve | `Number` |  | The minimum amount both peers need to maintain |
-| [options.ttl] | `Number` |  | Minimum block height to include the channel_create_tx |
-| options.host | `String` |  | Host of the responder's node |
-| options.port | `Number` |  | The port of the responders node |
-| options.lockPeriod | `Number` |  | Amount of blocks for disputing a solo close |
-| [options.existingChannelId] | `Number` |  | Existing channel id (required if reestablishing a channel) |
-| [options.offchainTx] | `Number` |  | Offchain transaction (required if reestablishing a channel) |
-| options.sign | `function` |  | Function which verifies and signs transactions |
+| Param | Type | Description |
+| --- | --- | --- |
+| options | `Object` | Channel params |
+| options.url | `String` | Channel url (for example: "ws://localhost:3001") |
+| options.role | `String` | Participant role ("initiator" or "responder") |
+| options.initiatorId | `String` | Initiator's public key |
+| options.responderId | `String` | Responder's public key |
+| options.pushAmount | `Number` | Initial deposit in favour of the responder by the initiator |
+| options.initiatorAmount | `Number` | Amount of tokens the initiator has committed to the channel |
+| options.responderAmount | `Number` | Amount of tokens the responder has committed to the channel |
+| options.channelReserve | `Number` | The minimum amount both peers need to maintain |
+| [options.ttl] | `Number` | Minimum block height to include the channel_create_tx |
+| options.host | `String` | Host of the responder's node |
+| options.port | `Number` | The port of the responders node |
+| options.lockPeriod | `Number` | Amount of blocks for disputing a solo close |
+| [options.existingChannelId] | `Number` | Existing channel id (required if reestablishing a channel) |
+| [options.offchainTx] | `Number` | Offchain transaction (required if reestablishing a channel) |
+| [options.timeoutIdle] | `Number` | The time waiting for a new event to be initiated (default: 600000) |
+| [options.timeoutFundingCreate] | `Number` | The time waiting for the initiator to produce the create channel transaction after the noise session had been established (default: 120000) |
+| [options.timeoutFundingSign] | `Number` | The time frame the other client has to sign an off-chain update after our client had initiated and signed it. This applies only for double signed on-chain intended updates: channel create transaction, deposit, withdrawal and etc. (default: 120000) |
+| [options.timeoutFundingLock] | `Number` | The time frame the other client has to confirm an on-chain transaction reaching maturity (passing minimum depth) after the local node has detected this. This applies only for double signed on-chain intended updates: channel create transaction, deposit, withdrawal and etc. (default: 360000) |
+| [options.timeoutSign] | `Number` | The time frame the client has to return a signed off-chain update or to decline it. This applies for all off-chain updates (default: 500000) |
+| [options.timeoutAccept] | `Number` | The time frame the other client has to react to an event. This applies for all off-chain updates that are not meant to land on-chain, as well as some special cases: opening a noise connection, mutual closing acknowledgement and reestablishing an existing channel (default: 120000) |
+| [options.timeoutInitialized] | `Number` | the time frame the responder has to accept an incoming noise session. Applicable only for initiator (default: timeout_accept's value) |
+| [options.timeoutAwaitingOpen] | `Number` | The time frame the initiator has to start an outgoing noise session to the responder's node. Applicable only for responder (default: timeout_idle's value) |
+| options.sign | `function` | Function which verifies and signs transactions |
 
 **Example**  
 ```js
 Channel({
   url: 'ws://localhost:3001',
   role: 'initiator'
-  initiatorId: 'ak$2QC98ahNHSrZLWKrpQyv91eQfCDA3aFVSNoYKdQ1ViYWVF8Z9d',
-  responderId: 'ak$Gi42jcRm9DcZjk72UWQQBSxi43BG3285C9n4QSvP5JdzDyH2o',
-  pushAmount: 3,
-  initiatorAmount: 10,
-  responderAmount: 10,
-  channelReserve: 2,
+  initiatorId: 'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
+  responderId: 'ak_V6an1xhec1xVaAhLuak7QoEbi6t7w5hEtYWp9bMKaJ19i6A9E',
+  initiatorAmount: 1e18,
+  responderAmount: 1e18,
+  pushAmount: 0,
+  channelReserve: 0,
   ttl: 1000,
   host: 'localhost',
   port: 3002,
@@ -81,53 +90,74 @@ Channel({
 #### Channel~on(event, callback)
 Register event listener function
 
+Possible events:
+
+  - "error"
+  - "onChainTx"
+  - "ownWithdrawLocked"
+  - "withdrawLocked"
+  - "ownDepositLocked"
+  - "depositLocked"
+
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| event | `string` | Event name |
+| event | `String` | Event name |
 | callback | `function` | Callback function |
 
+<a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..disconnect"></a>
+
+#### Channel~disconnect()
+Close the connection
+
+**Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..status"></a>
 
-#### Channel~status() ⇒ `string`
+#### Channel~status() ⇒ `String`
 Get current status
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..state"></a>
 
-#### Channel~state() ⇒ `object`
+#### Channel~state() ⇒ `Promise.&lt;Object&gt;`
 Get current state
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..id"></a>
 
-#### Channel~id() ⇒ `string`
+#### Channel~id() ⇒ `String`
 Get channel id
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..update"></a>
 
-#### Channel~update(from, to, amount, sign) ⇒ `Promise.&lt;object&gt;`
-Trigger an update
+#### Channel~update(from, to, amount, sign) ⇒ `Promise.&lt;Object&gt;`
+Trigger a transfer update
+
+The transfer update is moving tokens from one channel account to another.
+The update is a change to be applied on top of the latest state.
+
+Sender and receiver are the channel parties. Both the initiator and responder
+can take those roles. Any public key outside of the channel is considered invalid.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| from | `string` | Sender's public address |
-| to | `string` | Receiver's public address |
-| amount | `number` | Transaction amount |
-| sign | `function` | Function which verifies and signs transaction |
+| from | `String` | Sender's public address |
+| to | `String` | Receiver's public address |
+| amount | `Number` | Transaction amount |
+| sign | `function` | Function which verifies and signs offchain transaction |
 
 **Example**  
 ```js
 channel.update(
-  'ak$2QC98ahNHSrZLWKrpQyv91eQfCDA3aFVSNoYKdQ1ViYWVF8Z9d',
-  'ak$Gi42jcRm9DcZjk72UWQQBSxi43BG3285C9n4QSvP5JdzDyH2o',
+  'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
+  'ak_V6an1xhec1xVaAhLuak7QoEbi6t7w5hEtYWp9bMKaJ19i6A9E',
   10,
   async (tx) => await account.signTransaction(tx)
-).then({ accepted, signedTx } =>
+).then(({ accepted, signedTx }) =>
   if (accepted) {
     console.log('Update has been accepted')
   }
@@ -135,16 +165,19 @@ channel.update(
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..poi"></a>
 
-#### Channel~poi(addresses) ⇒ `Promise.&lt;string&gt;`
+#### Channel~poi(addresses) ⇒ `Promise.&lt;String&gt;`
 Get proof of inclusion
+
+If a certain address of an account or a contract is not found
+in the state tree - the response is an error.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| addresses | `object` |  |
-| [addresses.accounts] | `array.&lt;string&gt;` | List of account addresses to include in poi |
-| [addresses.contracts] | `array.&lt;string&gt;` | List of contract addresses to include in poi |
+| addresses | `Object` |  |
+| [addresses.accounts] | `Array.&lt;String&gt;` | List of account addresses to include in poi |
+| [addresses.contracts] | `Array.&lt;String&gt;` | List of contract addresses to include in poi |
 
 **Example**  
 ```js
@@ -158,14 +191,20 @@ channel.poi({
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..balances"></a>
 
-#### Channel~balances(accounts) ⇒ `Promise.&lt;object&gt;`
+#### Channel~balances(accounts) ⇒ `Promise.&lt;Object&gt;`
 Get balances
+
+The accounts paramcontains a list of addresses to fetch balances of.
+Those can be either account balances or a contract ones, encoded as an account addresses.
+
+If a certain account address had not being found in the state tree - it is simply
+skipped in the response.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| accounts | `array.&lt;string&gt;` | List of addresses to fetch balances from |
+| accounts | `Array.&lt;String&gt;` | List of addresses to fetch balances from |
 
 **Example**  
 ```js
@@ -179,27 +218,39 @@ channel.balances([
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..leave"></a>
 
-#### Channel~leave() ⇒ `Promise.&lt;object&gt;`
+#### Channel~leave() ⇒ `Promise.&lt;Object&gt;`
 Leave channel
+
+It is possible to leave a channel and then later reestablish the channel
+off-chain state and continue operation. When a leave method is called,
+the channel fsm passes it on to the peer fsm, reports the current mutually
+signed state and then terminates.
+
+The channel can be reestablished by instantiating another Channel instance
+with two extra params: existingChannelId and offchainTx (returned from leave
+method as channelId and signedTx respectively).
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 **Example**  
 ```js
-channel.leave().then(({ channelId, signedTx }) =>
+channel.leave().then(({ channelId, signedTx }) => {
   console.log(channelId)
-  console.log(state)
-)
+  console.log(signedTx)
+})
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..shutdown"></a>
 
-#### Channel~shutdown(sign) ⇒ `Promise.&lt;string&gt;`
-Trigger a channel shutdown
+#### Channel~shutdown(sign) ⇒ `Promise.&lt;String&gt;`
+Trigger mutual close
+
+At any moment after the channel is opened, a closing procedure can be triggered.
+This can be done by either of the parties. The process is similar to the off-chain updates.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| sign | `function` | Function which verifies and signs transaction |
+| sign | `function` | Function which verifies and signs mutual close transaction |
 
 **Example**  
 ```js
@@ -209,16 +260,40 @@ channel.shutdown(
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..withdraw"></a>
 
-#### Channel~withdraw(amount, sign, [callbacks]) ⇒ `Promise.&lt;object&gt;`
+#### Channel~withdraw(amount, sign, [callbacks]) ⇒ `Promise.&lt;Object&gt;`
 Withdraw tokens from the channel
+
+After the channel had been opened any of the participants can initiate a withdrawal.
+The process closely resembles the update. The most notable difference is that the
+transaction has been co-signed: it is channel_withdraw_tx and after the procedure
+is finished - it is being posted on-chain.
+
+Any of the participants can initiate a withdrawal. The only requirements are:
+
+  - Channel is already opened
+  - No off-chain update/deposit/withdrawal is currently being performed
+  - Channel is not being closed or in a solo closing state
+  - The withdrawal amount must be equal to or greater than zero, and cannot exceed
+    the available balance on the channel (minus the channel_reserve)
+
+After the other party had signed the withdraw transaction, the transaction is posted
+on-chain and onOnChainTx callback is called with on-chain transaction as first argument.
+After computing transaction hash it can be tracked on the chain: entering the mempool,
+block inclusion and a number of confirmations.
+
+After the minimum_depth block confirmations onOwnWithdrawLocked callback is called
+(without any arguments).
+
+When the other party had confirmed that the block height needed is reached
+onWithdrawLocked callback is called (without any arguments).
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| amount | `number` | Amount of tokens to withdraw |
+| amount | `Number` | Amount of tokens to withdraw |
 | sign | `function` | Function which verifies and signs withdraw transaction |
-| [callbacks] | `object` |  |
+| [callbacks] | `Object` |  |
 | [callbacks.onOnChainTx] | `function` | Called when withdraw transaction has been posted on chain |
 | [callbacks.onOwnWithdrawLocked] | `function` |  |
 | [callbacks.onWithdrawLocked] | `function` |  |
@@ -239,16 +314,40 @@ channel.withdraw(
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..deposit"></a>
 
-#### Channel~deposit(amount, sign, [callbacks]) ⇒ `Promise.&lt;object&gt;`
+#### Channel~deposit(amount, sign, [callbacks]) ⇒ `Promise.&lt;Object&gt;`
 Deposit tokens into the channel
+
+After the channel had been opened any of the participants can initiate a deposit.
+The process closely resembles the update. The most notable difference is that the
+transaction has been co-signed: it is channel_deposit_tx and after the procedure
+is finished - it is being posted on-chain.
+
+Any of the participants can initiate a deposit. The only requirements are:
+
+  - Channel is already opened
+  - No off-chain update/deposit/withdrawal is currently being performed
+  - Channel is not being closed or in a solo closing state
+  - The deposit amount must be equal to or greater than zero, and cannot exceed
+    the available balance on the channel (minus the channel_reserve)
+
+After the other party had signed the deposit transaction, the transaction is posted
+on-chain and onOnChainTx callback is called with on-chain transaction as first argument.
+After computing transaction hash it can be tracked on the chain: entering the mempool,
+block inclusion and a number of confirmations.
+
+After the minimum_depth block confirmations onOwnDepositLocked callback is called
+(without any arguments).
+
+When the other party had confirmed that the block height needed is reached
+onDepositLocked callback is called (without any arguments).
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| amount | `number` | Amount of tokens to deposit |
+| amount | `Number` | Amount of tokens to deposit |
 | sign | `function` | Function which verifies and signs deposit transaction |
-| [callbacks] | `object` |  |
+| [callbacks] | `Object` |  |
 | [callbacks.onOnChainTx] | `function` | Called when deposit transaction has been posted on chain |
 | [callbacks.onOwnDepositLocked] | `function` |  |
 | [callbacks.onDepositLocked] | `function` |  |
@@ -270,19 +369,25 @@ channel.deposit(
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..createContract"></a>
 
-#### Channel~createContract(options, sign) ⇒ `Promise.&lt;object&gt;`
-Create a contract
+#### Channel~createContract(options, sign) ⇒ `Promise.&lt;Object&gt;`
+Trigger create contract update
+
+The create contract update is creating a contract inside the channel's internal state tree.
+The update is a change to be applied on top of the latest state.
+
+That would create a contract with the poster being the owner of it. Poster commits initially
+a deposit amount of tokens to the new contract.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | `object` |  |
-| [options.code] | `string` | Api encoded compiled AEVM byte code |
-| [options.callData] | `string` | Api encoded compiled AEVM call data for the code |
-| [options.deposit] | `number` | Initial amount the owner of the contract commits to it |
-| [options.vmVersion] | `number` | Version of the AEVM |
-| [options.abiVersion] | `number` | Version of the ABI |
+| options | `Object` |  |
+| options.code | `String` | Api encoded compiled AEVM byte code |
+| options.callData | `String` | Api encoded compiled AEVM call data for the code |
+| options.deposit | `Number` | Initial amount the owner of the contract commits to it |
+| options.vmVersion | `Number` | Version of the AEVM |
+| options.abiVersion | `Number` | Version of the ABI |
 | sign | `function` | Function which verifies and signs create contract transaction |
 
 **Example**  
@@ -304,18 +409,31 @@ channel.createContract({
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..callContract"></a>
 
-#### Channel~callContract(options, sign) ⇒ `Promise.&lt;object&gt;`
-Call a contract
+#### Channel~callContract(options, sign) ⇒ `Promise.&lt;Object&gt;`
+Trigger call a contract update
+
+The call contract update is calling a preexisting contract inside the channel's
+internal state tree. The update is a change to be applied on top of the latest state.
+
+That would call a contract with the poster being the caller of it. Poster commits
+an amount of tokens to the contract.
+
+The call would also create a call object inside the channel state tree. It contains
+the result of the contract call.
+
+It is worth mentioning that the gas is not consumed, because this is an off-chain
+contract call. It would be consumed if it were a on-chain one. This could happen
+if a call with a similar computation amount is to be forced on-chain.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | `object` |  |
-| [options.amount] | `string` | Amount the caller of the contract commits to it |
-| [options.callData] | `string` | ABI encoded compiled AEVM call data for the code |
-| [options.contract] | `number` | Address of the contract to call |
-| [options.abiVersion] | `number` | Version of the ABI |
+| options | `Object` |  |
+| [options.amount] | `String` | Amount the caller of the contract commits to it |
+| [options.callData] | `String` | ABI encoded compiled AEVM call data for the code |
+| [options.contract] | `Number` | Address of the contract to call |
+| [options.abiVersion] | `Number` | Version of the ABI |
 | sign | `function` | Function which verifies and signs contract call transaction |
 
 **Example**  
@@ -335,18 +453,26 @@ channel.callContract({
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..callContractStatic"></a>
 
-#### Channel~callContractStatic(options) ⇒ `Promise.&lt;object&gt;`
+#### Channel~callContractStatic(options) ⇒ `Promise.&lt;Object&gt;`
 Call contract using dry-run
+
+In order to get the result of a potential contract call, one might need to
+dry-run a contract call. It takes the exact same arguments as a call would
+and returns the call object.
+
+The call is executed in the channel's state but it does not impact the state
+whatsoever. It uses as an environment the latest channel's state and the current
+top of the blockchain as seen by the node.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | `object` |  |
-| [options.amount] | `string` | Amount the caller of the contract commits to it |
-| [options.callData] | `string` | ABI encoded compiled AEVM call data for the code |
-| [options.contract] | `number` | Address of the contract to call |
-| [options.abiVersion] | `number` | Version of the ABI |
+| options | `Object` |  |
+| [options.amount] | `String` | Amount the caller of the contract commits to it |
+| [options.callData] | `String` | ABI encoded compiled AEVM call data for the code |
+| [options.contract] | `Number` | Address of the contract to call |
+| [options.abiVersion] | `Number` | Version of the ABI |
 
 **Example**  
 ```js
@@ -362,17 +488,20 @@ channel.callContractStatic({
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractCall"></a>
 
-#### Channel~getContractCall(options) ⇒ `Promise.&lt;object&gt;`
+#### Channel~getContractCall(options) ⇒ `Promise.&lt;Object&gt;`
 Get contract call result
+
+The combination of a caller, contract and a round of execution determines the
+contract call. Providing an incorrect set of those results in an error response.
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | `object` |  |
-| [options.caller] | `string` | Address of contract caller |
-| [options.contract] | `string` | Address of the contract |
-| [options.round] | `number` | Round when contract was called |
+| options | `Object` |  |
+| [options.caller] | `String` | Address of contract caller |
+| [options.contract] | `String` | Address of the contract |
+| [options.round] | `Number` | Round when contract was called |
 
 **Example**  
 ```js
@@ -386,19 +515,19 @@ channel.getContractCall({
 ```
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractState"></a>
 
-#### Channel~getContractState(contract) ⇒ `Promise.&lt;object&gt;`
+#### Channel~getContractState(contract) ⇒ `Promise.&lt;Object&gt;`
 Get contract latest state
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| contract | `string` | Address of the contract |
+| contract | `String` | Address of the contract |
 
 **Example**  
 ```js
 channel.getContractState(
-  'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa',
+  'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa'
 ).then(({ contract }) => {
   console.log('deposit:', contract.deposit)
 })
@@ -422,12 +551,15 @@ Send generic message
 If message is an object it will be serialized into JSON string
 before sending.
 
+If there is ongoing update that has not yet been finished the message
+will be sent after that update is finalized.
+
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| message | `string` \| `object` |  |
-| recipient | `string` | Address of the recipient |
+| message | `String` \| `Object` |  |
+| recipient | `String` | Address of the recipient |
 
 **Example**  
 ```js

--- a/docs/api/channel/index.md
+++ b/docs/api/channel/index.md
@@ -14,6 +14,7 @@ import Channel from '@aeternity/aepp-sdk/es/channel/index'
         * [~on(event, callback)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..on)
         * [~status()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..status) ⇒ `string`
         * [~state()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..state) ⇒ `object`
+        * [~id()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..id) ⇒ `string`
         * [~update(from, to, amount, sign)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..update) ⇒ `Promise.&lt;object&gt;`
         * [~poi(addresses)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..poi) ⇒ `Promise.&lt;string&gt;`
         * [~balances(accounts)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..balances) ⇒ `Promise.&lt;object&gt;`
@@ -26,6 +27,7 @@ import Channel from '@aeternity/aepp-sdk/es/channel/index'
         * [~callContractStatic(options)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..callContractStatic) ⇒ `Promise.&lt;object&gt;`
         * [~getContractCall(options)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractCall) ⇒ `Promise.&lt;object&gt;`
         * [~getContractState(contract)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..getContractState) ⇒ `Promise.&lt;object&gt;`
+        * [~cleanContractCalls()](#module_@aeternity/aepp-sdk/es/channel/index--Channel..cleanContractCalls) ⇒ `Promise`
         * [~sendMessage(message, recipient)](#module_@aeternity/aepp-sdk/es/channel/index--Channel..sendMessage)
 
 <a id="exp_module_@aeternity/aepp-sdk/es/channel/index--Channel"></a>
@@ -96,6 +98,12 @@ Get current status
 
 #### Channel~state() ⇒ `object`
 Get current state
+
+**Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
+<a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..id"></a>
+
+#### Channel~id() ⇒ `string`
+Get channel id
 
 **Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..update"></a>
@@ -395,6 +403,17 @@ channel.getContractState(
   console.log('deposit:', contract.deposit)
 })
 ```
+<a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..cleanContractCalls"></a>
+
+#### Channel~cleanContractCalls() ⇒ `Promise`
+Clean up all locally stored contract calls
+
+Contract calls are kept locally in order for the participant to be able to look them up.
+They consume memory and in order for the participant to free it - one can prune all messages.
+This cleans up all locally stored contract calls and those will no longer be available for
+fetching and inspection.
+
+**Kind**: inner method of [`Channel`](#exp_module_@aeternity/aepp-sdk/es/channel/index--Channel)  
 <a id="module_@aeternity/aepp-sdk/es/channel/index--Channel..sendMessage"></a>
 
 #### Channel~sendMessage(message, recipient)

--- a/docs/api/contract.md
+++ b/docs/api/contract.md
@@ -13,6 +13,8 @@ import ContractBase from '@aeternity/aepp-sdk/es/contract'
     * [ContractBase([options])](#exp_module_@aeternity/aepp-sdk/es/contract--ContractBase) ⇒ `Object` ⏏
         * *[.contractEncodeCallDataAPI(source, name, args)](#module_@aeternity/aepp-sdk/es/contract--ContractBase+contractEncodeCallDataAPI) ⇒ `String`*
         * *[.contractDecodeDataAPI(type, data)](#module_@aeternity/aepp-sdk/es/contract--ContractBase+contractDecodeDataAPI) ⇒ `String`*
+        * *[.contractDecodeCallDataBySourceAPI(source, function, callData)](#module_@aeternity/aepp-sdk/es/contract--ContractBase+contractDecodeCallDataBySourceAPI) ⇒ `String`*
+        * *[.contractDecodeCallDataByCodeAPI(code, callData)](#module_@aeternity/aepp-sdk/es/contract--ContractBase+contractDecodeCallDataByCodeAPI) ⇒ `String`*
         * *[.compileContractAPI(code, [options])](#module_@aeternity/aepp-sdk/es/contract--ContractBase+compileContractAPI) ⇒ `Object`*
 
 <a id="exp_module_@aeternity/aepp-sdk/es/contract--ContractBase"></a>
@@ -62,6 +64,37 @@ Decode data
 | --- | --- | --- |
 | type | `String` | Contract call result type |
 | data | `String` | Encoded contract call result |
+
+<a id="module_@aeternity/aepp-sdk/es/contract--ContractBase+contractDecodeCallDataBySourceAPI"></a>
+
+#### *contractBase.contractDecodeCallDataBySourceAPI(source, function, callData) ⇒ `String`*
+Decode call data by source
+
+**Kind**: instance abstract method of [`ContractBase`](#exp_module_@aeternity/aepp-sdk/es/contract--ContractBase)  
+**Returns**: `String` - - Decoded contract call data  
+**Category**: async  
+**rtype**: `(source: String, function: String, callData: String) => decodedResult: Promise[String]`
+
+| Param | Type | Description |
+| --- | --- | --- |
+| source | `String` | contract source |
+| function | `String` | function name |
+| callData | `String` | Encoded contract call data |
+
+<a id="module_@aeternity/aepp-sdk/es/contract--ContractBase+contractDecodeCallDataByCodeAPI"></a>
+
+#### *contractBase.contractDecodeCallDataByCodeAPI(code, callData) ⇒ `String`*
+Decode call data by bytecode
+
+**Kind**: instance abstract method of [`ContractBase`](#exp_module_@aeternity/aepp-sdk/es/contract--ContractBase)  
+**Returns**: `String` - - Decoded contract call data  
+**Category**: async  
+**rtype**: `(code: String, callData: String) => decodedResult: Promise[String]`
+
+| Param | Type | Description |
+| --- | --- | --- |
+| code | `String` | contract byte code |
+| callData | `String` | Encoded contract call data |
 
 <a id="module_@aeternity/aepp-sdk/es/contract--ContractBase+compileContractAPI"></a>
 

--- a/docs/api/tx/builder.md
+++ b/docs/api/tx/builder.md
@@ -101,6 +101,7 @@ Build transaction hash
 | type | `String` |  | Transaction type |
 | [options] | `Object` | <code>{}</code> | options |
 | [options.excludeKeys] | `Object` |  | excludeKeys Array of keys to exclude for validation and build |
+| [options.prefix] | `String` |  | Prefix of transaction |
 
 <a id="exp_module_@aeternity/aepp-sdk/es/tx/builder--exports.unpackTx"></a>
 

--- a/docs/api/tx/builder/schema.md
+++ b/docs/api/tx/builder/schema.md
@@ -10,7 +10,7 @@ import TxSchema from '@aeternity/aepp-sdk/es/tx/builder/schema'
 ```
 <a id="exp_module_@aeternity/aepp-sdk/es/tx/builder/schema--exports.TX_TYPE"></a>
 
-### exports.TX_TYPE : `Object` ⏏
+### exports.TX\_TYPE : `Object` ⏏
 Object with transaction types
 
 **Kind**: Exported constant  

--- a/es/account/index.js
+++ b/es/account/index.js
@@ -39,13 +39,24 @@ const DEFAULT_NETWORK_ID = `ae_mainnet`
  * @return {String} Signed transaction
  */
 async function signTransaction (tx) {
-  const networkId = this.networkId || this.nodeNetworkId || DEFAULT_NETWORK_ID
+  const networkId = this.getNetworkId()
   const rlpBinaryTx = Crypto.decodeBase64Check(Crypto.assertedType(tx, 'tx'))
   // Prepend `NETWORK_ID` to begin of data binary
   const txWithNetworkId = Buffer.concat([Buffer.from(networkId), rlpBinaryTx])
 
   const signatures = [await this.sign(txWithNetworkId)]
   return buildTx({ encodedTx: rlpBinaryTx, signatures }, TX_TYPE.signed).tx
+}
+
+/**
+ * Obtain networkId for signing
+ * @instance
+ * @category async
+ * @rtype () => networkId: String
+ * @return {String} NetworkId
+ */
+function getNetworkId () {
+  return this.networkId || this.nodeNetworkId || DEFAULT_NETWORK_ID
 }
 
 /**
@@ -70,10 +81,10 @@ const Account = stampit({
       this.networkId = networkId
     }
   },
-  methods: { signTransaction },
+  methods: { signTransaction, getNetworkId },
   deepConf: {
     Ae: {
-      methods: ['sign', 'address', 'signTransaction']
+      methods: ['sign', 'address', 'signTransaction', 'getNetworkId']
     }
   }
 }, required({ methods: {

--- a/es/chain/index.js
+++ b/es/chain/index.js
@@ -43,7 +43,7 @@ const Chain = Oracle.compose({
     Ae: {
       methods: [
         'sendTransaction', 'height', 'awaitHeight', 'poll', 'balance', 'tx',
-        'mempool', 'topBlock', 'getTxInfo', 'txDryRun', 'getName'
+        'mempool', 'topBlock', 'getTxInfo', 'txDryRun', 'getName', 'getNodeInfo'
       ]
     }
   }
@@ -242,6 +242,16 @@ const Chain = Oracle.compose({
  * @param {Array} txs - Array of transaction's
  * @param {Array} accounts - Array of account's
  * @param {String|Number} hashOrHeight - hash or height of block on which to make dry-run
+ * @return {Object} Result
+ */
+
+/**
+ * Get Node Info
+ * @function getInfo
+ * @instance
+ * @abstract
+ * @category async
+ * @rtype () => result: Object
  * @return {Object} Result
  */
 

--- a/es/chain/node.js
+++ b/es/chain/node.js
@@ -126,7 +126,7 @@ async function poll (th, { blocks = 10, interval = 5000 } = {}) {
       await pause(interval)
       return probe()
     }
-    throw new Error(`Giving up after ${blocks} blocks mined.`)
+    throw new Error(`Giving up after ${blocks} blocks mined. TxHash ${th}`)
   }
 
   return probe()

--- a/es/channel/handlers.js
+++ b/es/channel/handlers.js
@@ -22,9 +22,20 @@ import {
   changeState,
   send,
   emit,
-  channelId
+  channelId,
+  disconnect
 } from './internal'
 import { unpackTx } from '../tx/builder'
+
+function handleUnexpectedMessage (channel, message, state) {
+  if (state.reject) {
+    state.reject(Object.assign(
+      Error(`Unexpected message received:\n\n${JSON.stringify(message)}`),
+      { wsMessage: message }
+    ))
+  }
+  return { handler: channelOpen }
+}
 
 export function awaitingConnection (channel, message, state) {
   if (message.method === 'channels.info') {
@@ -159,6 +170,7 @@ export async function awaitingOffChainTx (channel, message, state) {
     }
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingOffChainUpdate (channel, message, state) {
@@ -175,6 +187,7 @@ export function awaitingOffChainUpdate (channel, message, state) {
     state.reject(new Error(message.error.message))
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export async function awaitingTxSignRequest (channel, message, state) {
@@ -198,6 +211,7 @@ export async function awaitingTxSignRequest (channel, message, state) {
     })
     return { handler: awaitingUpdateConflict }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingUpdateConflict (channel, message, state) {
@@ -207,6 +221,7 @@ export function awaitingUpdateConflict (channel, message, state) {
   if (message.method === 'channels.conflict') {
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export async function awaitingShutdownTx (channel, message, state) {
@@ -215,24 +230,28 @@ export async function awaitingShutdownTx (channel, message, state) {
     send(channel, { jsonrpc: '2.0', method: 'channels.shutdown_sign', params: { tx: signedTx } })
     return { handler: awaitingShutdownOnChainTx, state }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingShutdownOnChainTx (channel, message, state) {
   if (message.method === 'channels.on_chain_tx') {
-    state.resolveShutdownPromise(message.params.data.tx)
+    state.resolve(message.params.data.tx)
     return { handler: channelClosed }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingLeave (channel, message, state) {
   if (message.method === 'channels.leave') {
     state.resolve({ channelId: message.params.channel_id, signedTx: message.params.data.state })
+    disconnect(channel)
     return { handler: channelClosed }
   }
   if (message.method === 'channels.error') {
     state.reject(new Error(message.data.message))
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export async function awaitingWithdrawTx (channel, message, state) {
@@ -241,6 +260,7 @@ export async function awaitingWithdrawTx (channel, message, state) {
     send(channel, { jsonrpc: '2.0', method: 'channels.withdraw_tx', params: { tx: signedTx } })
     return { handler: awaitingWithdrawCompletion, state }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingWithdrawCompletion (channel, message, state) {
@@ -271,6 +291,7 @@ export function awaitingWithdrawCompletion (channel, message, state) {
     state.resolve({ accepted: false })
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export async function awaitingDepositTx (channel, message, state) {
@@ -279,6 +300,7 @@ export async function awaitingDepositTx (channel, message, state) {
     send(channel, { jsonrpc: '2.0', method: 'channels.deposit_tx', params: { tx: signedTx } })
     return { handler: awaitingDepositCompletion, state }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingDepositCompletion (channel, message, state) {
@@ -309,6 +331,7 @@ export function awaitingDepositCompletion (channel, message, state) {
     state.resolve({ accepted: false })
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export async function awaitingNewContractTx (channel, message, state) {
@@ -317,6 +340,7 @@ export async function awaitingNewContractTx (channel, message, state) {
     send(channel, { jsonrpc: '2.0', method: 'channels.update', params: { tx: signedTx } })
     return { handler: awaitingNewContractCompletion, state }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingNewContractCompletion (channel, message, state) {
@@ -339,6 +363,7 @@ export function awaitingNewContractCompletion (channel, message, state) {
     state.resolve({ accepted: false })
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export async function awaitingCallContractUpdateTx (channel, message, state) {
@@ -347,6 +372,7 @@ export async function awaitingCallContractUpdateTx (channel, message, state) {
     send(channel, { jsonrpc: '2.0', method: 'channels.update', params: { tx: signedTx } })
     return { handler: awaitingCallContractCompletion, state }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingCallContractCompletion (channel, message, state) {
@@ -359,6 +385,7 @@ export function awaitingCallContractCompletion (channel, message, state) {
     state.resolve({ accepted: false })
     return { handler: channelOpen }
   }
+  return handleUnexpectedMessage(channel, message, state)
 }
 
 export function awaitingCallsPruned (channels, message, state) {

--- a/es/channel/index.js
+++ b/es/channel/index.js
@@ -46,8 +46,17 @@ function snakeToPascalObjKeys (obj) {
 /**
  * Register event listener function
  *
- * @param {string} event - Event name
- * @param {function} callback - Callback function
+ * Possible events:
+ *
+ *   - "error"
+ *   - "onChainTx"
+ *   - "ownWithdrawLocked"
+ *   - "withdrawLocked"
+ *   - "ownDepositLocked"
+ *   - "depositLocked"
+ *
+ * @param {String} event - Event name
+ * @param {Function} callback - Callback function
  */
 function on (event, callback) {
   eventEmitters.get(this).on(event, callback)
@@ -56,7 +65,7 @@ function on (event, callback) {
 /**
  * Get current status
  *
- * @return {string}
+ * @return {String}
  */
 function status () {
   return channelStatus.get(this)
@@ -65,7 +74,7 @@ function status () {
 /**
  * Get current state
  *
- * @return {object}
+ * @return {Promise<Object>}
  */
 async function state () {
   return snakeToPascalObjKeys(await call(this, 'channels.get.offchain_state', {}))
@@ -74,26 +83,32 @@ async function state () {
 /**
  * Get channel id
  *
- * @return {string}
+ * @return {String}
  */
 function id () {
   return channelId.get(this)
 }
 
 /**
- * Trigger an update
+ * Trigger a transfer update
  *
- * @param {string} from - Sender's public address
- * @param {string} to - Receiver's public address
- * @param {number} amount - Transaction amount
- * @param {function} sign - Function which verifies and signs transaction
- * @return {Promise<object>}
+ * The transfer update is moving tokens from one channel account to another.
+ * The update is a change to be applied on top of the latest state.
+ *
+ * Sender and receiver are the channel parties. Both the initiator and responder
+ * can take those roles. Any public key outside of the channel is considered invalid.
+ *
+ * @param {String} from - Sender's public address
+ * @param {String} to - Receiver's public address
+ * @param {Number} amount - Transaction amount
+ * @param {Function} sign - Function which verifies and signs offchain transaction
+ * @return {Promise<Object>}
  * @example channel.update(
- *   'ak$2QC98ahNHSrZLWKrpQyv91eQfCDA3aFVSNoYKdQ1ViYWVF8Z9d',
- *   'ak$Gi42jcRm9DcZjk72UWQQBSxi43BG3285C9n4QSvP5JdzDyH2o',
+ *   'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
+ *   'ak_V6an1xhec1xVaAhLuak7QoEbi6t7w5hEtYWp9bMKaJ19i6A9E',
  *   10,
  *   async (tx) => await account.signTransaction(tx)
- * ).then({ accepted, signedTx } =>
+ * ).then(({ accepted, signedTx }) =>
  *   if (accepted) {
  *     console.log('Update has been accepted')
  *   }
@@ -126,10 +141,13 @@ function update (from, to, amount, sign) {
 /**
  * Get proof of inclusion
  *
- * @param {object} addresses
- * @param {array<string>} [addresses.accounts] - List of account addresses to include in poi
- * @param {array<string>} [addresses.contracts] - List of contract addresses to include in poi
- * @return {Promise<string>}
+ * If a certain address of an account or a contract is not found
+ * in the state tree - the response is an error.
+ *
+ * @param {Object} addresses
+ * @param {Array<String>} [addresses.accounts] - List of account addresses to include in poi
+ * @param {Array<String>} [addresses.contracts] - List of contract addresses to include in poi
+ * @return {Promise<String>}
  * @example channel.poi({
  *   accounts: [
  *     'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
@@ -145,8 +163,14 @@ async function poi ({ accounts, contracts }) {
 /**
  * Get balances
  *
- * @param {array<string>} accounts - List of addresses to fetch balances from
- * @return {Promise<object>}
+ * The accounts paramcontains a list of addresses to fetch balances of.
+ * Those can be either account balances or a contract ones, encoded as an account addresses.
+ *
+ * If a certain account address had not being found in the state tree - it is simply
+ * skipped in the response.
+ *
+ * @param {Array<String>} accounts - List of addresses to fetch balances from
+ * @return {Promise<Object>}
  * @example channel.balances([
  *   'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
  *   'ak_V6an1xhec1xVaAhLuak7QoEbi6t7w5hEtYWp9bMKaJ19i6A9E'
@@ -165,11 +189,20 @@ async function balances (accounts) {
 /**
  * Leave channel
  *
- * @return {Promise<object>}
- * @example channel.leave().then(({ channelId, signedTx }) =>
+ * It is possible to leave a channel and then later reestablish the channel
+ * off-chain state and continue operation. When a leave method is called,
+ * the channel fsm passes it on to the peer fsm, reports the current mutually
+ * signed state and then terminates.
+ *
+ * The channel can be reestablished by instantiating another Channel instance
+ * with two extra params: existingChannelId and offchainTx (returned from leave
+ * method as channelId and signedTx respectively).
+ *
+ * @return {Promise<Object>}
+ * @example channel.leave().then(({ channelId, signedTx }) => {
  *   console.log(channelId)
- *   console.log(state)
- * )
+ *   console.log(signedTx)
+ * })
  */
 function leave () {
   return new Promise((resolve) => {
@@ -187,10 +220,13 @@ function leave () {
 }
 
 /**
- * Trigger a channel shutdown
+ * Trigger mutual close
  *
- * @param {function} sign - Function which verifies and signs transaction
- * @return {Promise<string>}
+ * At any moment after the channel is opened, a closing procedure can be triggered.
+ * This can be done by either of the parties. The process is similar to the off-chain updates.
+ *
+ * @param {Function} sign - Function which verifies and signs mutual close transaction
+ * @return {Promise<String>}
  * @example channel.shutdown(
  *   async (tx) => await account.signTransaction(tx)
  * ).then(tx => console.log('on_chain_tx', tx))
@@ -217,13 +253,37 @@ function shutdown (sign) {
 /**
  * Withdraw tokens from the channel
  *
- * @param {number} amount - Amount of tokens to withdraw
- * @param {function} sign - Function which verifies and signs withdraw transaction
- * @param {object} [callbacks]
- * @param {function} [callbacks.onOnChainTx] - Called when withdraw transaction has been posted on chain
- * @param {function} [callbacks.onOwnWithdrawLocked]
- * @param {function} [callbacks.onWithdrawLocked]
- * @return {Promise<object>}
+ * After the channel had been opened any of the participants can initiate a withdrawal.
+ * The process closely resembles the update. The most notable difference is that the
+ * transaction has been co-signed: it is channel_withdraw_tx and after the procedure
+ * is finished - it is being posted on-chain.
+ *
+ * Any of the participants can initiate a withdrawal. The only requirements are:
+ *
+ *   - Channel is already opened
+ *   - No off-chain update/deposit/withdrawal is currently being performed
+ *   - Channel is not being closed or in a solo closing state
+ *   - The withdrawal amount must be equal to or greater than zero, and cannot exceed
+ *     the available balance on the channel (minus the channel_reserve)
+ *
+ * After the other party had signed the withdraw transaction, the transaction is posted
+ * on-chain and onOnChainTx callback is called with on-chain transaction as first argument.
+ * After computing transaction hash it can be tracked on the chain: entering the mempool,
+ * block inclusion and a number of confirmations.
+ *
+ * After the minimum_depth block confirmations onOwnWithdrawLocked callback is called
+ * (without any arguments).
+ *
+ * When the other party had confirmed that the block height needed is reached
+ * onWithdrawLocked callback is called (without any arguments).
+ *
+ * @param {Number} amount - Amount of tokens to withdraw
+ * @param {Function} sign - Function which verifies and signs withdraw transaction
+ * @param {Object} [callbacks]
+ * @param {Function} [callbacks.onOnChainTx] - Called when withdraw transaction has been posted on chain
+ * @param {Function} [callbacks.onOwnWithdrawLocked]
+ * @param {Function} [callbacks.onWithdrawLocked]
+ * @return {Promise<Object>}
  * @example channel.withdraw(
  *   100,
  *   async (tx) => await account.signTransaction(tx),
@@ -261,13 +321,37 @@ function withdraw (amount, sign, { onOnChainTx, onOwnWithdrawLocked, onWithdrawL
 /**
  * Deposit tokens into the channel
  *
- * @param {number} amount - Amount of tokens to deposit
- * @param {function} sign - Function which verifies and signs deposit transaction
- * @param {object} [callbacks]
- * @param {function} [callbacks.onOnChainTx] - Called when deposit transaction has been posted on chain
- * @param {function} [callbacks.onOwnDepositLocked]
- * @param {function} [callbacks.onDepositLocked]
- * @return {Promise<object>}
+ * After the channel had been opened any of the participants can initiate a deposit.
+ * The process closely resembles the update. The most notable difference is that the
+ * transaction has been co-signed: it is channel_deposit_tx and after the procedure
+ * is finished - it is being posted on-chain.
+ *
+ * Any of the participants can initiate a deposit. The only requirements are:
+ *
+ *   - Channel is already opened
+ *   - No off-chain update/deposit/withdrawal is currently being performed
+ *   - Channel is not being closed or in a solo closing state
+ *   - The deposit amount must be equal to or greater than zero, and cannot exceed
+ *     the available balance on the channel (minus the channel_reserve)
+ *
+ * After the other party had signed the deposit transaction, the transaction is posted
+ * on-chain and onOnChainTx callback is called with on-chain transaction as first argument.
+ * After computing transaction hash it can be tracked on the chain: entering the mempool,
+ * block inclusion and a number of confirmations.
+ *
+ * After the minimum_depth block confirmations onOwnDepositLocked callback is called
+ * (without any arguments).
+ *
+ * When the other party had confirmed that the block height needed is reached
+ * onDepositLocked callback is called (without any arguments).
+ *
+ * @param {Number} amount - Amount of tokens to deposit
+ * @param {Function} sign - Function which verifies and signs deposit transaction
+ * @param {Object} [callbacks]
+ * @param {Function} [callbacks.onOnChainTx] - Called when deposit transaction has been posted on chain
+ * @param {Function} [callbacks.onOwnDepositLocked]
+ * @param {Function} [callbacks.onDepositLocked]
+ * @return {Promise<Object>}
  * @example channel.deposit(
  *   100,
  *   async (tx) => await account.signTransaction(tx),
@@ -304,16 +388,22 @@ function deposit (amount, sign, { onOnChainTx, onOwnDepositLocked, onDepositLock
 }
 
 /**
- * Create a contract
+ * Trigger create contract update
  *
- * @param {object} options
- * @param {string} [options.code] - Api encoded compiled AEVM byte code
- * @param {string} [options.callData] - Api encoded compiled AEVM call data for the code
- * @param {number} [options.deposit] - Initial amount the owner of the contract commits to it
- * @param {number} [options.vmVersion] - Version of the AEVM
- * @param {number} [options.abiVersion] - Version of the ABI
- * @param {function} sign - Function which verifies and signs create contract transaction
- * @return {Promise<object>}
+ * The create contract update is creating a contract inside the channel's internal state tree.
+ * The update is a change to be applied on top of the latest state.
+ *
+ * That would create a contract with the poster being the owner of it. Poster commits initially
+ * a deposit amount of tokens to the new contract.
+ *
+ * @param {Object} options
+ * @param {String} options.code - Api encoded compiled AEVM byte code
+ * @param {String} options.callData - Api encoded compiled AEVM call data for the code
+ * @param {Number} options.deposit - Initial amount the owner of the contract commits to it
+ * @param {Number} options.vmVersion - Version of the AEVM
+ * @param {Number} options.abiVersion - Version of the ABI
+ * @param {Function} sign - Function which verifies and signs create contract transaction
+ * @return {Promise<Object>}
  * @example channel.createContract({
  *   code: 'cb_HKtpipK4aCgYb17wZ...',
  *   callData: 'cb_1111111111111111...',
@@ -359,15 +449,28 @@ function createContract ({ code, callData, deposit, vmVersion, abiVersion }, sig
 }
 
 /**
- * Call a contract
+ * Trigger call a contract update
  *
- * @param {object} options
- * @param {string} [options.amount] - Amount the caller of the contract commits to it
- * @param {string} [options.callData] - ABI encoded compiled AEVM call data for the code
- * @param {number} [options.contract] - Address of the contract to call
- * @param {number} [options.abiVersion] - Version of the ABI
- * @param {function} sign - Function which verifies and signs contract call transaction
- * @return {Promise<object>}
+ * The call contract update is calling a preexisting contract inside the channel's
+ * internal state tree. The update is a change to be applied on top of the latest state.
+ *
+ * That would call a contract with the poster being the caller of it. Poster commits
+ * an amount of tokens to the contract.
+ *
+ * The call would also create a call object inside the channel state tree. It contains
+ * the result of the contract call.
+ *
+ * It is worth mentioning that the gas is not consumed, because this is an off-chain
+ * contract call. It would be consumed if it were a on-chain one. This could happen
+ * if a call with a similar computation amount is to be forced on-chain.
+ *
+ * @param {Object} options
+ * @param {String} [options.amount] - Amount the caller of the contract commits to it
+ * @param {String} [options.callData] - ABI encoded compiled AEVM call data for the code
+ * @param {Number} [options.contract] - Address of the contract to call
+ * @param {Number} [options.abiVersion] - Version of the ABI
+ * @param {Function} sign - Function which verifies and signs contract call transaction
+ * @return {Promise<Object>}
  * @example channel.callContract({
  *   contract: 'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa',
  *   callData: 'cb_1111111111111111...',
@@ -409,12 +512,20 @@ function callContract ({ amount, callData, contract, abiVersion }, sign) {
 /**
  * Call contract using dry-run
  *
- * @param {object} options
- * @param {string} [options.amount] - Amount the caller of the contract commits to it
- * @param {string} [options.callData] - ABI encoded compiled AEVM call data for the code
- * @param {number} [options.contract] - Address of the contract to call
- * @param {number} [options.abiVersion] - Version of the ABI
- * @return {Promise<object>}
+ * In order to get the result of a potential contract call, one might need to
+ * dry-run a contract call. It takes the exact same arguments as a call would
+ * and returns the call object.
+ *
+ * The call is executed in the channel's state but it does not impact the state
+ * whatsoever. It uses as an environment the latest channel's state and the current
+ * top of the blockchain as seen by the node.
+ *
+ * @param {Object} options
+ * @param {String} [options.amount] - Amount the caller of the contract commits to it
+ * @param {String} [options.callData] - ABI encoded compiled AEVM call data for the code
+ * @param {Number} [options.contract] - Address of the contract to call
+ * @param {Number} [options.abiVersion] - Version of the ABI
+ * @return {Promise<Object>}
  * @example channel.callContractStatic({
   *   contract: 'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa',
   *   callData: 'cb_1111111111111111...',
@@ -437,11 +548,14 @@ async function callContractStatic ({ amount, callData, contract, abiVersion }) {
 /**
  * Get contract call result
  *
- * @param {object} options
- * @param {string} [options.caller] - Address of contract caller
- * @param {string} [options.contract] - Address of the contract
- * @param {number} [options.round] - Round when contract was called
- * @return {Promise<object>}
+ * The combination of a caller, contract and a round of execution determines the
+ * contract call. Providing an incorrect set of those results in an error response.
+ *
+ * @param {Object} options
+ * @param {String} [options.caller] - Address of contract caller
+ * @param {String} [options.contract] - Address of the contract
+ * @param {Number} [options.round] - Round when contract was called
+ * @return {Promise<Object>}
  * @example channel.getContractCall({
  *   caller: 'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
  *   contract: 'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa',
@@ -457,14 +571,14 @@ async function getContractCall ({ caller, contract, round }) {
 /**
  * Get contract latest state
  *
- * @param {string} contract - Address of the contract
- * @return {Promise<object>}
+ * @param {String} contract - Address of the contract
+ * @return {Promise<Object>}
  * @example channel.getContractState(
-  *   'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa',
-  * ).then(({ contract }) => {
-  *   console.log('deposit:', contract.deposit)
-  * })
-  */
+ *   'ct_9sRA9AVE4BYTAkh5RNfJYmwQe1NZ4MErasQLXZkFWG43TPBqa'
+ * ).then(({ contract }) => {
+ *   console.log('deposit:', contract.deposit)
+ * })
+ */
 async function getContractState (contract) {
   const result = await call(this, 'channels.get.contract', { pubkey: contract })
   return snakeToPascalObjKeys({
@@ -509,8 +623,11 @@ function cleanContractCalls () {
  * If message is an object it will be serialized into JSON string
  * before sending.
  *
- * @param {string|object} message
- * @param {string} recipient - Address of the recipient
+ * If there is ongoing update that has not yet been finished the message
+ * will be sent after that update is finalized.
+ *
+ * @param {String|Object} message
+ * @param {String} recipient - Address of the recipient
  * @example channel.sendMessage(
  *   'hello world',
  *   'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH'
@@ -521,8 +638,6 @@ function sendMessage (message, recipient) {
   if (typeof message === 'object') {
     info = JSON.stringify(message)
   }
-  // TODO: is it possible to send a message when channel is in other state
-  //       than `channelOpen`? For example in the middle of an update.
   enqueueAction(
     this,
     (channel, state) => state.handler === handlers.channelOpen,
@@ -539,8 +654,8 @@ function sendMessage (message, recipient) {
  * @function
  * @alias module:@aeternity/aepp-sdk/es/channel/index
  * @rtype Channel
- * @param {Object} [options={}] - Initializer object
- * @param {String} options.url - Channel url (for example: "ws://localhost:3001/channel")
+ * @param {Object} options - Channel params
+ * @param {String} options.url - Channel url (for example: "ws://localhost:3001")
  * @param {String} options.role - Participant role ("initiator" or "responder")
  * @param {String} options.initiatorId - Initiator's public key
  * @param {String} options.responderId - Responder's public key
@@ -554,23 +669,31 @@ function sendMessage (message, recipient) {
  * @param {Number} options.lockPeriod - Amount of blocks for disputing a solo close
  * @param {Number} [options.existingChannelId] - Existing channel id (required if reestablishing a channel)
  * @param {Number} [options.offchainTx] - Offchain transaction (required if reestablishing a channel)
+ * @param {Number} [options.timeoutIdle] - The time waiting for a new event to be initiated (default: 600000)
+ * @param {Number} [options.timeoutFundingCreate] - The time waiting for the initiator to produce the create channel transaction after the noise session had been established (default: 120000)
+ * @param {Number} [options.timeoutFundingSign] - The time frame the other client has to sign an off-chain update after our client had initiated and signed it. This applies only for double signed on-chain intended updates: channel create transaction, deposit, withdrawal and etc. (default: 120000)
+ * @param {Number} [options.timeoutFundingLock] - The time frame the other client has to confirm an on-chain transaction reaching maturity (passing minimum depth) after the local node has detected this. This applies only for double signed on-chain intended updates: channel create transaction, deposit, withdrawal and etc. (default: 360000)
+ * @param {Number} [options.timeoutSign] - The time frame the client has to return a signed off-chain update or to decline it. This applies for all off-chain updates (default: 500000)
+ * @param {Number} [options.timeoutAccept] - The time frame the other client has to react to an event. This applies for all off-chain updates that are not meant to land on-chain, as well as some special cases: opening a noise connection, mutual closing acknowledgement and reestablishing an existing channel (default: 120000)
+ * @param {Number} [options.timeoutInitialized] - the time frame the responder has to accept an incoming noise session. Applicable only for initiator (default: timeout_accept's value)
+ * @param {Number} [options.timeoutAwaitingOpen] - The time frame the initiator has to start an outgoing noise session to the responder's node. Applicable only for responder (default: timeout_idle's value)
  * @param {Function} options.sign - Function which verifies and signs transactions
- * @return {Object} Channel instance
+ * @return {Promise<Object>} Channel instance
  * @example Channel({
-  url: 'ws://localhost:3001',
-  role: 'initiator'
-  initiatorId: 'ak$2QC98ahNHSrZLWKrpQyv91eQfCDA3aFVSNoYKdQ1ViYWVF8Z9d',
-  responderId: 'ak$Gi42jcRm9DcZjk72UWQQBSxi43BG3285C9n4QSvP5JdzDyH2o',
-  pushAmount: 3,
-  initiatorAmount: 10,
-  responderAmount: 10,
-  channelReserve: 2,
-  ttl: 1000,
-  host: 'localhost',
-  port: 3002,
-  lockPeriod: 10,
-  async sign (tag, tx) => await account.signTransaction(tx)
-})
+ *   url: 'ws://localhost:3001',
+ *   role: 'initiator'
+ *   initiatorId: 'ak_Y1NRjHuoc3CGMYMvCmdHSBpJsMDR6Ra2t5zjhRcbtMeXXLpLH',
+ *   responderId: 'ak_V6an1xhec1xVaAhLuak7QoEbi6t7w5hEtYWp9bMKaJ19i6A9E',
+ *   initiatorAmount: 1e18,
+ *   responderAmount: 1e18,
+ *   pushAmount: 0,
+ *   channelReserve: 0,
+ *   ttl: 1000,
+ *   host: 'localhost',
+ *   port: 3002,
+ *   lockPeriod: 10,
+ *   async sign (tag, tx) => await account.signTransaction(tx)
+ * })
  */
 const Channel = AsyncInit.compose({
   async init (options) {

--- a/es/channel/internal.js
+++ b/es/channel/internal.js
@@ -21,6 +21,9 @@ import * as R from 'ramda'
 import { pascalToSnake } from '../utils/string'
 import { awaitingConnection } from './handlers'
 
+const PING_TIMEOUT_MS = 10000
+const PONG_TIMEOUT_MS = 5000
+
 const options = new WeakMap()
 const status = new WeakMap()
 const state = new WeakMap()
@@ -34,6 +37,8 @@ const actionQueueLocked = new WeakMap()
 const sequence = new WeakMap()
 const channelId = new WeakMap()
 const rpcCallbacks = new WeakMap()
+const pingTimeoutId = new WeakMap()
+const pongTimeoutId = new WeakMap()
 
 function channelURL (url, params, endpoint = 'channel') {
   const paramString = R.join('&', R.values(R.mapObjIndexed((value, key) =>
@@ -154,6 +159,24 @@ function call (channel, method, params) {
   })
 }
 
+function ping (channel) {
+  const ws = websockets.get(channel)
+  if (ws.readyState === ws.OPEN) {
+    ws._connection.ping()
+    clearTimeout(pongTimeoutId.get(channel))
+    pongTimeoutId.set(channel, setTimeout(() => ws._connection.drop(), PONG_TIMEOUT_MS))
+  }
+}
+
+function disconnect (channel) {
+  const ws = websockets.get(channel)
+  if (ws.readyState === ws.OPEN) {
+    ws._connection.close()
+    clearTimeout(pongTimeoutId.get(channel))
+    clearTimeout(pingTimeoutId.get(channel))
+  }
+}
+
 function WebSocket (url, callbacks) {
   function fireOnce (target, key, always) {
     target[key] = (...args) => {
@@ -185,11 +208,18 @@ async function initialize (channel, channelOptions) {
   eventEmitters.set(channel, new EventEmitter())
   sequence.set(channel, 0)
   rpcCallbacks.set(channel, new Map())
-  websockets.set(channel, await WebSocket(wsUrl, {
+  const ws = await WebSocket(wsUrl, {
     onopen: () => changeStatus(channel, 'connected'),
     onclose: () => changeStatus(channel, 'disconnected'),
     onmessage: ({ data }) => onMessage(channel, data)
-  }))
+  })
+  ws._connection.on('pong', () => {
+    clearTimeout(pongTimeoutId.get(channel))
+    clearTimeout(pingTimeoutId.get(channel))
+    pingTimeoutId.set(channel, setTimeout(() => ping(channel), PING_TIMEOUT_MS))
+  })
+  pingTimeoutId.set(channel, setTimeout(() => ping(channel), PING_TIMEOUT_MS))
+  websockets.set(channel, ws)
 }
 
 export {
@@ -204,5 +234,6 @@ export {
   send,
   enqueueAction,
   channelId,
-  call
+  call,
+  disconnect
 }

--- a/es/contract/compiler.js
+++ b/es/contract/compiler.js
@@ -33,6 +33,16 @@ async function contractEncodeCallDataAPI (source, name, args = [], options = {})
     .then(({ calldata }) => calldata)
 }
 
+async function contractDecodeCallDataByCodeAPI (bytecode, calldata, options = {}) {
+  return this.http
+    .post('/decode-calldata/bytecode', { bytecode, calldata }, options)
+}
+
+async function contractDecodeCallDataBySourceAPI (source, fn, callData, options = {}) {
+  return this.http
+    .post('/decode-calldata/source', { 'function': fn, source, calldata: callData }, options)
+}
+
 async function contractDecodeDataAPI (type, data, options = {}) {
   return this.http
     .post('/decode-data', { data, 'sophia-type': type }, options)
@@ -73,6 +83,8 @@ const ContractCompilerAPI = ContractBase.compose({
     contractDecodeDataAPI,
     compileContractAPI,
     contractGetACI,
+    contractDecodeCallDataByCodeAPI,
+    contractDecodeCallDataBySourceAPI,
     setCompilerUrl
   }
 })

--- a/es/contract/index.js
+++ b/es/contract/index.js
@@ -44,6 +44,8 @@ const ContractBase = stampit({
         'contractEncodeCallDataAPI',
         'contractDecodeDataAPI',
         'compileContractAPI',
+        'contractDecodeCallDataBySourceAPI',
+        'contractDecodeCallDataByCodeAPI',
         'contractGetACI'
       ]
     }
@@ -80,6 +82,31 @@ const ContractBase = stampit({
  * @param {String} type - Contract call result type
  * @param {String} data - Encoded contract call result
  * @return {String} - Decoded contract call result
+ */
+
+/**
+ * Decode call data by source
+ * @function contractDecodeCallDataBySourceAPI
+ * @instance
+ * @abstract
+ * @category async
+ * @rtype (source: String, function: String, callData: String) => decodedResult: Promise[String]
+ * @param {String} source - contract source
+ * @param {String} function - function name
+ * @param {String} callData - Encoded contract call data
+ * @return {String} - Decoded contract call data
+ */
+
+/**
+ * Decode call data by bytecode
+ * @function contractDecodeCallDataByCodeAPI
+ * @instance
+ * @abstract
+ * @category async
+ * @rtype (code: String, callData: String) => decodedResult: Promise[String]
+ * @param {String} code - contract byte code
+ * @param {String} callData - Encoded contract call data
+ * @return {String} - Decoded contract call data
  */
 
 /**

--- a/es/node.js
+++ b/es/node.js
@@ -74,14 +74,25 @@ const loader = ({ url, internalUrl }) => (path, definition) => {
 const Node = stampit({
   async init ({ url = this.url, internalUrl = this.internalUrl }) {
     url = url.replace(/\/?$/, '/')
-
     // Get swagger schema
     const swag = await remoteSwag(url)
     this.version = swag.info.version
     return Object.assign(this, {
+      url,
+      internalUrl,
       swag: swag,
       urlFor: loader({ url, internalUrl })
     })
+  },
+  methods: {
+    getNodeInfo () {
+      return {
+        url: this.url,
+        internalUrl: this.internalUrl,
+        nodeNetworkId: this.nodeNetworkId,
+        version: this.version
+      }
+    }
   },
   props: {
     version: null,

--- a/es/rpc/client.js
+++ b/es/rpc/client.js
@@ -94,8 +94,10 @@ const RpcClient = stampit(AsyncInit, {
       ...(R.path(['compose', 'deepConfiguration', 'Contract', 'methods'], stamp) || [])
     ]
     const rpcMethods = R.fromPairs(methods.map(m => [m, post(m)]))
-    // remove signTransaction from AEPP instance, let's go it through RPC
-    if (stamp.compose.methods) delete stamp.compose.methods.signTransaction
+    if (stamp.compose.methods) {
+      // remove signTransaction and getNetworkId from AEPP instance, let's go it through RPC
+      ['signTransaction', 'getNetworkId'].forEach(m => delete stamp.compose.methods[m])
+    }
     stamp.compose.methods = Object.assign(rpcMethods, stamp.compose.methods)
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1836,8 +1836,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
       "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
@@ -1952,15 +1951,6 @@
         "any-promise": "^1.3.0",
         "bindings": "^1.3.0",
         "nan": "^2.10.0"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "argv-tools": {
@@ -2094,8 +2084,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -3197,7 +3186,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3323,6 +3311,12 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "conventional-commit-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.1.1.tgz",
+      "integrity": "sha512-0Ts+fEdmjqYDOQ1yZ+LNgdSPO335XZw9qC10M7CxtLP3nIMGmeMhmkM8Taffa4+MXN13bRPlp0CtH+QfOzKTzw==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -3440,8 +3434,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
       "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -3457,6 +3450,19 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+    },
+    "cz-conventional-changelog": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
+      "dev": true,
+      "requires": {
+        "conventional-commit-types": "^2.0.0",
+        "lodash.map": "^4.5.1",
+        "longest": "^1.0.1",
+        "right-pad": "^1.0.1",
+        "word-wrap": "^1.0.3"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -3629,8 +3635,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -3681,9 +3686,9 @@
       }
     },
     "dmd": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.12.tgz",
-      "integrity": "sha512-79w644JdsB2TthYpVl2bDurX7i9Abaegg2E7X46Ajc135aASTMXxrHzJ9mOa5X5nbmnXwlBYiF68K+1baX+BzQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.13.tgz",
+      "integrity": "sha512-FV/417bH2c/CYpe8BjFEAHoaHaItcJnPlKELi/qyPZdmUom8joyuC78OhhfPUdyKD/WcouTQ2LxQT4M/RoiJ3w==",
       "dev": true,
       "requires": {
         "array-back": "^2.0.0",
@@ -4662,8 +4667,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -4949,14 +4953,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+      "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4968,8 +4972,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4978,7 +4981,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4990,21 +4993,19 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5012,20 +5013,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5034,16 +5032,16 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5092,7 +5090,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5112,12 +5110,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -5142,8 +5140,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5155,7 +5152,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5170,7 +5166,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5178,21 +5173,19 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5204,41 +5197,47 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true,
+          "optional": true
+        },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -5255,13 +5254,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5285,8 +5284,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5298,7 +5296,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5338,12 +5335,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -5373,19 +5370,18 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5400,7 +5396,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5421,7 +5417,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5441,7 +5436,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5453,17 +5447,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -5474,25 +5468,23 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5666,25 +5658,29 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
+          "optional": true
+        },
+        "neo-async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+          "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -5693,13 +5689,13 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+          "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "commander": "~2.17.1",
+            "commander": "~2.20.0",
             "source-map": "~0.6.1"
           }
         }
@@ -6387,11 +6383,9 @@
     },
     "js-yaml": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "resolved": "",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       },
       "dependencies": {
@@ -6839,6 +6833,12 @@
       "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
       "dev": true
     },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6891,9 +6891,9 @@
       }
     },
     "marked": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.0.tgz",
-      "integrity": "sha512-UhjmkCWKu1SS/BIePL2a59BMJ7V42EYtTfksodPRXzPEGEph3Inp5dylseqt+KbU9Jglsx8xcMKmlumfJMBXAA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
       "dev": true
     },
     "md5": {
@@ -6972,15 +6972,13 @@
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
       "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.19",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "mime-db": "~1.35.0"
       }
@@ -7960,8 +7958,7 @@
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.2",
@@ -8122,7 +8119,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -8551,6 +8548,12 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "right-pad": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
       "dev": true
     },
     "rimraf": {
@@ -9101,12 +9104,6 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
     },
     "sshpk": {
       "version": "1.14.2",
@@ -9768,7 +9765,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -9778,8 +9774,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10468,6 +10463,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "browser": "dist/aepp-sdk.browser.js",
@@ -15,6 +15,7 @@
     "test:watch": "mocha --recursive --require @babel/register --watch",
     "test-jenkins": "mocha --recursive --require @babel/register --reporter mocha-junit-reporter",
     "prepare": "npm run build",
+    "genChangelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "prepublishOnly": "npm run docs:docco && npm run docs:api"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "browser": "dist/aepp-sdk.browser.js",

--- a/test/integration/channel.js
+++ b/test/integration/channel.js
@@ -705,7 +705,7 @@ describe('Channel', function () {
     })
 
     it('when posting an update with incorrect amount', async () => {
-      return update({ amount: '1' }).should.eventually.be.rejectedWith('Internal error')
+      return update({ amount: '1' }).should.eventually.be.rejectedWith('Rejected')
     })
 
     it('when posting incorrect update tx', async () => {

--- a/test/integration/channel.js
+++ b/test/integration/channel.js
@@ -85,6 +85,11 @@ describe('Channel', function () {
     await initiator.spend('6000000000000000', await responder.address())
   })
 
+  after(() => {
+    initiatorCh.disconnect()
+    responderCh.disconnect()
+  })
+
   beforeEach(() => {
     responderShouldRejectUpdate = false
   })
@@ -403,7 +408,8 @@ describe('Channel', function () {
     await Promise.all([waitForChannel(initiatorCh), waitForChannel(responderCh)])
     sinon.assert.notCalled(initiatorSign)
     sinon.assert.notCalled(responderSign)
-    await initiatorCh.leave()
+    initiatorCh.disconnect()
+    responderCh.disconnect()
   })
 
   it('can solo close a channel', async () => {


### PR DESCRIPTION
# [3.1.0](https://github.com/aeternity/aepp-sdk-js/compare/2.4.0...3.1.0) (2019-04-24)


### Bug Fixes

* **ACI:** Fix address type transformation when decoding data ([#335](https://github.com/aeternity/aepp-sdk-js/issues/335)) ([e37cdfc](https://github.com/aeternity/aepp-sdk-js/commit/e37cdfc))


### Features

* **ACI:** Add `contract`, `address`, `record` types argument/result transformation ([#349](https://github.com/aeternity/aepp-sdk-js/issues/349)) ([0599d7d](https://github.com/aeternity/aepp-sdk-js/commit/0599d7d))
* **ACI:** Update due to compiler API changes ([#331](https://github.com/aeternity/aepp-sdk-js/issues/331)) ([e047f3b](https://github.com/aeternity/aepp-sdk-js/commit/e047f3b))
* **Aepp:** Add Compiler to Aepp rpc methods. Update example app ([#312](https://github.com/aeternity/aepp-sdk-js/issues/312)) ([9c72521](https://github.com/aeternity/aepp-sdk-js/commit/9c72521))
* **Compiler:** Add decode CallData by source/bytecode ([#354](https://github.com/aeternity/aepp-sdk-js/issues/354)) ([761f36b](https://github.com/aeternity/aepp-sdk-js/commit/761f36b))
* **RPC:** Add getNodeInfo and getNetworkId to AEPP stamp through RPC ([#359](https://github.com/aeternity/aepp-sdk-js/issues/359)) ([2ddeea8](https://github.com/aeternity/aepp-sdk-js/commit/2ddeea8))
* **State Channels:** Add cleanContractCalls method ([#338](https://github.com/aeternity/aepp-sdk-js/issues/338)) ([778159a](https://github.com/aeternity/aepp-sdk-js/commit/778159a))
* **State Channels:** Ping every 10 seconds to persist connection ([#324](https://github.com/aeternity/aepp-sdk-js/issues/324)) ([6d0e156](https://github.com/aeternity/aepp-sdk-js/commit/6d0e156))
