### PR TITLE
rpc client: Handle case if aepp opened without wallet

### DIFF
--- a/es/rpc/client.js
+++ b/es/rpc/client.js
@@ -46,7 +46,7 @@ function post (method) {
 const RpcClient = stampit(AsyncInit, {
   async init ({ parent = window.parent, self = window }, { stamp }) {
     if (parent === self) {
-      throw new Error('rpc client: Can\'t send messages to itself');
+      throw new Error('rpc client: Can\'t send messages to itself')
     }
 
     let sequence = 0

--- a/es/rpc/client.js
+++ b/es/rpc/client.js
@@ -45,6 +45,10 @@ function post (method) {
  */
 const RpcClient = stampit(AsyncInit, {
   async init ({ parent = window.parent, self = window }, { stamp }) {
+    if (parent === self) {
+      throw new Error('rpc client: Can\'t send messages to itself');
+    }
+
     let sequence = 0
     const callbacks = {}
 


### PR DESCRIPTION
`window.parent` is equal to `window` if a web page opened as usual. If we accidentally start dapp in this way (also not setting `parent` option), then `rpc/client` will send a `hello` to itself and fail with exception:
> Uncaught TypeError: Cannot destructure property `resolve` of 'undefined' or 'null'. at receive (client.js?aafa:56)

I think much cleaner for dapp developers to handle this case separately. In that case this PR makes dapp to throw:
> Uncaught (in promise) Error: rpc client: Can't send messages to itself at Object._callee$ (client.js?6b57:46)