### PR TITLE
fix(TxBuilder): Fix serialization of payload

### DIFF
--- a/es/tx/builder/index.js
+++ b/es/tx/builder/index.js
@@ -98,6 +98,7 @@ function serializeField (value, type, prefix) {
     case FIELD_TYPES.signatures:
       return value.map(Buffer.from)
     case FIELD_TYPES.payload:
+      return decode(value, 'ba')
     case FIELD_TYPES.string:
       return toBytes(value)
     case FIELD_TYPES.pointers:


### PR DESCRIPTION
In case of empty payload unpackTx leads to 'ba_Xfbg4g==' in payload. After that we're calling buildTx with that payload and in builded tx payload stored in exact this string instead of decoded into empty string.