### PR TITLE
Release 6.1.1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Till Kolter <till.kolter@gmail.com>
 Alexander Kahl <ak@sodosopa.io>
+Nazar Duchak <omelko39@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [6.1.1](https://github.com/aeternity/aepp-sdk-js/compare/6.1.0...6.1.1) (2019-11-12)
+
+
+### Bug Fixes
+
+* **ACI:** Disable bytecode check for source and code on-chain. This changes will be included in next major release ([#783](https://github.com/aeternity/aepp-sdk-js/issues/783)) ([fe6021b](https://github.com/aeternity/aepp-sdk-js/commit/fe6021b))
+
+
+### Features
+
+* **KeyStore:** Remove `argon2` package, use `libsodium` for both browser and node ([#782](https://github.com/aeternity/aepp-sdk-js/issues/782)) ([c18047e](https://github.com/aeternity/aepp-sdk-js/commit/c18047e))
+
+
+
 # [6.1.0](https://github.com/aeternity/aepp-sdk-js/compare/6.0.2...6.1.0) (2019-11-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@
 
 
 
-
 # [6.0.0](https://github.com/aeternity/aepp-sdk-js/compare/4.7.0...6.0.0) (2019-10-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 
 
 
+
+
+
 # [6.0.0](https://github.com/aeternity/aepp-sdk-js/compare/4.7.0...6.0.0) (2019-10-16)
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,4 +27,5 @@
   * [@aeternity/aepp-sdk/es/tx](api/tx.md)
   * [@aeternity/aepp-sdk/es/tx/tx](api/tx/tx.md)
   * [@aeternity/aepp-sdk/es/utils/crypto](api/utils/crypto.md)
+  * [@aeternity/aepp-sdk/es/utils/keystore](api/utils/keystore.md)
   * [@aeternity/aepp-sdk/es/utils/swagger](api/utils/swagger.md)

--- a/docs/api/contract/aci.md
+++ b/docs/api/contract/aci.md
@@ -71,7 +71,6 @@ Generate contract ACI object with predefined js methods for contract usage - can
 | [options.aci] | `String` |  | Contract ACI |
 | [options.contractAddress] | `String` |  | Contract address |
 | [options.filesystem] | `Object` |  | Contact source external namespaces map |
-| [options.forceCodeCheck] | `Boolean` | <code>false</code> | Flag to force validation of corresponding on chain bytecode |
 | [options.opt] | `Object` |  | Contract options |
 
 **Example**  

--- a/docs/api/utils/keystore.md
+++ b/docs/api/utils/keystore.md
@@ -6,7 +6,11 @@ KeyStore module
 
 **Example**  
 ```js
-import * as Crypto from '@aeternity/aepp-sdk/es/utils/keystore'
+import * as Keystore from '@aeternity/aepp-sdk/es/utils/keystore'
+```
+**Example**  
+```js
+const { Keystore } = require('@aeternity/aepp-sdk')
 ```
 
 * [@aeternity/aepp-sdk/es/utils/keystore](#module_@aeternity/aepp-sdk/es/utils/keystore)

--- a/docs/examples/node/aecontract.md
+++ b/docs/examples/node/aecontract.md
@@ -197,7 +197,6 @@ program
   .arguments('<infile> <function> [args...]')
   .option('-i, --init [state]', 'Arguments to contructor function')
   .option('-H, --host [hostname]', 'Node to connect to', 'http://localhost:3013')
-  .option('-C, --compilerUrl [compilerUrl]', 'Compiler to connect to', 'http://localhost:3088')
   .option('--debug', 'Switch on debugging')
   .action(exec)
   .parse(process.argv)

--- a/docs/examples/node/aecontract.md
+++ b/docs/examples/node/aecontract.md
@@ -107,7 +107,7 @@ implementation directly in the SDK.
   
 
 ```js
-  Ae({ url: program.host, debug: program.debug, process }).then(ae => {
+  Ae({ url: program.host, debug: program.debug, compilerUrl: program.compilerUrl,  process }).then(ae => {
     return ae.contractCompile(code)
 
 ```
@@ -197,6 +197,7 @@ program
   .arguments('<infile> <function> [args...]')
   .option('-i, --init [state]', 'Arguments to contructor function')
   .option('-H, --host [hostname]', 'Node to connect to', 'http://localhost:3013')
+  .option('-C, --compilerUrl [compilerUrl]', 'Compiler to connect to', 'http://localhost:3088')
   .option('--debug', 'Switch on debugging')
   .action(exec)
   .parse(process.argv)

--- a/es/ae/wallet.js
+++ b/es/ae/wallet.js
@@ -31,7 +31,6 @@ import Rpc from '../rpc/server'
 import * as R from 'ramda'
 import Tx from '../tx/tx'
 import Contract from './contract'
-import NodePool from '../node-pool'
 import GeneralizeAccount from '../contract/ga'
 
 const contains = R.flip(R.contains)
@@ -131,7 +130,7 @@ async function rpcAddress ({ params, session }) {
   onContract: confirm
 })
  */
-const Wallet = Ae.compose(Accounts, Chain, NodePool, Tx, Contract, GeneralizeAccount, Rpc, {
+const Wallet = Ae.compose(Accounts, Chain, Tx, Contract, GeneralizeAccount, Rpc, {
   init ({ onTx = this.onTx, onChain = this.onChain, onAccount = this.onAccount, onContract = this.onContract }, { stamp }) {
     this.onTx = onTx
     this.onChain = onChain

--- a/es/chain/index.js
+++ b/es/chain/index.js
@@ -43,7 +43,7 @@ const Chain = Oracle.compose({
     Ae: {
       methods: [
         'sendTransaction', 'height', 'awaitHeight', 'poll', 'balance', 'getBalance', 'tx',
-        'mempool', 'topBlock', 'getTxInfo', 'txDryRun', 'getName', 'getNodeInfo', 'getAccount', 'getContractByteCode', 'getContract'
+        'mempool', 'topBlock', 'getTxInfo', 'txDryRun', 'getName', 'getNodeInfo', 'getAccount'
       ]
     }
   }
@@ -60,7 +60,9 @@ const Chain = Oracle.compose({
     getTxInfo: required,
     mempool: required,
     txDryRun: required,
-    getAccount: required
+    getAccount: required,
+    getContractByteCode: required,
+    getContract: required
   }
 }))
 

--- a/es/contract/aci/index.js
+++ b/es/contract/aci/index.js
@@ -29,7 +29,6 @@ import { validateArguments, transform, transformDecodedData } from './transforma
 import { buildContractMethods, getFunctionACI } from './helpers'
 import AsyncInit from '../../utils/async-init'
 import { BigNumber } from 'bignumber.js'
-import { isAddressValid } from '../../utils/crypto'
 
 /**
  * Validated contract call arguments using contract ACI
@@ -62,7 +61,6 @@ async function prepareArgsForEncode (aci, params) {
  * @param {String} [options.aci] Contract ACI
  * @param {String} [options.contractAddress] Contract address
  * @param {Object} [options.filesystem] Contact source external namespaces map
- * @param {Boolean} [options.forceCodeCheck = false] Flag to force validation of corresponding on chain bytecode
  * @param {Object} [options.opt] Contract options
  * @return {ContractInstance} JS Contract API
  * @example
@@ -73,7 +71,7 @@ async function prepareArgsForEncode (aci, params) {
  * Also you can call contract like: await contractIns.methods.setState(123, options)
  * Then sdk decide to make on-chain or static call(dry-run API) transaction based on function is stateful or not
  */
-async function getContractInstance (source, { aci, contractAddress, filesystem = {}, forceCodeCheck = false, opt } = {}) {
+async function getContractInstance (source, { aci, contractAddress, filesystem = {}, opt } = {}) {
   aci = aci || await this.contractGetACI(source, { filesystem })
   const defaultOptions = {
     skipArgsConvert: false,
@@ -98,17 +96,6 @@ async function getContractInstance (source, { aci, contractAddress, filesystem =
     compilerVersion: this.compilerVersion,
     setOptions (opt) {
       this.options = R.merge(this.options, opt)
-    }
-  }
-  // Check for valid contract address and contract code
-  if (contractAddress) {
-    if (!isAddressValid(contractAddress, 'ct')) throw new Error('Invalid contract address')
-    const contract = await this.getContract(contractAddress).catch(e => null)
-    if (!contract) throw new Error(`Contract with address ${contractAddress} not found on-chain`)
-    if (!forceCodeCheck) {
-      const onChanByteCode = (await this.getContractByteCode(contractAddress)).bytecode
-      instance.compiled = (await this.contractCompile(source, instance.options)).bytecode
-      if (instance.compile !== onChanByteCode) throw new Error('Contract source do not correspond to the contract source deploying on the chain')
     }
   }
 

--- a/es/utils/keystore.js
+++ b/es/utils/keystore.js
@@ -4,6 +4,8 @@ import uuid from 'uuid'
 import { encodeBase58Check, isBase64 } from './crypto'
 import { isHex } from './string'
 
+const _sodium = require('libsodium-wrappers-sumo')
+
 /**
  * KeyStore module
  * !!!Work only in node.js!!!
@@ -31,30 +33,23 @@ const DERIVED_KEY_FUNCTIONS = {
 }
 
 export async function deriveKeyUsingArgon2id (password, salt, options) {
-  const { memlimit_kib: memoryCost, parallelism, opslimit: timeCost } = options.kdf_params
-  const isBrowser = !(typeof module !== 'undefined' && module.exports)
+  const { memlimit_kib: memoryCost, opslimit: timeCost } = options.kdf_params
+  // const isBrowser = !(typeof module !== 'undefined' && module.exports)
 
-  if (isBrowser) {
-    const _sodium = require('libsodium-wrappers-sumo')
+  return _sodium.ready.then(async () => {
+    // tslint:disable-next-line:typedef
+    const sodium = _sodium
 
-    return _sodium.ready.then(async () => {
-      // tslint:disable-next-line:typedef
-      const sodium = _sodium
-
-      const result = sodium.crypto_pwhash(
-        32,
-        password,
-        salt,
-        timeCost,
-        memoryCost * 1024,
-        sodium.crypto_pwhash_ALG_ARGON2ID13
-      )
-      return Buffer.from(result)
-    })
-  } else {
-    const argon2 = require('argon2')
-    return argon2.hash(password, { timeCost, memoryCost, parallelism, type: argon2.argon2id, raw: true, salt })
-  }
+    const result = sodium.crypto_pwhash(
+      32,
+      password,
+      salt,
+      timeCost,
+      memoryCost * 1024,
+      sodium.crypto_pwhash_ALG_ARGON2ID13
+    )
+    return Buffer.from(result)
+  })
 }
 
 // CRYPTO PART

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "6.0.2",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1398,14 +1398,6 @@
         }
       }
     },
-    "@phc/format": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@phc/format/-/format-0.5.0.tgz",
-      "integrity": "sha512-JWtZ5P1bfXU0bAtTzCpOLYHDXuxSVdtL/oqz4+xa97h8w9E5IlVN333wugXVFv8vZ1hbXObKQf1ptXmFFcMByg==",
-      "requires": {
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -1708,7 +1700,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
       "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -1832,16 +1825,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
-    "argon2": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.24.1.tgz",
-      "integrity": "sha512-2S677iO18I+SQEUONkpvyagF9BJDYdiT82KqSMPQ2zP0oIYagVIPM0Y8T5pJ/4F4CrnN9PTCGA+ye1S0KupW3g==",
-      "requires": {
-        "@phc/format": "^0.5.0",
-        "node-addon-api": "^1.7.1",
-        "node-gyp-build": "^4.1.0"
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1955,7 +1938,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -3126,6 +3110,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3583,7 +3568,8 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -3762,7 +3748,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5102,7 +5089,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -5508,7 +5496,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5529,12 +5518,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5549,17 +5540,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5676,7 +5670,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5688,6 +5683,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5702,6 +5698,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5709,12 +5706,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5733,6 +5732,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5813,7 +5813,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5825,6 +5826,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5910,7 +5912,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5946,6 +5949,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5965,6 +5969,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6008,12 +6013,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6180,9 +6187,9 @@
       }
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6192,9 +6199,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         },
@@ -6205,13 +6212,13 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
-          "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
+          "version": "3.6.8",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+          "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "commander": "2.20.0",
+            "commander": "~2.20.3",
             "source-map": "~0.6.1"
           }
         }
@@ -6980,7 +6987,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsdoc": {
       "version": "3.6.3",
@@ -7676,8 +7684,7 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
@@ -8010,11 +8017,6 @@
         "path-to-regexp": "^1.7.0"
       }
     },
-    "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
-    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -8024,11 +8026,6 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
-    },
-    "node-gyp-build": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -8738,7 +8735,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
       "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -9280,7 +9278,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "resolve-global": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7684,6 +7684,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "1.40.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7684,7 +7684,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "mime-db": "1.40.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@stamp/it": "^1.0.3",
     "@stamp/required": "^1.0.1",
     "aes-js": "^3.1.1",
-    "argon2": "^0.24.0",
     "axios": "^0.19.0",
     "bignumber.js": "^9.0.0",
     "bip32-path": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "browser": "dist/aepp-sdk.browser.js",


### PR DESCRIPTION
## [6.1.1](https://github.com/aeternity/aepp-sdk-js/compare/6.1.0...6.1.1) (2019-11-12)


### Bug Fixes

* **ACI:** Disable bytecode check for source and code on-chain. This changes will be included in next major release ([#783](https://github.com/aeternity/aepp-sdk-js/issues/783)) ([fe6021b](https://github.com/aeternity/aepp-sdk-js/commit/fe6021b))


### Features

* **KeyStore:** Remove `argon2` package, use `libsodium` for both browser and node ([#782](https://github.com/aeternity/aepp-sdk-js/issues/782)) ([c18047e](https://github.com/aeternity/aepp-sdk-js/commit/c18047e))
