### PR TITLE
index: Export in tree shaking friendly way

### DIFF
--- a/docs/guides/aens.md
+++ b/docs/guides/aens.md
@@ -121,7 +121,7 @@ Note:
 In case there is an auction running for a name you want to claim you need to place a bid.
 
 ```js
-import { TxBuilderHelper } from '@aeternity/aepp-sdk'
+import { computeBidFee, computeAuctionEndBlock } from '@aeternity/aepp-sdk'
 
 const name = 'auctiontest1.chain'
 
@@ -131,11 +131,11 @@ const increment = 0.05 // 5%, the minimum required increment
 // startFee is OPTIONAL and defaults to minimum calculated fee for the name in general
 // startFee MUST be at least the nameFee of the last bid
 // increment is OPTIONAL and defaults to 0.05
-const nameFee = TxBuilderHelper.computeBidFee(name, startFee, increment)
+const nameFee = computeBidFee(name, startFee, increment)
 const bidTx = await aeSdk.aensBid(name, nameFee)
 
 console.log(bidTx)
-console.log(`BID PLACED AT ${bidTx.blockHeight} WILL END AT ${TxBuilderHelper.computeAuctionEndBlock(name, bidTx.blockHeight)}`)
+console.log(`BID PLACED AT ${bidTx.blockHeight} WILL END AT ${computeAuctionEndBlock(name, bidTx.blockHeight)}`)
 
 /*
 {

--- a/docs/guides/build-wallet.md
+++ b/docs/guides/build-wallet.md
@@ -17,15 +17,15 @@ First you need to create a bridge between your extension and the page. This can 
 
 ```js
 import {
-  BrowserRuntimeConnection, BrowserWindowMessageConnection, AeppWalletSchema,
-  ContentScriptBridge, AeppWalletHelpers
+  BrowserRuntimeConnection, BrowserWindowMessageConnection, MESSAGE_DIRECTION,
+  ContentScriptBridge, getBrowserAPI
 } from '@aeternity/aepp-sdk'
 
 const readyStateCheckInterval = setInterval(function () {
   if (document.readyState === 'complete') {
     clearInterval(readyStateCheckInterval)
 
-    const port = AeppWalletHelpers.getBrowserAPI().runtime.connect()
+    const port = getBrowserAPI().runtime.connect()
     const extConnection = BrowserRuntimeConnection({
       connectionInfo: {
         description: 'Content Script to Extension connection',
@@ -39,8 +39,8 @@ const readyStateCheckInterval = setInterval(function () {
         origin: window.origin
       },
       origin: window.origin,
-      sendDirection: AeppWalletSchema.MESSAGE_DIRECTION.to_aepp,
-      receiveDirection: AeppWalletSchema.MESSAGE_DIRECTION.to_waellet
+      sendDirection: MESSAGE_DIRECTION.to_aepp,
+      receiveDirection: MESSAGE_DIRECTION.to_waellet
     })
 
     const bridge = ContentScriptBridge({ pageConnection, extConnection })
@@ -58,8 +58,8 @@ After the connection is established you can share the wallet details with the ap
 const NODE_URL = 'https://testnet.aeternity.io'
 const COMPILER_URL = 'https://compiler.aepps.com'
 const accounts = [
-  MemoryAccount({ keypair: Crypto.generateKeyPair() }), // generate keypair for account1
-  MemoryAccount({ keypair: Crypto.generateKeyPair() })  // generate keypair for account2
+  MemoryAccount({ keypair: generateKeyPair() }), // generate keypair for account1
+  MemoryAccount({ keypair: generateKeyPair() })  // generate keypair for account2
 ]
 
 async function init () {
@@ -135,8 +135,8 @@ AEPP can request the wallet for its connected node URLs. Wallet can selectively 
 const NODE_URL = 'https://testnet.aeternity.io'
 const COMPILER_URL = 'https://compiler.aepps.com'
 const accounts = [
-  MemoryAccount({ keypair: Crypto.generateKeyPair() }), // generate keypair for account1
-  MemoryAccount({ keypair: Crypto.generateKeyPair() })  // generate keypair for account2
+  MemoryAccount({ keypair: generateKeyPair() }), // generate keypair for account1
+  MemoryAccount({ keypair: generateKeyPair() })  // generate keypair for account2
 ]
 
 async function init () {

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -117,15 +117,15 @@ const {
   Universal,
   Node,
   MemoryAccount,
-  Crypto,
+  generateKeyPair,
   InvalidTxParamsError,
   InvalidAensNameError
 } = require('@aeternity/aepp-sdk')
 
 // setup
 const NODE_URL = 'https://testnet.aeternity.io'
-const PAYER_ACCOUNT_KEYPAIR = Crypto.generateKeyPair()
-const NEW_USER_KEYPAIR = Crypto.generateKeyPair()
+const PAYER_ACCOUNT_KEYPAIR = generateKeyPair()
+const NEW_USER_KEYPAIR = generateKeyPair()
 
 const payerAccount = MemoryAccount({ keypair: PAYER_ACCOUNT_KEYPAIR })
 const newUserAccount = MemoryAccount({ keypair: NEW_USER_KEYPAIR })

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,22 +1,22 @@
 # Quick Start
 
 ## 1. Specify imports
-For the following snippets in the guide you need to specify multiple imports. Most imports like `Universal`, `MemoryAccount` & `Node` are [Stamps](https://stampit.js.org/essentials/what-is-a-stamp) that compose certain functionalities. Others like `AmountFormatter` & `Crypto` are util modules with typical function exports.
+For the following snippets in the guide you need to specify multiple imports. Most imports like `Universal`, `MemoryAccount` & `Node` are [Stamps](https://stampit.js.org/essentials/what-is-a-stamp) that compose certain functionalities. Others utility functions like `generateKeyPair` also can be imported.
 
 ```js
 import {
   Universal,
   MemoryAccount,
   Node,
-  AmountFormatter,
-  Crypto
+  AE_AMOUNT_FORMATS,
+  generateKeyPair
 } from '@aeternity/aepp-sdk'
 ```
 
 ## 2. Create a Keypair
 
 ```js
-  const keypair = Crypto.generateKeyPair()
+  const keypair = generateKeyPair()
   console.log(`Secret key: ${keypair.secretKey}`)
   console.log(`Public key: ${keypair.publicKey}`)
 ```
@@ -52,7 +52,7 @@ const account = MemoryAccount({
 
   // spend one AE
   await aeSdk.spend(1, '<RECIPIENT_PUBLIC_KEY>', { // replace <RECIPIENT_PUBLIC_KEY>
-      denomination: AmountFormatter.AE_AMOUNT_FORMATS.AE
+      denomination: AE_AMOUNT_FORMATS.AE
   })
 })()
 ```

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -29,8 +29,8 @@
 
 <script>
 import {
-  MemoryAccount, RpcWallet, Node, Crypto,
-  BrowserWindowMessageConnection, AeppWalletSchema
+  MemoryAccount, RpcWallet, Node, generateKeyPair,
+  BrowserWindowMessageConnection, METHODS
 } from '@aeternity/aepp-sdk'
 import Value from './Value'
 
@@ -56,7 +56,7 @@ export default {
     },
     disconnect () {
       Object.values(this.aeSdk.rpcClients).forEach(client => {
-        client.sendMessage({ method: AeppWalletSchema.METHODS.closeConnection }, true)
+        client.sendMessage({ method: METHODS.closeConnection }, true)
         client.disconnect()
       })
     },
@@ -89,7 +89,7 @@ export default {
             secretKey: 'bf66e1c256931870908a649572ed0257876bb84e3cdf71efb12f56c7335fad54d5cf08400e988222f26eb4b02c8f89077457467211a6e6d955edb70749c6a33b',
           }
         }),
-        MemoryAccount({ keypair: Crypto.generateKeyPair() })
+        MemoryAccount({ keypair: generateKeyPair() })
       ],
       name: 'Wallet Iframe',
       onConnection: genConfirmCallback(() => 'connect'),

--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -1,7 +1,7 @@
 /* global browser */
 
 import {
-  RpcWallet, Node, MemoryAccount, Crypto, BrowserRuntimeConnection
+  RpcWallet, Node, MemoryAccount, generateKeyPair, BrowserRuntimeConnection
 } from '@aeternity/aepp-sdk'
 
 (async () => {
@@ -21,7 +21,7 @@ import {
           secretKey: 'bf66e1c256931870908a649572ed0257876bb84e3cdf71efb12f56c7335fad54d5cf08400e988222f26eb4b02c8f89077457467211a6e6d955edb70749c6a33b'
         }
       }),
-      MemoryAccount({ keypair: Crypto.generateKeyPair() })
+      MemoryAccount({ keypair: generateKeyPair() })
     ],
     // Hook for sdk registration
     onConnection (aepp, action) {

--- a/examples/browser/wallet-web-extension/src/content-script.js
+++ b/examples/browser/wallet-web-extension/src/content-script.js
@@ -1,7 +1,7 @@
 /* global browser */
 
 import {
-  BrowserRuntimeConnection, BrowserWindowMessageConnection, AeppWalletSchema, ContentScriptBridge
+  BrowserRuntimeConnection, BrowserWindowMessageConnection, MESSAGE_DIRECTION, ContentScriptBridge
 } from '@aeternity/aepp-sdk'
 
 (async () => {
@@ -30,8 +30,8 @@ import {
       origin: window.origin
     },
     origin: window.origin,
-    sendDirection: AeppWalletSchema.MESSAGE_DIRECTION.to_aepp,
-    receiveDirection: AeppWalletSchema.MESSAGE_DIRECTION.to_waellet
+    sendDirection: MESSAGE_DIRECTION.to_aepp,
+    receiveDirection: MESSAGE_DIRECTION.to_waellet
   })
 
   const bridge = ContentScriptBridge({ pageConnection, extConnection })

--- a/examples/node/paying-for-tx-contract-call-tx.js
+++ b/examples/node/paying-for-tx-contract-call-tx.js
@@ -46,8 +46,8 @@
 
 // ## 1. Specify imports
 // You need to import `Universal`, `Node` and `MemoryAccount` [Stamps](https://stampit.js.org/essentials/what-is-a-stamp) from the SDK.
-// Additionally you import the `Crypto` utility module to generate a new keypair.
-const { Universal, Node, MemoryAccount, Crypto } = require('@aeternity/aepp-sdk')
+// Additionally you import the `generateKeyPair` utility function to generate a new keypair.
+const { Universal, Node, MemoryAccount, generateKeyPair } = require('@aeternity/aepp-sdk')
 
 // **Note**:
 //
@@ -79,7 +79,7 @@ contract PayingForTxExample =
     entrypoint get_last_caller() : option(address) =
         state.last_caller
 `
-const NEW_USER_KEYPAIR = Crypto.generateKeyPair();
+const NEW_USER_KEYPAIR = generateKeyPair();
 
 // Note:
 //

--- a/examples/node/paying-for-tx-spend-tx.js
+++ b/examples/node/paying-for-tx-spend-tx.js
@@ -32,8 +32,8 @@
 
 // ## 1. Specify imports
 // You need to import `Universal`, `Node` and `MemoryAccount` [Stamps](https://stampit.js.org/essentials/what-is-a-stamp) from the SDK.
-// Additionally you import the `Crypto` utility module to generate a new keypair.
-const { Universal, Node, MemoryAccount, Crypto } = require('@aeternity/aepp-sdk')
+// Additionally you import the `generateKeyPair` utility function to generate a new keypair.
+const { Universal, Node, MemoryAccount, generateKeyPair } = require('@aeternity/aepp-sdk')
 
 // **Note**:
 //
@@ -46,7 +46,7 @@ const PAYER_ACCOUNT_KEYPAIR = {
   secretKey: 'bf66e1c256931870908a649572ed0257876bb84e3cdf71efb12f56c7335fad54d5cf08400e988222f26eb4b02c8f89077457467211a6e6d955edb70749c6a33b'
 }
 const NODE_URL = 'https://testnet.aeternity.io'
-const NEW_USER_KEYPAIR = Crypto.generateKeyPair()
+const NEW_USER_KEYPAIR = generateKeyPair()
 const AMOUNT = 1;
 
 // Note:

--- a/src/ae/index.js
+++ b/src/ae/index.js
@@ -26,7 +26,7 @@ import stampit from '@stamp/it'
 import Tx from '../tx'
 import Chain from '../chain'
 import AccountBase from '../account/base'
-import TxBuilder from '../tx/builder'
+import { buildTxHash, unpackTx } from '../tx/builder'
 import BigNumber from 'bignumber.js'
 import { AE_AMOUNT_FORMATS } from '../utils/amount-formatter'
 import { ArgumentError } from '../utils/errors'
@@ -51,7 +51,7 @@ async function send (tx, options = {}) {
     ? await this.signUsingGA(tx, { ...opt, authFun })
     : await this.signTransaction(tx, opt)
   return opt.innerTx
-    ? { hash: TxBuilder.buildTxHash(signed), rawTx: signed }
+    ? { hash: buildTxHash(signed), rawTx: signed }
     : this.sendTransaction(signed, opt)
 }
 
@@ -102,7 +102,7 @@ async function transferFunds (fraction, recipientIdOrName, options) {
   const senderId = await this.address(opt)
   const balance = new BigNumber(await this.balance(senderId))
   const desiredAmount = balance.times(fraction).integerValue(BigNumber.ROUND_HALF_UP)
-  const { tx: { fee } } = TxBuilder.unpackTx(
+  const { tx: { fee } } = unpackTx(
     await this.spendTx({ ...opt, senderId, recipientId, amount: desiredAmount })
   )
   // Reducing of the amount may reduce transaction fee, so this is not completely accurate

--- a/src/ae/oracle.js
+++ b/src/ae/oracle.js
@@ -110,7 +110,7 @@ async function getQueryObject (oracleId, queryId) {
     respond: this.respondToQuery.bind(this, oracleId, queryId),
     pollForResponse: this.pollForQueryResponse.bind(this, oracleId, queryId),
     /**
-     * @deprecated use TxBuilderHelper.decode instead
+     * @deprecated use plain decode instead
      * @param data
      * @returns {Buffer}
      */

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /*
  * ISC License (ISC)
- * Copyright (c) 2021 aeternity developers
+ * Copyright (c) 2022 aeternity developers
  *
  *  Permission to use, copy, modify, and/or distribute this software for any
  *  purpose with or without fee is hereby granted, provided that the above
@@ -15,75 +15,41 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 
-import * as Crypto from './utils/crypto'
-import * as Keystore from './utils/keystore'
-import * as Bytes from './utils/bytes'
-import * as TxBuilder from './tx/builder'
-import * as TxBuilderHelper from './tx/builder/helpers'
-import * as SCHEMA from './tx/builder/schema'
-import * as AmountFormatter from './utils/amount-formatter'
-import * as HdWallet from './utils/hd-wallet'
+export * from './utils/crypto'
+export * from './utils/keystore'
+export * from './utils/bytes'
+export * from './tx/builder'
+export * from './tx/builder/helpers'
+export * from './tx/builder/schema'
+export * from './utils/amount-formatter'
+export * from './utils/hd-wallet'
 
-import Ae from './ae'
-import Chain from './chain'
-import ChainNode from './chain/node'
-import Node from './node'
-import NodePool from './node-pool'
-import Tx from './tx'
-import Transaction from './tx/tx'
-import verifyTransaction from './tx/validator'
-import AccountBase from './account/base'
-import AccountMultiple from './account/multiple'
-import MemoryAccount from './account/memory'
-import Aens from './ae/aens'
-import Contract from './ae/contract'
-import GeneralizedAccount from './contract/ga'
-import ContractCompilerHttp from './contract/compiler'
-import RpcAepp from './ae/aepp'
-import RpcWallet from './ae/wallet'
-import Oracle from './ae/oracle'
-import genSwaggerClient from './utils/swagger'
-import Channel from './channel'
-import Universal from './ae/universal'
+export { default as Ae } from './ae'
+export { default as Chain } from './chain'
+export { default as ChainNode } from './chain/node'
+export { default as Node } from './node'
+export { default as NodePool } from './node-pool'
+export { default as Tx } from './tx'
+export { default as Transaction } from './tx/tx'
+export { default as verifyTransaction } from './tx/validator'
+export { default as AccountBase } from './account/base'
+export { default as AccountMultiple } from './account/multiple'
+export { default as MemoryAccount } from './account/memory'
+export { default as Aens } from './ae/aens'
+export { default as Contract } from './ae/contract'
+export { default as GeneralizedAccount } from './contract/ga'
+export { default as ContractCompilerHttp } from './contract/compiler'
+export { default as RpcAepp } from './ae/aepp'
+export { default as RpcWallet } from './ae/wallet'
+export { default as Oracle } from './ae/oracle'
+export { default as genSwaggerClient } from './utils/swagger'
+export { default as Channel } from './channel'
+export { default as Universal } from './ae/universal'
 
 export { default as ContentScriptBridge } from './utils/aepp-wallet-communication/content-script-bridge'
-export * as AeppWalletHelpers from './utils/aepp-wallet-communication/helpers'
-export * as AeppWalletSchema from './utils/aepp-wallet-communication/schema'
+export * from './utils/aepp-wallet-communication/helpers'
+export * from './utils/aepp-wallet-communication/schema'
 export { default as WalletDetector } from './utils/aepp-wallet-communication/wallet-detector'
 export { default as BrowserRuntimeConnection } from './utils/aepp-wallet-communication/connection/browser-runtime'
 export { default as BrowserWindowMessageConnection } from './utils/aepp-wallet-communication/connection/browser-window-message'
 export * from './utils/errors'
-
-export const getDefaultPointerKey = TxBuilderHelper.getDefaultPointerKey
-
-export {
-  AmountFormatter,
-  AccountBase,
-  AccountMultiple,
-  Ae,
-  Aens,
-  Bytes,
-  Contract,
-  ContractCompilerHttp,
-  ChainNode,
-  RpcAepp,
-  RpcWallet,
-  Channel,
-  Crypto,
-  Keystore,
-  Chain,
-  GeneralizedAccount,
-  HdWallet,
-  MemoryAccount,
-  Node,
-  NodePool,
-  Oracle,
-  genSwaggerClient,
-  Transaction,
-  verifyTransaction,
-  Tx,
-  TxBuilder,
-  TxBuilderHelper,
-  Universal,
-  SCHEMA
-}

--- a/src/tx/builder/helpers.js
+++ b/src/tx/builder/helpers.js
@@ -24,8 +24,7 @@ import {
 /**
  * JavaScript-based Transaction builder helper function's
  * @module @aeternity/aepp-sdk/es/tx/builder/helpers
- * @export TxBuilderHelper
- * @example import { TxBuilderHelper } from '@aeternity/aepp-sdk'
+ * @example import { buildContractId } from '@aeternity/aepp-sdk'
  */
 
 export const createSalt = salt

--- a/src/tx/builder/index.js
+++ b/src/tx/builder/index.js
@@ -32,8 +32,7 @@ import { InvalidTxParamsError, SchemaNotFoundError } from '../../utils/errors'
 /**
  * JavaScript-based Transaction builder
  * @module @aeternity/aepp-sdk/es/tx/builder
- * @export TxBuilder
- * @example import { TxBuilder } from '@aeternity/aepp-sdk'
+ * @example import { calculateFee } from '@aeternity/aepp-sdk'
  */
 
 const ORACLE_TTL_TYPES = {

--- a/src/tx/builder/schema.js
+++ b/src/tx/builder/schema.js
@@ -1,8 +1,7 @@
 /**
  * Transaction Schema for TxBuilder
  * @module @aeternity/aepp-sdk/es/tx/builder/schema
- * @export TxSchema
- * @example import { SCHEMA } from '@aeternity/aepp-sdk'
+ * @example import { TX_TYPE } from '@aeternity/aepp-sdk'
  */
 // # RLP version number
 // # https://github.com/aeternity/protocol/blob/master/serializations.md#binary-serialization

--- a/src/utils/amount-formatter.ts
+++ b/src/utils/amount-formatter.ts
@@ -18,7 +18,7 @@
 /**
  * Amount Formatter
  * @module @aeternity/aepp-sdk/es/utils/amount-formatter
- * @example import { AmountFormatter } from '@aeternity/aepp-sdk'
+ * @example import { formatAmount } from '@aeternity/aepp-sdk'
  */
 import BigNumber from 'bignumber.js'
 import { isBigNumber } from './bignumber'

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -21,7 +21,7 @@ import { isBase64, isHex } from './string'
 /**
  * Bytes module
  * @module @aeternity/aepp-sdk/es/utils/bytes
- * @example import { Crypto } from '@aeternity/aepp-sdk'
+ * @example import { bigNumberToByteArray } from '@aeternity/aepp-sdk'
  */
 
 /**

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -18,7 +18,7 @@
 /**
  * Crypto module
  * @module @aeternity/aepp-sdk/es/utils/crypto
- * @example import { Crypto } from '@aeternity/aepp-sdk'
+ * @example import { getAddressFromPriv } from '@aeternity/aepp-sdk'
  */
 
 import nacl from 'tweetnacl'

--- a/src/utils/keystore.js
+++ b/src/utils/keystore.js
@@ -10,8 +10,8 @@ import {
 /**
  * KeyStore module
  * @module @aeternity/aepp-sdk/es/utils/keystore
- * @example import { Keystore } from '@aeternity/aepp-sdk'
- * @example const { Keystore } = require('@aeternity/aepp-sdk')
+ * @example import { recover } from '@aeternity/aepp-sdk'
+ * @example const { recover } = require('@aeternity/aepp-sdk')
  */
 
 const DEFAULTS = {

--- a/src/utils/keystore.js
+++ b/src/utils/keystore.js
@@ -1,7 +1,7 @@
 import nacl from 'tweetnacl'
 import { v4 as uuid } from '@aeternity/uuid'
 import { ArgonType, hash } from '@aeternity/argon2-browser/dist/argon2-bundled.min.js'
-import { encode } from '../tx/builder/helpers'
+import { getAddressFromPriv } from './crypto'
 import { str2buf } from './bytes'
 import {
   ArgumentError, InvalidKeyError, UnsupportedAlgorithmError, InvalidPasswordError
@@ -139,12 +139,6 @@ function marshal (name, derivedKey, privateKey, nonce, salt, options = {}) {
       )
     }
   )
-}
-
-export function getAddressFromPriv (secret) {
-  const keys = nacl.sign.keyPair.fromSecretKey(str2buf(secret))
-  const publicBuffer = Buffer.from(keys.publicKey)
-  return encode(publicBuffer, 'ak')
 }
 
 /**

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -16,13 +16,12 @@
  */
 import { expect } from 'chai'
 import { before, describe, it } from 'mocha'
-import { commitmentHash, decode, encode } from '../../src/tx/builder/helpers'
-import { DRY_RUN_ACCOUNT } from '../../src/tx/builder/schema'
-import { messageToHash, salt } from '../../src/utils/crypto'
 import { randomName } from '../utils'
 import { BaseAe, getSdk, publicKey } from './'
-import { Crypto, IllegalArgumentError, MemoryAccount } from '../../src'
-import { NodeInvocationError } from '../../src/utils/errors'
+import {
+  IllegalArgumentError, NodeInvocationError, MemoryAccount, generateKeyPair,
+  commitmentHash, decode, encode, DRY_RUN_ACCOUNT, messageToHash, salt
+} from '../../src'
 
 const identityContract = `
 contract Identity =
@@ -124,7 +123,7 @@ describe('Contract', function () {
     aeSdk = await getSdk()
     // TODO: option of getSdk to have accounts without genesis
     aeSdk.removeAccount(aeSdk.addresses()[1])
-    await aeSdk.addAccount(MemoryAccount({ keypair: Crypto.generateKeyPair() }))
+    await aeSdk.addAccount(MemoryAccount({ keypair: generateKeyPair() }))
     await aeSdk.spend(1e18, aeSdk.addresses()[1])
   })
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -15,7 +15,7 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 
-import { Universal, Crypto, MemoryAccount, Node } from '../../src'
+import { Universal, generateKeyPair, MemoryAccount, Node } from '../../src'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 
@@ -30,7 +30,7 @@ const secretKey = process.env.SECRET_KEY || 'bf66e1c256931870908a649572ed0257876
 export const networkId = process.env.TEST_NETWORK_ID || 'ae_devnet'
 export const ignoreVersion = process.env.IGNORE_VERSION || false
 export const genesisAccount = MemoryAccount({ keypair: { publicKey, secretKey } })
-export const account = Crypto.generateKeyPair()
+export const account = generateKeyPair()
 
 export const BaseAe = async (params = {}, compose = {}) => Universal
   .compose({

--- a/test/integration/paying-for.js
+++ b/test/integration/paying-for.js
@@ -19,7 +19,7 @@ import { describe, it, before } from 'mocha'
 import { expect } from 'chai'
 import BigNumber from 'bignumber.js'
 import { getSdk, BaseAe } from './'
-import { Crypto, MemoryAccount } from '../../src'
+import { generateKeyPair, MemoryAccount } from '../../src'
 
 describe('Paying for transaction of another account', function () {
   let aeSdk
@@ -29,8 +29,8 @@ describe('Paying for transaction of another account', function () {
   })
 
   it('pays for spend transaction', async () => {
-    const sender = MemoryAccount({ keypair: Crypto.generateKeyPair() })
-    const receiver = MemoryAccount({ keypair: Crypto.generateKeyPair() })
+    const sender = MemoryAccount({ keypair: generateKeyPair() })
+    const receiver = MemoryAccount({ keypair: generateKeyPair() })
     await aeSdk.spend(1e4, await sender.address())
     const spendTx = await aeSdk.spendTx({
       senderId: await sender.address(),
@@ -62,7 +62,7 @@ describe('Paying for transaction of another account', function () {
   it('pays for contract deployment', async () => {
     aeSdkNotPayingFee = await BaseAe({
       withoutGenesisAccount: true,
-      accounts: [MemoryAccount({ keypair: Crypto.generateKeyPair() })]
+      accounts: [MemoryAccount({ keypair: generateKeyPair() })]
     }, {
       deepProps: { Ae: { defaults: { waitMined: false, innerTx: true } } }
     })

--- a/test/unit/keystore.js
+++ b/test/unit/keystore.js
@@ -18,7 +18,8 @@
 import '../'
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
-import { dump, recover, getAddressFromPriv, validateKeyObj } from '../../src/utils/keystore'
+import { dump, recover, validateKeyObj } from '../../src/utils/keystore'
+import { getAddressFromPriv } from '../../src/utils/crypto'
 import { InvalidKeyError, InvalidPasswordError } from '../../src/utils/errors'
 
 const invalidKeystore = {


### PR DESCRIPTION
Currently, to import something from `crypto` module you have to import it completely, like:
```js
import { Crypto } from '@aeternity/aepp-sdk-js';
Crypto.isAddressValid(...)
```
Tree shaking works better if imported only a specific thing, I'm proposing to make it possible by inlining `crypto` exports into `index` exports, making user import it by:
```js
import { isAddressValid } from '@aeternity/aepp-sdk-js';
isAddressValid(...)
```