### PR TITLE
Fix lris updating domain name maximum height issue

### DIFF
--- a/src/ae/aens.js
+++ b/src/ae/aens.js
@@ -198,7 +198,7 @@ async function query (name, opt = {}) {
     },
     revoke: async (options = {}) => this.aensRevoke(name, R.merge(opt, options)),
     extendTtl: async (nameTtl = NAME_TTL, options = {}) => {
-      if (!nameTtl || typeof nameTtl !== 'number' || nameTtl > NAME_TTL) throw new Error('Ttl must be an number and less then 50000 blocks')
+      if (!nameTtl || typeof nameTtl !== 'number' || nameTtl > NAME_TTL) throw new Error('Ttl must be an number and less then 180000 blocks')
 
       return {
         ...(await this.aensUpdate(name, o.pointers.map(p => p.id), { ...R.merge(opt, options), nameTtl })),

--- a/src/tx/builder/schema.js
+++ b/src/tx/builder/schema.js
@@ -27,7 +27,7 @@ export const MIN_GAS_PRICE = 1e9
 export const MAX_AUTH_FUN_GAS = 50000
 export const DRY_RUN_ACCOUNT = { pub: 'ak_11111111111111111111111111111111273Yts', amount: '100000000000000000000000000000000000' }
 // # AENS
-export const NAME_TTL = 50000
+export const NAME_TTL = 180000
 // # max number of block into the future that the name is going to be available
 // # https://github.com/aeternity/protocol/blob/epoch-v0.22.0/AENS.md#update
 // # https://github.com/aeternity/protocol/blob/44a93d3aab957ca820183c3520b9daf6b0fedff4/AENS.md#aens-entry


### PR DESCRIPTION
The validity of domain name renewal after IRIS should be changed to `180000`, currently, it is still `5000`. Restrictions are made in the SDK. I have modified this