### PR TITLE
Improve tests stability

### DIFF
--- a/docker/aeternity_node_mean16.yaml
+++ b/docker/aeternity_node_mean16.yaml
@@ -29,8 +29,9 @@ chain:
 mining:
   autostart: true
   beneficiary: "ak_2iBPH7HUz3cSDVEUWiHg76MZJ6tZooVNBmmxcgVK6VV8KAE688"
-  expected_mine_rate: 4000
-  micro_block_cycle: 1000
+  expected_mine_rate: 1000
+  micro_block_cycle: 200
+  strictly_follow_top: true
   cuckoo:
     miner:
       executable: mean15-generic


### PR DESCRIPTION
When the node is mining with a high frequency of producing blocks, there
is the risk of a race condition within the node.  Then the node mines a
keyblock and produces a microblock roughly at the same time. In this
case the keyblock is not based on the microblock so those are competing
forks. Since in real life scenario this would mean a miner discarding a
valid keyblock and losing the block reward from it, the keyblock is
included, the microblock is discarded. This results in a temporary
transaction rollback. The rolled back transactions are included in the
next generation but since they were rolled back, the correct account
nonce is fluctuating a bit, causing havoc in tests.  There is a node
setting that informs the node that microblocks shall take advantage
instead, discarding any keyblock that is not based on the latest `top`.


This shall not be used in real life scenario but fits perfectly the test
setup.

Fixes aeternity/aeternity#3516