### PR TITLE
refactor: don't retrieve account from process.env

### DIFF
--- a/src/account/multiple.js
+++ b/src/account/multiple.js
@@ -50,14 +50,7 @@ import AccountBase, { isAccountBase } from './base'
  */
 export default AccountBase.compose(AsyncInit, {
   async init ({ accounts = [], address }) {
-    const { WALLET_PUB, WALLET_PRIV } = process?.env || {}
-    if (WALLET_PUB && WALLET_PRIV) {
-      accounts.push(MemoryAccount({
-        keypair: { publicKey: WALLET_PUB, secretKey: WALLET_PRIV }
-      }))
-    }
     this.accounts = R.fromPairs(await Promise.all(accounts.map(async a => [await a.address(), a])))
-
     if (!address) address = Object.keys(this.accounts)[0]
     assertedType(address, 'ak')
     this.selectedAddress = address

--- a/src/ae/universal.js
+++ b/src/ae/universal.js
@@ -42,7 +42,4 @@ import Contract from './contract'
  * @param {Object} [options={}] - Initializer object
  * @return {Object} Universal instance
  */
-export default Ae.compose(AccountMultiple, Chain, Transaction, Aens, Contract, Oracle, GeneralizeAccount, {
-  init () {},
-  props: { process: {} }
-})
+export default Ae.compose(AccountMultiple, Chain, Transaction, Aens, Contract, Oracle, GeneralizeAccount)

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -32,10 +32,10 @@ const ignoreVersion = process.env.IGNORE_VERSION || false
 export const genesisAccount = MemoryAccount({ keypair: { publicKey, secretKey } })
 export const account = Crypto.generateKeyPair()
 
-export const BaseAe = async (params = {}) => {
-  const ae = await Universal.waitMined(true).compose({
-    deepProps: { Ae: { defaults: { interval: 50, attempts: 1200 } }, Swagger: { defaults: { debug: !!process.env.DEBUG } } },
-    props: { process }
+export const BaseAe = async (params = {}) => Universal
+  .waitMined(true)
+  .compose({
+    deepProps: { Ae: { defaults: { interval: 50, attempts: 1200 } }, Swagger: { defaults: { debug: !!process.env.DEBUG } } }
   })({
     ...params,
     compilerUrl,
@@ -43,9 +43,6 @@ export const BaseAe = async (params = {}) => {
     accounts: [...params.accounts || [], genesisAccount],
     nodes: [{ name: 'test', instance: await Node({ url, internalUrl }) }]
   })
-  ae.removeAccount(process.env.WALLET_PUB)
-  return ae
-}
 
 const spendPromise = (async () => {
   const ae = await BaseAe({ networkId })

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -71,7 +71,6 @@ describe('Aepp<->Wallet', function () {
           this.shareWalletInfo(connectionFromWalletToAepp.sendMessage.bind(connectionFromWalletToAepp))
         }
       })
-      wallet.removeAccount(process.env.WALLET_PUB)
       aepp = await RpcAepp({
         name: 'AEPP',
         nodes: [{ name: 'test', instance: node }],


### PR DESCRIPTION
SDK is a library and retrieving the account from the process environment seems to be more suitable for the end-user product like sdk cli or so. Also, it may lead to unexpected behavior if sdk would be used in an app that manages accounts by itself.