### PR TITLE
Bug's correction

### DIFF
--- a/docs/guides/contract-aci-usage.md
+++ b/docs/guides/contract-aci-usage.md
@@ -12,7 +12,7 @@ const { Universal: Ae, MemoryAccount, Node } = require('@aeternity/aepp-SDK')
 
 // same with async
 const main = async () => {
-  const node1 = await Node({ url: NODE_URL, internalUrl: NODE_INTERNAL_URL })
+  const node = await Node({ url: NODE_URL, internalUrl: NODE_INTERNAL_URL })
   const acc = MemoryAccount({ keypair: KEYPAIR })
 
   const SDKInstance = await Ae({


### PR DESCRIPTION
The variable 'node1' was later called 'node', the name was unified to 'node' and the tutorial worked correctly