### PR TITLE
Better node defaults

### DIFF
--- a/docker/aeternity_node_mean16.yaml
+++ b/docker/aeternity_node_mean16.yaml
@@ -19,7 +19,7 @@ keys:
   dir: ./keys
 
 chain:
-  persist: true
+  persist: false
   hard_forks:
     "1": 0
     "2": 2
@@ -29,8 +29,8 @@ chain:
 mining:
   autostart: true
   beneficiary: "ak_2iBPH7HUz3cSDVEUWiHg76MZJ6tZooVNBmmxcgVK6VV8KAE688"
-  expected_mine_rate: 4000
-  micro_block_cycle: 1000
+  expected_mine_rate: 1000
+  micro_block_cycle: 200
   cuckoo:
     miner:
       executable: mean15-generic

--- a/es/chain/node.js
+++ b/es/chain/node.js
@@ -105,7 +105,14 @@ async function tx (hash, info = true) {
 }
 
 async function height () {
-  return (await this.api.getCurrentKeyBlockHeight()).height
+  try {
+    if (this.height_query_promise === undefined) {
+      this.height_query_promise = this.api.getCurrentKeyBlockHeight()
+    }
+    return (await this.height_query_promise).height
+  } finally {
+    this.height_query_promise = undefined
+  }
 }
 
 async function awaitHeight (height, { interval = 5000, attempts = 20 } = {}) {

--- a/test/integration/chain.js
+++ b/test/integration/chain.js
@@ -30,6 +30,28 @@ describe('Node Chain', function () {
     return client.height().should.eventually.be.a('number')
   })
 
+  it('Compresses height queries', async () => {
+    const origFun = client.api.getCurrentKeyBlockHeight
+    try {
+      var calls = 0
+      client.api.getCurrentKeyBlockHeight = () => {
+        calls += 1
+        return origFun()
+      }
+      const H1P = client.height()
+      const H2P = client.height()
+      const H3P = client.height()
+      const H1 = await H1P
+      const H2 = await H2P
+      const H3 = await H3P
+      H1.should.be.equal(H2)
+      H1.should.be.equal(H3)
+      calls.should.be.equal(1)
+    } finally {
+      client.api.getCurrentKeyBlockHeight = origFun
+    }
+  })
+
   it('waits for specified heights', async () => {
     const target = await client.height() + 1
     await client.awaitHeight(target, { interval: 200, attempts: 100 }).should.eventually.be.at.least(target)
@@ -92,12 +114,12 @@ describe('Node Chain', function () {
   })
 
   it('Wait for transaction confirmation', async () => {
-    const txData = await client.spend(1000, await client.address(), { confirm: true, interval: 200, attempts: 100 })
+    const txData = await client.spend(1000, await client.address(), { confirm: true, interval: 400, attempts: 50 })
     const isConfirmed = (await client.height()) >= txData.blockHeight + 3
 
     isConfirmed.should.be.equal(true)
 
-    const txData2 = await client.spend(1000, await client.address(), { confirm: 4, interval: 200, attempts: 100 })
+    const txData2 = await client.spend(1000, await client.address(), { confirm: 4, interval: 400, attempts: 50 })
     const isConfirmed2 = (await client.height()) >= txData2.blockHeight + 4
     isConfirmed2.should.be.equal(true)
   })


### PR DESCRIPTION
Now with the polling interval fixed we can increase the mining rate of the node.
Tests now finally execute in reasonable amounts of time :)
How to improve this even further:
1. JS ACI calldata encoder/decoder
2. Instant mining in the node
Will see when I will be in the mood to implement those ;)

PR on top of #1073