### PR TITLE
Modify default gas to a reasonable number and update docs with Gas estimation

### DIFF
--- a/docs/transaction-options.md
+++ b/docs/transaction-options.md
@@ -85,7 +85,7 @@ The following options are sepcific for each tx-type.
     - You can specify the denomination of the `amount` that will be provided to the contract related transaction.
 
 ## How to estimate gas?
-- As æpp developer, It is reasonable to estimate the gas consumption for a contract call using the dry-run feature of the node **once** and provide a specific offset (multiplied by 1.5 or 2) as default in the æpp to ensure that contract calls are mined. Depending on the logic of the contract the gas consumption of a specific contract call can vary and therefore you should monitor the gas consumption and increase the default for the respective contract call accordingly.
+- As æpp developer, it is reasonable to estimate the gas consumption for a contract call using the dry-run feature of the node **once** and provide a specific offset (e.g. multiplied by 1.5 or 2) as default in the æpp to ensure that contract calls are mined. Depending on the logic of the contract the gas consumption of a specific contract call can vary and therefore you should monitor the gas consumption and increase the default for the respective contract call accordingly over time.
 - The default `gas` value of `25000` covers trivial contract calls but, The recommended way is estimating the gas using the dry-run feature instead of relying on the default value.
 
 

--- a/docs/transaction-options.md
+++ b/docs/transaction-options.md
@@ -46,8 +46,8 @@ The following options are sepcific for each tx-type.
     - To be used for providing `aettos` (or `AE` with respective denomination) to a contract related transaction.
 - `denomination` (default: `aettos`)
     - You can specify the denomination of the `amount` that will be provided to the contract related transaction.
-- `gas` (default: `1600000 - 21000`)
-    - Max. amount of gas to be consumed by the transaction.
+- `gas` (default: `25000`)
+    - Max. amount of gas to be consumed by the transaction. Learn more on [How to estimate gas?](#how-to-estimate-gas)
 - `gasPrice` (default: `1e9`)
     - To increase chances to get your transaction included quickly you can use a higher gasPrice.
 
@@ -83,3 +83,9 @@ The following options are sepcific for each tx-type.
 ### SpendTx
 - `denomination` (default: `aettos`)
     - You can specify the denomination of the `amount` that will be provided to the contract related transaction.
+
+## How to estimate gas?
+- As æpp developer, It is reasonable to estimate the gas consumption for a contract call using the dry-run feature of the node **once** and provide a specific offset (multiplied by 1.5 or 2) as default in the æpp to ensure that contract calls are mined. Depending on the logic of the contract the gas consumption of a specific contract call can vary and therefore you should monitor the gas consumption and increase the default for the respective contract call accordingly.
+- The default `gas` value of `25000` covers trivial contract calls but, The recommended way is estimating the gas using the dry-run feature instead of relying on the default value.
+
+

--- a/docs/transaction-options.md
+++ b/docs/transaction-options.md
@@ -86,6 +86,6 @@ The following options are sepcific for each tx-type.
 
 ## How to estimate gas?
 - As æpp developer, it is reasonable to estimate the gas consumption for a contract call using the dry-run feature of the node **once** and provide a specific offset (e.g. multiplied by 1.5 or 2) as default in the æpp to ensure that contract calls are mined. Depending on the logic of the contract the gas consumption of a specific contract call can vary and therefore you should monitor the gas consumption and increase the default for the respective contract call accordingly over time.
-- The default `gas` value of `25000` covers trivial contract calls but, The recommended way is estimating the gas using the dry-run feature instead of relying on the default value.
+- The default `gas` value of `25000` should cover all trivial contract calls. In case transactions start running out of gas you should proceed the way described above and estimate the required gas using the dry-run feature.
 
 

--- a/src/tx/builder/schema.js
+++ b/src/tx/builder/schema.js
@@ -22,7 +22,7 @@ export const RESPONSE_TTL = { type: 'delta', value: 10 }
 // # CONTRACT
 export const DEPOSIT = 0
 export const AMOUNT = 0
-export const GAS = 1600000 - 21000
+export const GAS = 25000
 export const MIN_GAS_PRICE = 1e9
 export const MAX_AUTH_FUN_GAS = 50000
 export const DRY_RUN_ACCOUNT = { pub: 'ak_11111111111111111111111111111111273Yts', amount: '100000000000000000000000000000000000' }


### PR DESCRIPTION
Issue disucssion: Fix #1267 

Solution: Change default gas from ` 1600000 - 21000` to `25000`.  Discussion on the new value https://github.com/aeternity/aepp-sdk-js/issues/1267#issuecomment-909291108 

Updated the docs to reflect the changes. 