### PR TITLE
Enforce zero value of deposit while Contract deployment

### DIFF
--- a/src/ae/contract.js
+++ b/src/ae/contract.js
@@ -217,7 +217,7 @@ async function contractCall (source, address, name, argsOrCallData = [], options
  * }
  */
 async function contractDeploy (code, source, initState = [], options = {}) {
-  const opt = { ...this.Ae.defaults, ...options }
+  const opt = { ...this.Ae.defaults, ...options, deposit: DEPOSIT }
   const callData = Array.isArray(initState) ? await this.contractEncodeCall(source, 'init', initState, opt) : initState
   const ownerId = await this.address(opt)
 

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -294,6 +294,13 @@ describe('Contract', function () {
     const code = await contract.contractCompile(identityContract)
     return contract.contractDeploy(code.bytecode, identityContract).should.eventually.have.property('address')
   })
+  it('enforce zero deposit for contract deployment', async () => {
+    const { version, consensusProtocolVersion } = contract.getNodeInfo()
+    console.log(`Node => ${version}, consensus => ${consensusProtocolVersion}, compiler => ${contract.compilerVersion}`)
+    const code = await contract.contractCompile(identityContract)
+    var { txData } = await contract.contractDeploy(code.bytecode, identityContract, [], { deposit: 10 })
+    return txData.tx.deposit.should.be.equal(0)
+  })
   it('Verify message in Sophia', async () => {
     const msgHash = messageToHash('Hello')
     const signature = await contract.sign(msgHash)


### PR DESCRIPTION
Fix #1232 

Solution: In the  `contractDeploy` method, overwrite the `deposit` key in the options.