### PR TITLE
fix(State Channels): Fix websocket url

### DIFF
--- a/es/channel/internal.js
+++ b/es/channel/internal.js
@@ -183,7 +183,7 @@ function WebSocket (url, callbacks) {
 
 async function initialize (channel, channelOptions) {
   const optionsKeys = ['sign', 'url']
-  const params = R.pickBy(key => !optionsKeys.includes(key), channelOptions)
+  const params = R.pickBy((_, key) => !optionsKeys.includes(key), channelOptions)
   const { url } = channelOptions
   const wsUrl = channelURL(url, { ...params, protocol: 'json-rpc' })
 


### PR DESCRIPTION
Fixes a bug which caused unneccessary params (for example: sign, url) to be included to websocket
url.