### PR TITLE
Make Channel a part of Universal stamp

### DIFF
--- a/src/ae/universal.js
+++ b/src/ae/universal.js
@@ -30,6 +30,7 @@ import Oracle from './oracle'
 import GeneralizeAccount from '../contract/ga'
 import AccountMultiple from '../account/multiple'
 import Contract from './contract'
+import Channel from '../channel'
 
 /**
  * Universal Stamp
@@ -42,4 +43,4 @@ import Contract from './contract'
  * @param {Object} [options={}] - Initializer object
  * @return {Object} Universal instance
  */
-export default Ae.compose(AccountMultiple, Chain, Transaction, Aens, Contract, Oracle, GeneralizeAccount)
+export default Ae.compose(AccountMultiple, Chain, Transaction, Aens, Contract, Oracle, GeneralizeAccount, Channel)

--- a/test/integration/channel.js
+++ b/test/integration/channel.js
@@ -23,7 +23,6 @@ import { getSdk, BaseAe, networkId } from './'
 import { generateKeyPair, encodeBase64Check } from '../../src/utils/crypto'
 import { unpackTx, buildTx, buildTxHash } from '../../src/tx/builder'
 import { decode } from '../../src/tx/builder/helpers'
-import Channel from '../../src/channel'
 import MemoryAccount from '../../src/account/memory'
 
 const wsUrl = process.env.TEST_WS_URL || 'ws://localhost:3014/channel'
@@ -102,12 +101,12 @@ describe('Channel', function () {
   })
 
   it('can open a channel', async () => {
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       sign: initiatorSign
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       role: 'responder',
       sign: responderSign
@@ -661,12 +660,12 @@ describe('Channel', function () {
   it('can leave a channel', async () => {
     initiatorCh.disconnect()
     responderCh.disconnect()
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       sign: initiatorSign
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       role: 'responder',
       sign: responderSign
@@ -681,7 +680,7 @@ describe('Channel', function () {
   })
 
   it('can reestablish a channel', async () => {
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       port: 3002,
@@ -699,13 +698,13 @@ describe('Channel', function () {
   it('can solo close a channel', async () => {
     initiatorCh.disconnect()
     responderCh.disconnect()
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       port: 3003,
       sign: initiatorSign
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       role: 'responder',
       port: 3003,
@@ -758,14 +757,14 @@ describe('Channel', function () {
     const responderAddr = await responder.address()
     initiatorCh.disconnect()
     responderCh.disconnect()
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       lockPeriod: 5,
       role: 'initiator',
       sign: initiatorSign,
       port: 3004
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       lockPeriod: 5,
       role: 'responder',
@@ -821,13 +820,13 @@ describe('Channel', function () {
   it('can create a contract and accept', async () => {
     initiatorCh.disconnect()
     responderCh.disconnect()
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       port: 3005,
       sign: initiatorSign
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       role: 'responder',
       port: 3005,
@@ -1044,13 +1043,13 @@ describe('Channel', function () {
   it('can reconnect', async () => {
     initiatorCh.disconnect()
     responderCh.disconnect()
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       port: 3006,
       sign: initiatorSign
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       role: 'responder',
       port: 3006,
@@ -1067,7 +1066,7 @@ describe('Channel', function () {
     const channelId = await initiatorCh.id()
     const fsmId = initiatorCh.fsmId()
     initiatorCh.disconnect()
-    const ch = await Channel({
+    const ch = await BaseAe({
       url: sharedParams.url,
       host: sharedParams.host,
       port: 3006,
@@ -1103,13 +1102,13 @@ describe('Channel', function () {
 
     initiatorCh.disconnect()
     responderCh.disconnect()
-    initiatorCh = await Channel({
+    initiatorCh = await BaseAe({
       ...sharedParams,
       role: 'initiator',
       port: 3007,
       sign: initiatorSign
     })
-    responderCh = await Channel({
+    responderCh = await BaseAe({
       ...sharedParams,
       role: 'responder',
       port: 3007,
@@ -1143,13 +1142,13 @@ describe('Channel', function () {
     before(async function () {
       initiatorCh.disconnect()
       responderCh.disconnect()
-      initiatorCh = await Channel({
+      initiatorCh = await BaseAe({
         ...sharedParams,
         role: 'initiator',
         port: 3008,
         sign: initiatorSign
       })
-      responderCh = await Channel({
+      responderCh = await BaseAe({
         ...sharedParams,
         role: 'responder',
         port: 3008,


### PR DESCRIPTION
Fix #1132 

Solution: Import Channel stamp in the Universal stamp and update the `channel tests` with universal stamp instead of direct Channel stamp
