### PR TITLE
Fix and make smaller browser script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9142,8 +9142,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "joi-browser": "^13.4.0",
     "libsodium-wrappers-sumo": "0.7.9",
     "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
     "ramda": "^0.27.1",
     "rlp": "2.2.6",
     "sha.js": "^2.4.11",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,8 @@ function configure (filename, opts = {}) {
     },
     plugins: [
       ...opts.target === 'node' ? [] : [new webpack.ProvidePlugin({
-        process: 'process'
+        process: 'process',
+        Buffer: ['buffer', 'Buffer']
       })],
       ...argv.report ? [new BundleAnalyzerPlugin({
         analyzerMode: 'static',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack')
 const path = require('path')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
@@ -24,13 +25,16 @@ function configure (filename, opts = {}) {
         crypto: require.resolve('crypto-browserify')
       }
     },
-    plugins: argv.report ? [
-      new BundleAnalyzerPlugin({
+    plugins: [
+      ...opts.target === 'node' ? [] : [new webpack.ProvidePlugin({
+        process: 'process'
+      })],
+      ...argv.report ? [new BundleAnalyzerPlugin({
         analyzerMode: 'static',
         reportFilename: filename + '.html',
         openAnalyzer: false
-      })
-    ] : [],
+      })] : []
+    ],
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,9 @@ function configure (filename, opts = {}) {
         path: require.resolve('path-browserify'),
         stream: require.resolve('stream-browserify'),
         crypto: require.resolve('crypto-browserify')
+      },
+      alias: {
+        'js-yaml': false
       }
     },
     plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,12 +12,6 @@ function configure (filename, opts = {}) {
           test: /\.(js|ts)$/,
           include: path.resolve(__dirname, 'src'),
           loader: 'babel-loader'
-        },
-        {
-          test: /\.js$/,
-          include: path.resolve(__dirname, 'node_modules/rlp'),
-          loader: 'babel-loader',
-          options: { presets: ['@babel/preset-env'] }
         }
       ]
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,8 +34,10 @@ function configure (filename, opts = {}) {
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename,
-      library: 'Ae',
-      libraryTarget: 'umd'
+      library: {
+        name: 'Ae',
+        type: 'umd'
+      }
     },
     externals: Object
       .keys(require('./package').dependencies)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,8 @@
 const path = require('path')
-const R = require('ramda')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
 function configure (filename, opts = {}) {
-  return (env, argv) => R.mergeDeepRight({
+  return (env, argv) => ({
     entry: './src/index.js',
     mode: 'development', // automatically overriden by production flag
     devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
@@ -52,8 +51,9 @@ function configure (filename, opts = {}) {
           commonjs: dependency,
           commonjs2: dependency
         }
-      }), {})
-  }, opts)
+      }), {}),
+    ...opts
+  })
 }
 
 module.exports = [


### PR DESCRIPTION
before:
```
$ ls -lah dist 
2.1M aepp-sdk.browser-script.js
6.6M aepp-sdk.browser-script.js.map
328K aepp-sdk.browser.js
1.1M aepp-sdk.browser.js.map
325K aepp-sdk.js
1.1M aepp-sdk.js.map
```
after this and #1208:
```
$ ls -lah dist
955K aepp-sdk.browser-script.js
3.5M aepp-sdk.browser-script.js.map
327K aepp-sdk.browser.js
1.1M aepp-sdk.browser.js.map
325K aepp-sdk.js
1.1M aepp-sdk.js.map
```

fixes `aepp-sdk.browser-script.js` package, discussed in https://forum.aeternity.com/t/issues-with-sdk8-0-0/9453/8

also should fix this issue: https://github.com/crypto-browserify/pbkdf2/issues/48#issuecomment-842311861 😃 