### PR TITLE
Disable Travis on all branches except master, develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: bionic
 language: node_js
 node_js: 12
 
+branches:
+  only:
+    - master
+    - develop
+
 services:
   - docker
 


### PR DESCRIPTION
This PR partially reverts 51c661dc4ece4235a1fb4dd71b0a28f323e1f668.
The goal is to avoid double-checking of all RPs.
Initially, I wanted to disable the testing of PRs and keep branch testing, but as we checked in https://github.com/aeternity/aepp-sdk-js/pull/1053 disabling of PR builds will complicate test running on third-party PRs.