### PR TITLE
explicitly set readthedocs template

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,15 @@ plugins:
         on_pre_build: "docs.hooks:pre_build"
 repo_url: 'https://github.com/aeternity/aepp-sdk-js'
 
+theme:
+  name: readthedocs
+  highlightjs: true
+  hljs_languages:
+    - yaml
+    - erlang
+    - javascript
+    - js
+
 nav:
   - Overview: README.md
   - guides/quick-start.md


### PR DESCRIPTION
This somehow got lost during @davidyuk 's last rebase and therefore the readTheDocs looked extremely ugly, using mkdocs default theme. But locally it's somehow loading the sphinx theme automagically - how is that actually done @davidyuk  ?
**Edit**: No, it's not automagically set for me anymore, maybe it was just a caching issue.

As a quickfix, I've redirected readTheDocs to the feature branch for now and will reconfigure to `devlop` after merge. thanks for a quick review ! ;)