### PR TITLE
refactor: remove unused asymmetric encode/decode functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16379,14 +16379,6 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
-    "ed2curve": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
-      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
-      "requires": {
-        "tweetnacl": "1.x.x"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.4",
     "crypto-browserify": "^3.12.0",
-    "ed2curve": "^0.3.0",
     "events": "^3.3.0",
     "libsodium-wrappers-sumo": "^0.7.9",
     "path-browserify": "^1.0.1",

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -22,7 +22,6 @@
  */
 
 import bs58check from 'bs58check'
-import ed2curve from 'ed2curve'
 import nacl from 'tweetnacl'
 import aesjs from 'aes-js'
 import shajs from 'sha.js'
@@ -310,54 +309,4 @@ export function isValidKeypair (privateKey, publicKey) {
   const message = Buffer.from('TheMessage')
   const signature = sign(message, privateKey)
   return verify(message, signature, publicKey)
-}
-
-/**
- * This function encrypts a message using base58check encoded and 'ak' prefixed
- * publicKey such that only the corresponding secretKey will
- * be able to decrypt
- * @rtype (msg: String, publicKey: String) => Object
- * @param {Buffer} msg - Data to encode
- * @param {String} publicKey - Public key
- * @return {Object}
- */
-export function encryptData (msg, publicKey) {
-  const ephemeralKeyPair = nacl.box.keyPair()
-  const pubKeyUInt8Array = decode(publicKey, 'ak')
-  const nonce = nacl.randomBytes(nacl.box.nonceLength)
-
-  const encryptedMessage = nacl.box(
-    Buffer.from(msg),
-    nonce,
-    ed2curve.convertPublicKey(pubKeyUInt8Array),
-    ephemeralKeyPair.secretKey
-  )
-
-  return {
-    ciphertext: Buffer.from(encryptedMessage).toString('hex'),
-    ephemPubKey: Buffer.from(ephemeralKeyPair.publicKey).toString('hex'),
-    nonce: Buffer.from(nonce).toString('hex'),
-    version: 'x25519-xsalsa20-poly1305'
-  }
-}
-
-/**
- * This function decrypt a message using secret key
- * @rtype (secretKey: String, encryptedData: Object) => Buffer|null
- * @param {String} secretKey - Secret key
- * @param {Object} encryptedData - Encrypted data
- * @return {Buffer|null}
- */
-export function decryptData (secretKey, encryptedData) {
-  const receiverSecretKeyUint8Array = ed2curve.convertSecretKey(Buffer.from(secretKey, 'hex'))
-  const nonce = Buffer.from(encryptedData.nonce, 'hex')
-  const ciphertext = Buffer.from(encryptedData.ciphertext, 'hex')
-  const ephemPubKey = Buffer.from(encryptedData.ephemPubKey, 'hex')
-  const decrypted = nacl.box.open(
-    ciphertext,
-    nonce,
-    ephemPubKey,
-    receiverSecretKeyUint8Array
-  )
-  return decrypted ? Buffer.from(decrypted) : decrypted
 }

--- a/test/unit/crypto.js
+++ b/test/unit/crypto.js
@@ -144,30 +144,4 @@ describe('crypto', () => {
     buildTxHash(txRaw).should.be.equal(expectedHash)
     buildTxHash(rlpEncodedTx).should.be.equal(expectedHash)
   })
-  describe('Encrypt data using nacl box asymmetric encryption', async () => {
-    const { publicKey, secretKey } = Crypto.generateKeyPair()
-    const msgString = 'Test string'
-    const msgBuffer = Buffer.from(msgString)
-
-    it('Encrypt String/Buffer and decrypt', () => {
-      const encryptedString = Crypto.encryptData(msgString, publicKey)
-      const encryptedBuffer = Crypto.encryptData(msgBuffer, publicKey)
-
-      const decryptedString = Crypto.decryptData(secretKey, encryptedString)
-      const decryptedBuffer = Crypto.decryptData(secretKey, encryptedBuffer)
-      Buffer.from(decryptedString).toString().should.be.equal(msgString)
-      decryptedBuffer.equals(msgBuffer).should.be.equal(true)
-    })
-    it('Decrypt with wrong secret', () => {
-      const keyPair = Crypto.generateKeyPair()
-
-      const encryptedString = Crypto.encryptData(msgString, keyPair.publicKey)
-      const encryptedBuffer = Crypto.encryptData(msgBuffer, keyPair.publicKey)
-
-      const decryptedString = Crypto.decryptData(secretKey, encryptedString)
-      const decryptedBuffer = Crypto.decryptData(secretKey, encryptedBuffer)
-      const isNull = decryptedBuffer === null && decryptedString === null
-      isNull.should.be.equal(true)
-    })
-  })
 })


### PR DESCRIPTION
- it was added in #466 without any reasoning
- it isn't used by sdk itself
- it is unclear who and for what reason can use it
- `nacl.box`/`nacl.box.open` can be used directly instead