### PR TITLE
Speed up some tests 5 times

### DIFF
--- a/test/integration/chain.js
+++ b/test/integration/chain.js
@@ -32,7 +32,7 @@ describe('Node Chain', function () {
 
   it('waits for specified heights', async () => {
     const target = await client.height() + 1
-    await client.awaitHeight(target, { attempts: 120 }).should.eventually.be.at.least(target)
+    await client.awaitHeight(target, { interval: 200, attempts: 100 }).should.eventually.be.at.least(target)
     return client.height().should.eventually.be.at.least(target)
   })
   it('Can verify transaction from broadcast error', async () => {
@@ -87,17 +87,17 @@ describe('Node Chain', function () {
     const signed = await client.signTransaction(tx)
     const { txHash } = await client.api.postTransaction({ tx: signed })
 
-    await client.poll(txHash).should.eventually.be.fulfilled
-    return client.poll('th_xxx', { blocks: 1 }).should.eventually.be.rejected
+    await client.poll(txHash, { interval: 50, attempts: 1200 }).should.eventually.be.fulfilled
+    return client.poll('th_xxx', { blocks: 1, interval: 50, attempts: 1200 }).should.eventually.be.rejected
   })
 
   it('Wait for transaction confirmation', async () => {
-    const txData = await client.spend(1000, await client.address(), { confirm: true })
+    const txData = await client.spend(1000, await client.address(), { confirm: true, interval: 200, attempts: 100 })
     const isConfirmed = (await client.height()) >= txData.blockHeight + 3
 
     isConfirmed.should.be.equal(true)
 
-    const txData2 = await client.spend(1000, await client.address(), { confirm: 4 })
+    const txData2 = await client.spend(1000, await client.address(), { confirm: 4, interval: 200, attempts: 100 })
     const isConfirmed2 = (await client.height()) >= txData2.blockHeight + 4
     isConfirmed2.should.be.equal(true)
   })

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -392,13 +392,13 @@ describe('Contract', function () {
 
   it('call contract/deploy with `waitMined: false`', async () => {
     const deployed = await bytecode.deploy([], { waitMined: false })
-    await contract.poll(deployed.transaction)
+    await contract.poll(deployed.transaction, { interval: 50, attempts: 1200 })
     Boolean(deployed.result === undefined).should.be.equal(true)
     Boolean(deployed.txData === undefined).should.be.equal(true)
     const result = await deployed.call('main', ['42'], { waitMined: false, verify: false })
     Boolean(result.result === undefined).should.be.equal(true)
     Boolean(result.txData === undefined).should.be.equal(true)
-    await contract.poll(result.hash)
+    await contract.poll(result.hash, { interval: 50, attempts: 1200 })
   })
 
   it('calls deployed contracts static', async () => {
@@ -645,13 +645,13 @@ describe('Contract', function () {
     })
     it('Deploy/Call contract with { waitMined: false }', async () => {
       const deployed = await contractObject.methods.init('123', 1, 'hahahaha', { waitMined: false })
-      await contract.poll(deployed.transaction)
+      await contract.poll(deployed.transaction, { interval: 50, attempts: 1200 })
       Boolean(deployed.result === undefined).should.be.equal(true)
       Boolean(deployed.txData === undefined).should.be.equal(true)
       const result = await contractObject.methods.intFn.send(2, { waitMined: false })
       Boolean(result.result === undefined).should.be.equal(true)
       Boolean(result.txData === undefined).should.be.equal(true)
-      await contract.poll(result.hash)
+      await contract.poll(result.hash, { interval: 50, attempts: 1200 })
     })
     it('Generate ACI object with corresponding bytecode', async () => {
       await contract.getContractInstance(testContract, { contractAddress: contractObject.deployInfo.address, filesystem, opt: { ttl: 0 } })

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -34,7 +34,7 @@ export const account = Crypto.generateKeyPair()
 
 export const BaseAe = async (params = {}) => {
   const ae = await Universal.waitMined(true).compose({
-    deepProps: { Swagger: { defaults: { debug: !!process.env.DEBUG } } },
+    deepProps: { Ae: { defaults: { interval: 50, attempts: 1200 } }, Swagger: { defaults: { debug: !!process.env.DEBUG } } },
     props: { process, compilerUrl }
   })({
     ...params,


### PR DESCRIPTION
There are more places where the default 5s pooling interval is used - need to find them.

This reduces Tx confirmation times 5 times :)