### PR TITLE
RpcClient: Simplify message id processing

### DIFF
--- a/es/utils/aepp-wallet-communication/helpers.js
+++ b/es/utils/aepp-wallet-communication/helpers.js
@@ -19,31 +19,33 @@ export const getWindow = () => {
 /**
  * RPC helper functions
  */
-export const sendMessage = (messageId, connection) => ({ id, method, params, result, error }, isNotificationOrResponse = false) => {
-  // Increment id for each request
-  isNotificationOrResponse || (messageId += 1)
-  id = isNotificationOrResponse ? (id || null) : messageId
-  const msgData = params
-    ? { params }
-    : result
-      ? { result }
-      : { error }
-  connection.sendMessage({
-    jsonrpc: '2.0',
-    ...id ? { id } : {},
-    method,
-    ...msgData
-  })
-  return id
+export const sendMessage = (connection) => {
+  let messageId = 0
+
+  return ({ id, method, params, result, error }, isNotificationOrResponse = false) => {
+    // Increment id for each request
+    isNotificationOrResponse || (messageId += 1)
+    id = isNotificationOrResponse ? (id || null) : messageId
+    const msgData = params
+      ? { params }
+      : result
+        ? { result }
+        : { error }
+    connection.sendMessage({
+      jsonrpc: '2.0',
+      ...id ? { id } : {},
+      method,
+      ...msgData
+    })
+    return id
+  }
 }
 
-export const receive = (handler, msgId) => (msg) => {
+export const receive = (handler) => (msg) => {
   if (!msg || !msg.jsonrpc || msg.jsonrpc !== '2.0' || !msg.method) {
     console.warn('Receive invalid message', msg)
     return
   }
-  // Increment id for each request
-  if (msg.id && +msg.id > msgId) msgId += 1
   handler(msg)
 }
 

--- a/es/utils/aepp-wallet-communication/rpc/rpc-clients.js
+++ b/es/utils/aepp-wallet-communication/rpc/rpc-clients.js
@@ -107,7 +107,6 @@ export const RpcClients = stampit({
  */
 export const RpcClient = stampit({
   init ({ id, name, networkId, icons, connection, handlers: [onMessage, onDisconnect] }) {
-    const messageId = 0
     this.id = id
     this.connection = connection
     this.info = { name, networkId, icons }
@@ -119,12 +118,12 @@ export const RpcClient = stampit({
     this.addressSubscription = []
     this.accounts = {}
 
-    this.sendMessage = sendMessage(messageId, this.connection)
+    this.sendMessage = sendMessage(this.connection)
     const disconnect = (aepp, connection) => {
       this.disconnect(true)
       typeof onDisconnect === 'function' && onDisconnect(connection, this)
     }
-    connection.connect(receive(onMessage, messageId), disconnect)
+    connection.connect(receive(onMessage), disconnect)
   },
   methods: {
     /**

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -508,7 +508,7 @@ describe('Aepp<->Wallet', function () {
   })
   describe('Rpc helpers', () => {
     it('Receive invalid message', () => {
-      (!receive(() => true, 1)(false)).should.be.equal(true)
+      (!receive(() => true)(false)).should.be.equal(true)
     })
     it('receive unknown method', () => {
       getHandler({}, { method: 'hey' })()().should.be.equal(true)


### PR DESCRIPTION
`messageId` in `RpcClient` is defined as a constant, and it is passed to `sendMessage` and `receive` methods as a primitive value, but as I know primitive variables are passed by values (not by reference) so it can't be mutated outside of function scope, also `messageId` can't be mutated because it is defined as a constant.

So, I propose to drop not working and confusing code.
