### PR TITLE
docs: update import path in SDK code sample

### DIFF
--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -49,7 +49,7 @@ Create an account using the [💻 CLI](#cli---command-line-client)
 ### B) Using the SDK
 
 ```javascript
-  import { Crypto } from '@aeternity/aepp-sdk/es'
+  import { Crypto } from '@aeternity/aepp-sdk'
   const keypair = Crypto.generateKeyPair()
   console.log(`Secret key: ${keypair.secretKey}`)
   console.log(`Public key: ${keypair.publicKey}`)


### PR DESCRIPTION
Certain code samples from the ReadTheDocs can not be executed in a NodeJS project.
---
Given this code from quick sample:
 ```javascript
import { Crypto } from '@aeternity/aepp-sdk/es'
const keypair = Crypto.generateKeyPair()
console.log(`Secret key: ${keypair.secretKey}`)
console.log(`Public key: ${keypair.publicKey}`)
```

accessing modules using import throws 
```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '<PATH>\node_modules\@aeternity\aepp-sdk\es' is not supported
```

and using require instead throws
```
import * as Crypto from './utils/crypto'
^^^^^^

SyntaxError: Cannot use import statement outside a module
```
---
The quick start code sample was changed as follows:
```diff
- import { Crypto } from '@aeternity/aepp-sdk/es'
+ import { Crypto } from '@aeternity/aepp-sdk'
```
Similar changes are likely necessary in other code samples.