### PR TITLE
refactor: use BigNumber constructor instead of custom wrapper

### DIFF
--- a/src/utils/amount-formatter.ts
+++ b/src/utils/amount-formatter.ts
@@ -21,7 +21,7 @@
  * @example import { AmountFormatter } from '@aeternity/aepp-sdk'
  */
 import BigNumber from 'bignumber.js'
-import { asBigNumber, isBigNumber } from './bignumber'
+import { isBigNumber } from './bignumber'
 
 /**
  * AE amount formats
@@ -90,7 +90,7 @@ export const formatAmount = (
   if (!denominations.includes(targetDenomination)) throw new Error(`Invalid target denomination: ${targetDenomination}`)
   if (!isBigNumber(value)) throw new Error(`Value ${value.toString()} is not type of number`)
 
-  return asBigNumber(value)
+  return new BigNumber(value)
     .shiftedBy(DENOMINATION_MAGNITUDE[denomination] - DENOMINATION_MAGNITUDE[targetDenomination])
     .toFixed()
 }

--- a/src/utils/bignumber.ts
+++ b/src/utils/bignumber.ts
@@ -1,7 +1,7 @@
 /**
  * Big Number Helpers
  * @module @aeternity/aepp-sdk/es/utils/bignumber
- * @example import { parseBigNumber, asBigNumber, isBigNumber, ceil } from '@aeternity/aepp-sdk/es/utils/bignumber'
+ * @example import { parseBigNumber, isBigNumber, ceil } from '@aeternity/aepp-sdk/es/utils/bignumber'
  */
 import BigNumber from 'bignumber.js'
 
@@ -12,14 +12,6 @@ import BigNumber from 'bignumber.js'
  */
 export const parseBigNumber = (number: string | number | BigNumber): string =>
   new BigNumber(number.toString()).toString(10)
-
-/**
- * Convert number to BigNumber instance
- * @param {String|Number|BigNumber} number number to convert
- * @return {BigNumber}
- */
-export const asBigNumber = (number: string | number | BigNumber): BigNumber =>
-  new BigNumber(number.toString())
 
 /**
  * Check if value is BigNumber, Number or number string representation

--- a/test/unit/amount-formatter.ts
+++ b/test/unit/amount-formatter.ts
@@ -16,9 +16,10 @@
  */
 
 import { describe, it } from 'mocha'
+import BigNumber from 'bignumber.js'
 import '..'
 import { AE_AMOUNT_FORMATS, formatAmount, toAe, toAettos } from '../../src/utils/amount-formatter'
-import { asBigNumber, parseBigNumber } from '../../src/utils/bignumber'
+import { parseBigNumber } from '../../src/utils/bignumber'
 
 describe('Amount Formatter', function () {
   it('to aettos', async () => {
@@ -34,10 +35,10 @@ describe('Amount Formatter', function () {
   })
   it('to Ae', () => {
     [
-      [1, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1).div(1e18)],
-      [10, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(10).div(1e18)],
-      [100, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(100).div(1e18)],
-      [10012312, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(10012312).div(1e18)],
+      [1, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1).div(1e18)],
+      [10, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(10).div(1e18)],
+      [100, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(100).div(1e18)],
+      [10012312, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(10012312).div(1e18)],
       [1, AE_AMOUNT_FORMATS.AE, 1]
     ].forEach(
       ([v, d, e]) => parseBigNumber(e).should.be.equal(toAe(v, { denomination: d.toString() }))
@@ -45,25 +46,25 @@ describe('Amount Formatter', function () {
   })
   it('format', () => {
     [
-      [1, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1e18)],
-      [10, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.AE, asBigNumber(10).div(1e18)],
-      [1e18, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.AE, asBigNumber(1)],
-      [10012312, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.AE, asBigNumber(10012312).div(1e18)],
+      [1, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1e18)],
+      [10, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.AE, new BigNumber(10).div(1e18)],
+      [1e18, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.AE, new BigNumber(1)],
+      [10012312, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.AE, new BigNumber(10012312).div(1e18)],
       [1, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.AE, 1],
-      [1, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AE, asBigNumber(0.000000000001)],
-      [1, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1000000)],
-      [1e6, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.PICO_AE, asBigNumber(1)],
-      [0.0001, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AE, asBigNumber(0.0000000000000001)],
-      [0.000000000001, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.PICO_AE, asBigNumber(1)],
-      [0.000001, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1)],
-      [0.000000000001, AE_AMOUNT_FORMATS.MICRO_AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1)],
-      [0.000001, AE_AMOUNT_FORMATS.MICRO_AE, AE_AMOUNT_FORMATS.PICO_AE, asBigNumber(1)],
-      [1, AE_AMOUNT_FORMATS.MILI_AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1000000000000000)],
-      [1, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.MILI_AE, asBigNumber(1000)],
-      [1, AE_AMOUNT_FORMATS.NANO_AE, AE_AMOUNT_FORMATS.AE, asBigNumber(0.000000001)],
-      [1, AE_AMOUNT_FORMATS.NANO_AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1000000000)],
-      [1, AE_AMOUNT_FORMATS.FEMTO_AE, AE_AMOUNT_FORMATS.AETTOS, asBigNumber(1000)],
-      [1, AE_AMOUNT_FORMATS.NANO_AE, AE_AMOUNT_FORMATS.FEMTO_AE, asBigNumber(1000000)]
+      [1, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AE, new BigNumber(0.000000000001)],
+      [1, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1000000)],
+      [1e6, AE_AMOUNT_FORMATS.AETTOS, AE_AMOUNT_FORMATS.PICO_AE, new BigNumber(1)],
+      [0.0001, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AE, new BigNumber(0.0000000000000001)],
+      [0.000000000001, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.PICO_AE, new BigNumber(1)],
+      [0.000001, AE_AMOUNT_FORMATS.PICO_AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1)],
+      [0.000000000001, AE_AMOUNT_FORMATS.MICRO_AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1)],
+      [0.000001, AE_AMOUNT_FORMATS.MICRO_AE, AE_AMOUNT_FORMATS.PICO_AE, new BigNumber(1)],
+      [1, AE_AMOUNT_FORMATS.MILI_AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1000000000000000)],
+      [1, AE_AMOUNT_FORMATS.AE, AE_AMOUNT_FORMATS.MILI_AE, new BigNumber(1000)],
+      [1, AE_AMOUNT_FORMATS.NANO_AE, AE_AMOUNT_FORMATS.AE, new BigNumber(0.000000001)],
+      [1, AE_AMOUNT_FORMATS.NANO_AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1000000000)],
+      [1, AE_AMOUNT_FORMATS.FEMTO_AE, AE_AMOUNT_FORMATS.AETTOS, new BigNumber(1000)],
+      [1, AE_AMOUNT_FORMATS.NANO_AE, AE_AMOUNT_FORMATS.FEMTO_AE, new BigNumber(1000000)]
     ].forEach(
       ([v, dF, dT, e]) => parseBigNumber(e).should.be.equal(formatAmount(v, { denomination: dF.toString(), targetDenomination: dT.toString() }))
     )


### PR DESCRIPTION
Probably it was necessary before when BigNumber was throwing an exception when passing a number that is not presented precisely.