### PR TITLE
Fix semantic version comparison

### DIFF
--- a/es/utils/semver-satisfies.js
+++ b/es/utils/semver-satisfies.js
@@ -6,7 +6,7 @@ export default function (version, geVersion, ltVersion) {
   const toNumber = (components, sliceLength) => components.slice(0, sliceLength).reverse()
     .reduce((acc, n, idx) => acc + n * Math.pow(base, idx), 0)
 
-  const componentsMinAmount = Math.min(versionComponents.length, geComponents.length, ltComponents.length);
+  const componentsMinAmount = Math.min(versionComponents.length, geComponents.length, ltComponents.length)
   const vNumber = toNumber(versionComponents, componentsMinAmount)
   const geNumber = toNumber(geComponents, componentsMinAmount)
   const ltNumber = toNumber(ltComponents, componentsMinAmount)

--- a/es/utils/semver-satisfies.js
+++ b/es/utils/semver-satisfies.js
@@ -3,11 +3,12 @@ export default function (version, geVersion, ltVersion) {
   const geComponents = geVersion.split('-')[0].split('.')
   const ltComponents = ltVersion.split('-')[0].split('.')
   const base = Math.max(...versionComponents, ...geComponents, ...ltComponents) + 1
-  const toNumber = components => components.reverse()
+  const toNumber = (components, sliceLength) => components.slice(0, sliceLength).reverse()
     .reduce((acc, n, idx) => acc + n * Math.pow(base, idx), 0)
 
-  const vNumber = toNumber(versionComponents)
-  const geNumber = toNumber(geComponents)
-  const ltNumber = toNumber(ltComponents)
+  const componentsMinAmount = Math.min(versionComponents.length, geComponents.length, ltComponents.length);
+  const vNumber = toNumber(versionComponents, componentsMinAmount)
+  const geNumber = toNumber(geComponents, componentsMinAmount)
+  const ltNumber = toNumber(ltComponents, componentsMinAmount)
   return vNumber >= geNumber && vNumber < ltNumber
 }

--- a/test/unit/semver-satisfies.js
+++ b/test/unit/semver-satisfies.js
@@ -27,5 +27,6 @@ describe('semverSatisfies', () => {
     expect(semverSatisfies('1.9.0', '2.0.0', '3.0.0')).to.equal(false)
     expect(semverSatisfies('1.9.0', '2.0.0', '3.0.0')).to.equal(false)
     expect(semverSatisfies('5.0.0', '3.0.0', '5.0.0')).to.equal(false)
+    expect(semverSatisfies('5.6.3.1', '5.0.0', '6.0.0')).to.equal(true)
   })
 })


### PR DESCRIPTION
A fix for [problem](https://github.com/aeternity/aepp-sdk-js/issues/1106) with node's semantic version digits count