### PR TITLE
Drop old names support, split ensureNameValid and isNameValid

### DIFF
--- a/src/ae/aens.js
+++ b/src/ae/aens.js
@@ -30,7 +30,7 @@ import * as R from 'ramda'
 import { salt } from '../utils/crypto'
 import {
   commitmentHash,
-  isNameValid,
+  ensureNameValid,
   getMinimumNameFee,
   classify,
   isAuctionName,
@@ -62,7 +62,7 @@ import { CLIENT_TTL, NAME_FEE, NAME_TTL } from '../tx/builder/schema'
  * await nameObject.revoke({ fee, ttl, nonce })
  */
 async function revoke (name, options = {}) {
-  isNameValid(name)
+  ensureNameValid(name)
   const opt = R.merge(this.Ae.defaults, options)
 
   const nameRevokeTx = await this.nameRevokeTx(R.merge(opt, {
@@ -102,7 +102,7 @@ async function revoke (name, options = {}) {
  * await nameObject.update(pointersArray, { nameTtl, ttl, fee, nonce, clientTtl })
  */
 async function update (name, pointers = [], options = { extendPointers: false }) {
-  isNameValid(name)
+  ensureNameValid(name)
   const opt = R.merge(this.Ae.defaults, options)
   if (!validatePointers(pointers)) throw new Error('Invalid pointers array')
 
@@ -144,7 +144,7 @@ async function update (name, pointers = [], options = { extendPointers: false })
  * await nameObject.transfer(recipientPub, { ttl, fee, nonce })
  */
 async function transfer (name, account, options = {}) {
-  isNameValid(name)
+  ensureNameValid(name)
   const opt = R.merge(this.Ae.defaults, options)
 
   const nameTransferTx = await this.nameTransferTx(R.merge(opt, {
@@ -179,7 +179,7 @@ async function transfer (name, account, options = {}) {
  * }
  */
 async function query (name, opt = {}) {
-  isNameValid(name)
+  ensureNameValid(name)
   const o = await this.getName(name)
 
   return Object.freeze(Object.assign(o, {
@@ -233,7 +233,7 @@ async function query (name, opt = {}) {
  * await sdkInstance.aensClaim(name, salt, { ttl, fee, nonce, nameFee })
  */
 async function claim (name, salt, options = { vsn: 2 }) {
-  isNameValid(name)
+  ensureNameValid(name)
   const opt = R.merge(this.Ae.defaults, options)
 
   const minNameFee = getMinimumNameFee(name)
@@ -283,7 +283,7 @@ async function claim (name, salt, options = { vsn: 2 }) {
  * }
  */
 async function preclaim (name, options = {}) {
-  isNameValid(name)
+  ensureNameValid(name)
   const opt = R.merge(this.Ae.defaults, options)
   const _salt = salt()
   const height = await this.height()

--- a/src/chain/node.js
+++ b/src/chain/node.js
@@ -208,14 +208,19 @@ async function getName (name) {
  * Resolve AENS name and return name hash
  * @param {String} nameOrId
  * @param {String} prefix
- * @param {Boolean} verify
- * @param {Boolean} resolveByNode
+ * @param {Object} [options]
+ * @param {Boolean} [options.verify] Enables resolving by node, needed for compatibility with `verify` option of other methods
+ * @param {Boolean} [options.resolveByNode] Enables pointer resolving using node (isn't more durable to resolve it on the node side?)
  * @return {String} Address or AENS name hash
  */
-async function resolveName (nameOrId, prefix, { verify = false, resolveByNode = false } = {}) {
+async function resolveName (nameOrId, prefix, { verify, resolveByNode } = {}) {
+  if (!nameOrId || typeof nameOrId !== 'string') {
+    throw new Error('Invalid name or address. Should be a string')
+  }
   const prefixes = Object.keys(NAME_ID_KEY)
-  if (!nameOrId || typeof nameOrId !== 'string') throw new Error('Invalid name or address. Should be a string')
-  if (!prefixes.includes(prefix)) throw new Error(`Invalid prefix ${prefix}. Should be one of [${prefixes}]`)
+  if (!prefixes.includes(prefix)) {
+    throw new Error(`Invalid prefix ${prefix}. Should be one of [${prefixes}]`)
+  }
   if (assertedType(nameOrId, prefix, true)) return nameOrId
 
   if (isNameValid(nameOrId)) {

--- a/src/tx/builder/schema.js
+++ b/src/tx/builder/schema.js
@@ -27,7 +27,6 @@ export const MIN_GAS_PRICE = 1000000000 // min gasPrice 1e9
 export const MAX_AUTH_FUN_GAS = 50000
 export const DRY_RUN_ACCOUNT = { pub: 'ak_11111111111111111111111111111111273Yts', amount: '100000000000000000000000000000000000' }
 // # AENS
-export const AENS_NAME_DOMAINS = ['chain']
 export const NAME_TTL = 50000
 // # max number of block into the future that the name is going to be available
 // # https://github.com/aeternity/protocol/blob/epoch-v0.22.0/AENS.md#update

--- a/test/integration/transaction.js
+++ b/test/integration/transaction.js
@@ -18,7 +18,7 @@
 import { describe, it, before } from 'mocha'
 import { encodeBase58Check, encodeBase64Check, generateKeyPair, salt } from '../../src/utils/crypto'
 import { getSdk } from './index'
-import { commitmentHash, isNameValid, oracleQueryId } from '../../src/tx/builder/helpers'
+import { commitmentHash, oracleQueryId } from '../../src/tx/builder/helpers'
 import { MemoryAccount } from '../../src'
 import { AE_AMOUNT_FORMATS } from '../../src/utils/amount-formatter'
 import { unpackTx } from '../../src/tx/builder'
@@ -29,7 +29,7 @@ const clientTtl = 1
 const amount = 0
 const senderId = 'ak_2iBPH7HUz3cSDVEUWiHg76MZJ6tZooVNBmmxcgVK6VV8KAE688'
 const recipientId = 'ak_2iBPH7HUz3cSDVEUWiHg76MZJ6tZooVNBmmxcgVK6VV8KAE688'
-const name = 'test123test.test'
+const name = 'test123test.chain'
 const nameHash = `nm_${encodeBase58Check(Buffer.from(name))}`
 const nameId = 'nm_2sFnPHi5ziAqhdApSpRBsYdomCahtmk3YGNZKYUTtUNpVSMccC'
 const nameFee = '1000000000000000000000'
@@ -257,13 +257,6 @@ describe('Native Transaction', function () {
     nonce.should.be.equal(accountNonce + 1)
     const nonceCustom = await client.getAccountNonce(await client.address(), 1)
     nonceCustom.should.be.equal(1)
-  })
-  it('Is name valid', () => {
-    try {
-      isNameValid('asdasdasd.testDomain')
-    } catch (e) {
-      e.message.indexOf('AENS: Invalid name domain').should.not.be.equal(-1)
-    }
   })
   it('Destroy instance', () => {
     client.destroyInstance()


### PR DESCRIPTION
Breaking changes:
- removed `nameHash` from `builder/helpers`
- `isNameValid` won't throw exceptions
- removed `AENS_NAME_DOMAINS` from `builder/schema`
- removed default export of `builder/helpers`
Features:
- added `ensureNameValid` function that will throw exception if name is not valid