### PR TITLE
refactor(SCM): Update compatibility range for node: 3.0.1 - 4

### DIFF
--- a/es/contract/compiler.js
+++ b/es/contract/compiler.js
@@ -26,6 +26,7 @@
 
 import Http from '../utils/http'
 import ContractBase from './index'
+import semverSatisfies from '../utils/semver-satisfies'
 
 async function getCompilerVersion (options = {}) {
   return this.http
@@ -89,6 +90,11 @@ const ContractCompilerAPI = ContractBase.compose({
   async init ({ compilerUrl = this.compilerUrl }) {
     this.http = Http({ baseUrl: compilerUrl })
     this.compilerVersion = await this.getCompilerVersion()
+    console.log(this.compilerVersion)
+    if (!semverSatisfies(this.compilerVersion.split('-')[0], COMPILER_GE_VERSION, COMPILER_LT_VERSION)) {
+      throw new Error(`Unsupported compiler version ${this.compilerVersion}. ` +
+        `Supported: >= ${COMPILER_GE_VERSION} < ${COMPILER_LT_VERSION}`)
+    }
   },
   methods: {
     contractEncodeCallDataAPI,
@@ -105,5 +111,8 @@ const ContractCompilerAPI = ContractBase.compose({
     compilerVersion: null
   }
 })
+
+const COMPILER_GE_VERSION = '3.1.0'
+const COMPILER_LT_VERSION = '4.0.0'
 
 export default ContractCompilerAPI

--- a/es/contract/compiler.js
+++ b/es/contract/compiler.js
@@ -90,7 +90,6 @@ const ContractCompilerAPI = ContractBase.compose({
   async init ({ compilerUrl = this.compilerUrl }) {
     this.http = Http({ baseUrl: compilerUrl })
     this.compilerVersion = await this.getCompilerVersion()
-    console.log(this.compilerVersion)
     if (!semverSatisfies(this.compilerVersion.split('-')[0], COMPILER_GE_VERSION, COMPILER_LT_VERSION)) {
       throw new Error(`Unsupported compiler version ${this.compilerVersion}. ` +
         `Supported: >= ${COMPILER_GE_VERSION} < ${COMPILER_LT_VERSION}`)

--- a/es/node.js
+++ b/es/node.js
@@ -150,7 +150,7 @@ const Node = stampit({
   }
 })
 
-const NODE_GE_VERSION = '2.3.0'
+const NODE_GE_VERSION = '3.0.1'
 const NODE_LT_VERSION = '4.0.0'
 
 export default Node


### PR DESCRIPTION
BREAKING CHANGE: This change will make the release not compatible with older version of the node and compiler