### PR TITLE
fix: swagger https issue

### DIFF
--- a/src/utils/swagger.js
+++ b/src/utils/swagger.js
@@ -46,8 +46,13 @@ export default async (specUrl, { spec, internalUrl, disableBigNumbers, disableCa
   spec = spec || await (await fetch(specUrl)).json()
   const jsonImp = disableBigNumbers ? JSON : JsonBig
 
-  if (['https://compiler.aepps.com', 'https://latest.compiler.aepps.com']
-    .includes(new URL(specUrl).origin)) {
+  if (
+    [
+      'https://compiler.aepps.com',
+      'https://latest.compiler.aepps.com'
+    ].includes(new URL(specUrl).origin) ||
+    new URL(specUrl).origin.includes('https://')
+  ) {
     spec.schemes = ['https']
   }
 


### PR DESCRIPTION
Added `https` check for the origin URL of the compiler, not only for the hosted compilers.

workaround for https://github.com/aeternity/aesophia_http/issues/70

ref: https://github.com/aeternity/aepp-sdk-js/issues/1225#issuecomment-863985169