### PR TITLE
swagger: Pass query params in case of get request

### DIFF
--- a/es/utils/swagger.js
+++ b/es/utils/swagger.js
@@ -202,7 +202,7 @@ const httpConfig = {
 }
 
 const httpClients = {
-  get: (config) => (url) => axios.get(url, R.mergeDeepRight(httpConfig, config)),
+  get: (config) => (url, params) => axios.get(url, [httpConfig, config, params].reduce(R.mergeDeepRight)),
   post: (config) => (url, params) => axios.post(url, params, R.mergeDeepRight(httpConfig, config))
 }
 


### PR DESCRIPTION
I'm using Swagger stamp to map [middleware api file](https://github.com/aeternity/aepp-middleware/issues/65) to js interface. It works fine except cases when I need to pass parameters to get method. For example, when I'm calling `.namesReverseGet('ak_2swhLkgBPeeADxVTAVCJnZLY5NZtCFiM93JxsEaMuC59euuFRQ', { limit: 1, page: 2 })`, `limit` and `page` params gets omitted by current implementation. This PR fixes it.