### PR TITLE
Specify the python version more precisely

### DIFF
--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - python>=3.8
+  - python=3.8.*
   - nodejs=10.*
   - pip
   - pip:


### PR DESCRIPTION
Currently, readthedocs build is broken, because firstly, Conda installs python@3.9.0 and then run readthedocs's scripts:

> conda install --yes --quiet --name latest mock pillow

That depends on python@3.8.5. Reinstalling of python removes the installed packages, so resulting in error:

> ERROR   -  Config value: 'plugins'. Error: The "mkdocs-simple-hooks" plugin is not installed 
 
Specifying the python@3.8 helps to get rid of the error, but until builtin readthedocs scripts will become dependent on a newer python.

related to #1089 

build log: https://readthedocs.org/projects/aepp-sdk-js/builds/12399787/