### PR TITLE
webpack configs: Mark all dependencies as external

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,16 @@ function configure (filename, opts = {}) {
       filename,
       library: 'Ae',
       libraryTarget: 'umd'
-    }
+    },
+    externals: Object
+      .keys(require('./package').dependencies)
+      .reduce((p, dependency) => ({
+        ...p,
+        [dependency]: {
+          commonjs: dependency,
+          commonjs2: dependency
+        }
+      }), {}),
   }, opts)
 }
 


### PR DESCRIPTION
This affects only the built version of sdk, e.g when it used by importing of '@aeternity/aepp-sdk' (without `/es`).

The idea of this PR is to make possible to reuse dependencies of sdk by other packages or the code of a project that depends on SDK. Also, it makes more understandable SDK dependencies and it's actual size. After all, it makes SDK bundle smaller, making the build of SDK faster and disables `WARNING in asset size limit: The following asset(s) exceed the recommended size limit`.

Before:
![localhost_63342_vue-debug_dist_report html__ijt=n726b48011cm8sqfi71pefh5l4](https://user-images.githubusercontent.com/9007851/57198427-efb3be80-6f72-11e9-8891-f6a7fcacb6a3.png)
After:
![localhost_63342_vue-debug_dist_report html__ijt=e7tnsuu9sehim6rbeh6gkib13s](https://user-images.githubusercontent.com/9007851/57198421-df9bdf00-6f72-11e9-89e3-14927f128746.png)
There reports generated by https://github.com/davidyuk/vue-reproductions/tree/sdk-external-dependencies project, using `npm run build -- --report`

The same configs we have in components repository: https://github.com/aeternity/aepp-components/blob/b891e32030291e1da8042c242a84eb14315d3b8c/config/webpack.config.js#L155-L163