### PR TITLE
Fix default account required to setup universal stamp of the SDK issue

### DIFF
--- a/src/account/multiple.js
+++ b/src/account/multiple.js
@@ -51,13 +51,13 @@ import AccountBase, { isAccountBase } from './base'
 export default AccountBase.compose(AsyncInit, {
   async init ({ accounts = [], address }) {
     /* An Account maynot be required for the Node/Chain methods */
-    if(Array.isArray(accounts) && accounts.length) {
+    if (Array.isArray(accounts) && accounts.length) {
       this.accounts = R.fromPairs(await Promise.all(accounts.map(async a => [await a.address(), a])))
       if (!address) address = Object.keys(this.accounts)[0]
       decode(address, 'ak')
       this.selectedAddress = address
     } else {
-      console.warn("No account/accounts supplied")
+      console.warn('No account/accounts supplied')
     }
   },
   props: {

--- a/src/account/multiple.js
+++ b/src/account/multiple.js
@@ -50,10 +50,15 @@ import AccountBase, { isAccountBase } from './base'
  */
 export default AccountBase.compose(AsyncInit, {
   async init ({ accounts = [], address }) {
-    this.accounts = R.fromPairs(await Promise.all(accounts.map(async a => [await a.address(), a])))
-    if (!address) address = Object.keys(this.accounts)[0]
-    decode(address, 'ak')
-    this.selectedAddress = address
+    /* An Account maynot be required for the Node/Chain methods */
+    if(Array.isArray(accounts) && accounts.length) {
+      this.accounts = R.fromPairs(await Promise.all(accounts.map(async a => [await a.address(), a])))
+      if (!address) address = Object.keys(this.accounts)[0]
+      decode(address, 'ak')
+      this.selectedAddress = address
+    } else {
+      console.warn("No account/accounts supplied")
+    }
   },
   props: {
     accounts: {}

--- a/test/integration/chain.js
+++ b/test/integration/chain.js
@@ -19,28 +19,29 @@ import { getSdk } from './'
 import { generateKeyPair } from '../../src/utils/crypto'
 
 describe('Node Chain', function () {
-  let client
+  let walletClient, openClient
   const { publicKey } = generateKeyPair()
 
   before(async function () {
-    client = await getSdk()
+    walletClient = await getSdk()
+    openClient = await getSdk({ withoutAccount: true })
   })
 
   it('determines the height', async () => {
-    return client.height().should.eventually.be.a('number')
+    return openClient.height().should.eventually.be.a('number')
   })
 
   it('Compresses height queries', async () => {
-    const origFun = client.api.getCurrentKeyBlockHeight
+    const origFun = openClient.api.getCurrentKeyBlockHeight
     try {
       var calls = 0
-      client.api.getCurrentKeyBlockHeight = () => {
+      openClient.api.getCurrentKeyBlockHeight = () => {
         calls += 1
         return origFun()
       }
-      const H1P = client.height()
-      const H2P = client.height()
-      const H3P = client.height()
+      const H1P = openClient.height()
+      const H2P = openClient.height()
+      const H3P = openClient.height()
       const H1 = await H1P
       const H2 = await H2P
       const H3 = await H3P
@@ -48,79 +49,79 @@ describe('Node Chain', function () {
       H1.should.be.equal(H3)
       calls.should.be.equal(1)
     } finally {
-      client.api.getCurrentKeyBlockHeight = origFun
+      openClient.api.getCurrentKeyBlockHeight = origFun
     }
   })
 
   it('waits for specified heights', async () => {
-    const target = await client.height() + 1
-    await client.awaitHeight(target, { interval: 200, attempts: 100 }).should.eventually.be.at.least(target)
-    return client.height().should.eventually.be.at.least(target)
+    const target = await openClient.height() + 1
+    await openClient.awaitHeight(target, { interval: 200, attempts: 100 }).should.eventually.be.at.least(target)
+    return openClient.height().should.eventually.be.at.least(target)
   })
   it('Can verify transaction from broadcast error', async () => {
     try {
-      await client.spend(0, publicKey, { fee: 100, verify: false })
+      await walletClient.spend(0, publicKey, { fee: 100, verify: false })
     } catch (e) {
       const validation = await e.verifyTx()
       validation.should.has.lengthOf(1)
     }
   })
   it('Get top block', async () => {
-    const top = await client.topBlock()
+    const top = await openClient.topBlock()
     top.should.has.property('hash')
     top.should.has.property('height')
   })
   it('Get pending transaction', async () => {
-    const mempool = await client.mempool()
+    const mempool = await openClient.mempool()
     mempool.should.has.property('transactions')
   })
   it('Get current generation', async () => {
-    const generation = await client.getCurrentGeneration()
+    const generation = await openClient.getCurrentGeneration()
     generation.should.has.property('keyBlock')
   })
   it('Get key block', async () => {
-    const { keyBlock } = await client.getCurrentGeneration()
-    const keyBlockByHash = await client.getKeyBlock(keyBlock.hash)
-    const keyBlockByHeight = await client.getKeyBlock(keyBlock.height)
-    const keyBlockError = await client.getKeyBlock(false).catch(e => true)
+    const { keyBlock } = await openClient.getCurrentGeneration()
+    const keyBlockByHash = await openClient.getKeyBlock(keyBlock.hash)
+    const keyBlockByHeight = await openClient.getKeyBlock(keyBlock.height)
+    const keyBlockError = await openClient.getKeyBlock(false).catch(e => true)
     keyBlockByHash.should.be.an('object')
     keyBlockByHeight.should.be.an('object')
     keyBlockError.should.be.equal(true)
   })
   it('Get generation', async () => {
-    const { keyBlock } = await client.getCurrentGeneration()
-    const genByHash = await client.getGeneration(keyBlock.hash)
-    const genByHeight = await client.getGeneration(keyBlock.height)
-    const genArgsError = await client.getGeneration(true).catch(e => true)
+    const { keyBlock } = await openClient.getCurrentGeneration()
+    const genByHash = await openClient.getGeneration(keyBlock.hash)
+    const genByHeight = await openClient.getGeneration(keyBlock.height)
+    const genArgsError = await openClient.getGeneration(true).catch(e => true)
     genByHash.should.be.an('object')
     genByHeight.should.be.an('object')
     genArgsError.should.be.equal(true)
   })
   it('polls for transactions', async () => {
-    const sender = await client.address()
+    const sender = await walletClient.address()
     const receiver = publicKey
-    const tx = await client.spendTx({
+    const tx = await walletClient.spendTx({
       amount: 1,
       senderId: sender,
       recipientId: receiver,
       payload: '',
       ttl: Number.MAX_SAFE_INTEGER
     })
-    const signed = await client.signTransaction(tx)
-    const { txHash } = await client.api.postTransaction({ tx: signed })
+    const signed = await walletClient.signTransaction(tx)
+    const { txHash } = await walletClient.api.postTransaction({ tx: signed })
 
-    await client.poll(txHash, { interval: 50, attempts: 1200 }).should.eventually.be.fulfilled
-    return client.poll('th_xxx', { blocks: 1, interval: 50, attempts: 1200 }).should.eventually.be.rejected
+    await walletClient.poll(txHash, { interval: 50, attempts: 1200 }).should.eventually.be.fulfilled
+    return walletClient.poll('th_xxx', { blocks: 1, interval: 50, attempts: 1200 }).should.eventually.be.rejected
   })
 
   it('Wait for transaction confirmation', async () => {
-    const txData = await client.spend(1000, await client.address(), { confirm: true, interval: 400, attempts: 50 })
-    const isConfirmed = (await client.height()) >= txData.blockHeight + 3
+    const txData = await walletClient.spend(1000, await walletClient.address(), { confirm: true, interval: 400, attempts: 50 })
+    const isConfirmed = (await walletClient.height()) >= txData.blockHeight + 3
 
     isConfirmed.should.be.equal(true)
 
-    const txData2 = await client.spend(1000, await client.address(), { confirm: 4, interval: 400, attempts: 50 })
-    const isConfirmed2 = (await client.height()) >= txData2.blockHeight + 4
+    const txData2 = await walletClient.spend(1000, await walletClient.address(), { confirm: 4, interval: 400, attempts: 50 })
+    const isConfirmed2 = (await walletClient.height()) >= txData2.blockHeight + 4
     isConfirmed2.should.be.equal(true)
   })
 })

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -48,17 +48,18 @@ export const BaseAe = async (params = {}, compose = {}) => Universal
   })
 
 const spendPromise = (async () => {
-  const ae = await BaseAe({ networkId })
+  const ae = await BaseAe({ networkId, withoutGenesisAccount: false })
   await ae.awaitHeight(2)
   await ae.spend('1' + '0'.repeat(26), account.publicKey)
 })()
 
-export async function getSdk (nativeMode) {
+export async function getSdk({ nativeMode = true, withoutAccount } = {}) {
   await spendPromise
 
   return BaseAe({
-    accounts: [MemoryAccount({ keypair: account })],
-    address: account.publicKey,
+    accounts: (withoutAccount === undefined || withoutAccount === false) ? [MemoryAccount({ keypair: account })] : [],
+    address: (withoutAccount === undefined || withoutAccount === false) ? account.publicKey : undefined,
+    withoutGenesisAccount: (withoutAccount === undefined || withoutAccount === false) ? false : true,
     nativeMode,
     networkId
   })

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -53,13 +53,13 @@ const spendPromise = (async () => {
   await ae.spend('1' + '0'.repeat(26), account.publicKey)
 })()
 
-export async function getSdk({ nativeMode = true, withoutAccount } = {}) {
+export async function getSdk ({ nativeMode = true, withoutAccount } = {}) {
   await spendPromise
 
   return BaseAe({
     accounts: (withoutAccount === undefined || withoutAccount === false) ? [MemoryAccount({ keypair: account })] : [],
     address: (withoutAccount === undefined || withoutAccount === false) ? account.publicKey : undefined,
-    withoutGenesisAccount: (withoutAccount === undefined || withoutAccount === false) ? false : true,
+    withoutGenesisAccount: !((withoutAccount === undefined || withoutAccount === false)),
     nativeMode,
     networkId
   })

--- a/test/integration/transaction.js
+++ b/test/integration/transaction.js
@@ -66,7 +66,7 @@ describe('Native Transaction', function () {
 
   before(async () => {
     const keyPair = generateKeyPair()
-    client = await getSdk(false)
+    client = await getSdk({ nativeMode: false })
     clientNative = await getSdk()
     await client.spend('16774200000000000000', keyPair.publicKey)
     await client.addAccount(MemoryAccount({ keypair: keyPair }), { select: true })


### PR DESCRIPTION
Issue descriptions:  #1224 

Process accounts in `accounts stamp` only when it's not empty.
Modify BaseAe SDK setup in integration tests to accomodate accountless instances.
Use Accountless stamp(openClient) in Chain tests.
