### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /dist
 /docs/api*
 /docs/examples
+__pycache__
 /.envrc
 /yarn-error.log
 .idea


### PR DESCRIPTION
__pycache__ is created when generating docs using mkdocs

Otherwise our CI will generate a commit like b8060d97e3e5c3917eacc85143127a147f416571 every day 😄