### PR TITLE
add mkdocs build output folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage.*
 /examples/**/package-lock.json
 /examples/**/dist
 .history
+site


### PR DESCRIPTION
Shouldn't be needed I think, as everything is being rebuilt by demand.