### PR TITLE
bigNumberToByteArray: Avoid unexpected behaviour by throwing exception

### DIFF
--- a/es/utils/bytes.js
+++ b/es/utils/bytes.js
@@ -63,6 +63,7 @@ export function rightPad (length, inputBuffer) {
  * @return Buffer
  */
 export function bigNumberToByteArray (x) {
+  if (!x.isInteger()) throw new Error(`Unexpected not integer value: ${x.toFixed()}`)
   let hexString = x.toString(16)
   if (hexString.length % 2 > 0) hexString = '0' + hexString
   return Buffer.from(hexString, 'hex')

--- a/test/unit/bytes.js
+++ b/test/unit/bytes.js
@@ -17,7 +17,9 @@
 
 import '../'
 import { describe, it } from 'mocha'
-import { leftPad, rightPad, toBytes } from '../../es/utils/bytes'
+import { expect } from 'chai'
+import BigNumber from 'bignumber.js'
+import { leftPad, rightPad, toBytes, bigNumberToByteArray } from '../../es/utils/bytes'
 import { isBase64, snakeOrKebabToPascal, snakeToPascal, pascalToSnake } from '../../es/utils/string'
 
 describe('Bytes', function () {
@@ -52,4 +54,13 @@ describe('Bytes', function () {
 
   it('converts pascal to snake case', () => pascalToSnake(testCase)
     .should.be.equal('test_test-test_test'))
+
+  describe('bigNumberToByteArray', () => {
+    it('converts BigNumber to Buffer', () => bigNumberToByteArray(new BigNumber('1000'))
+      .readInt16BE().should.be.equal(1000))
+
+    it('throws error if BigNumber is not integer', () =>
+      expect(() => bigNumberToByteArray(new BigNumber('1.5')))
+        .to.throw(/Unexpected not integer value:/))
+  })
 })


### PR DESCRIPTION
Implementing #1060 I have found that passing a non-integer amount value looks working, but actually the amount value is gets broken instead of being rounded somehow. `BigNumber.toString(16)` returns a hex value separated with a dot for non-integer values that get passed to `Buffer.from` that just ignores the part after `.`:
```
> Buffer.from('390cf7311ac9f5ab9746ab.2ab9f559b3d07c84b5dd', 'hex')
<Buffer 39 0c f7 31 1a c9 f5 ab 97 46 ab>
```
Alignment by adding a leading 0 also may not work properly in this case.

`bigNumberToByteArray` is handling non-integers not properly, so I propose to throw an exception then.