### PR TITLE
Add events package to package manager file to fix webpack building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "cross-fetch": "^3.1.4",
         "crypto-browserify": "^3.12.0",
         "ed2curve": "^0.3.0",
+        "events": "^3.3.0",
         "joi-browser": "^13.4.0",
         "libsodium-wrappers-sumo": "0.7.9",
         "path-browserify": "^1.0.1",
@@ -6991,7 +6992,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -20733,8 +20733,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cross-fetch": "^3.1.4",
     "crypto-browserify": "^3.12.0",
     "ed2curve": "^0.3.0",
+    "events": "^3.3.0",
     "joi-browser": "^13.4.0",
     "libsodium-wrappers-sumo": "0.7.9",
     "path-browserify": "^1.0.1",


### PR DESCRIPTION
Since latest webpack versions dropped the default "events" package, during a fresh setup of the SDK manual installation of the "events" package is necessary. Saved it in the `package.json` file