### PR TITLE
feat(AEX-2): Use `hex` string for `signMessage` response

### DIFF
--- a/es/account/index.js
+++ b/es/account/index.js
@@ -58,8 +58,9 @@ async function signTransaction (tx, opt = {}) {
  * @param {Object} opt - Options
  * @return {String} Signature
  */
-async function signMessage (message, opt = {}) {
-  return this.sign(hash(personalMessageToBinary(message)), opt)
+async function signMessage (message, opt = { returnHex: false }) {
+  const sig = await this.sign(hash(personalMessageToBinary(message)), opt)
+  return opt.returnHex ? Buffer.from(sig).toString('hex') : sig
 }
 
 /**
@@ -73,7 +74,7 @@ async function signMessage (message, opt = {}) {
  * @return {Boolean}
  */
 async function verifyMessage (message, signature, opt = {}) {
-  return verifyPersonalMessage(message, signature, decode(await this.address(opt)))
+  return verifyPersonalMessage(message, typeof signature === 'string' ? Buffer.from(signature, 'hex') : signature, decode(await this.address(opt)))
 }
 
 /**

--- a/es/account/memory.js
+++ b/es/account/memory.js
@@ -34,8 +34,8 @@ async function sign (data) {
   return Promise.resolve(Crypto.sign(data, secrets.get(this).secretKey))
 }
 
-async function address (format = Crypto.ADDRESS_FORMAT.api) {
-  return Promise.resolve(Crypto.formatAddress(format, secrets.get(this).publicKey))
+async function address (opt = { format: Crypto.ADDRESS_FORMAT.api }) {
+  return Promise.resolve(Crypto.formatAddress(opt.format, secrets.get(this).publicKey))
 }
 
 function setSecret (keyPair) {

--- a/es/utils/aepp-wallet-communication/rpc/wallet-rpc.js
+++ b/es/utils/aepp-wallet-communication/rpc/wallet-rpc.js
@@ -142,7 +142,7 @@ const REQUESTS = {
         id,
         method,
         {
-          result: { signature: await instance.signMessage(message, { onAccount }) }
+          result: { signature: await instance.signMessage(message, { onAccount, returnHex: true }) }
         }
       )
 

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -292,6 +292,7 @@ describe('Aepp<->Wallet', function () {
         action.accept()
       }
       const messageSig = await aepp.signMessage('test')
+      messageSig.should.be.a('string')
       const isValid = await aepp.verifyMessage('test', messageSig)
       isValid.should.be.equal(true)
     })

--- a/test/unit/memory-account.js
+++ b/test/unit/memory-account.js
@@ -18,8 +18,7 @@
 import '../'
 import { describe, it } from 'mocha'
 import MemoryAccount from '../../es/account/memory'
-import { generateKeyPair, verifyPersonalMessage } from '../../es/utils/crypto'
-import { decode } from '../../es/tx/builder/helpers'
+import { generateKeyPair } from '../../es/utils/crypto'
 
 const testAcc = generateKeyPair()
 
@@ -96,8 +95,12 @@ describe('MemoryAccount', function () {
   })
   it('Sign message', async () => {
     const message = 'test'
-    const sig = await MemoryAccount({ keypair: testAcc }).signMessage(message)
-    const isValid = verifyPersonalMessage(message, sig, decode(testAcc.publicKey))
+    const acc = MemoryAccount({ keypair: testAcc })
+    const sig = await acc.signMessage(message)
+    const sigHex = await acc.signMessage(message, { returnHex: true })
+    const isValid = await acc.verifyMessage(message, sig)
+    const isValidHex = await acc.verifyMessage(message, sigHex)
     isValid.should.be.equal(true)
+    isValidHex.should.be.equal(true)
   })
 })


### PR DESCRIPTION
Extend `verifyMessage` with ability to accept `buffer` or `hex`