### PR TITLE
Fix AENS and Oracle delegation signature

### DIFF
--- a/docs/guides/aens.md
+++ b/docs/guides/aens.md
@@ -114,7 +114,7 @@ Note:
     - It's still possible to pass it as additional param, see [transaction options](../transaction-options.md#nameclaimtx).
 - In case the `claim` triggers an auction the required `nameFee` is locked by the protocol.
     - If you win the auction the `nameFee` is permanently deducted from your accounts balance and effectively *burned*.
-        - It will be credited to `ak_11111111111111111111111111111111273Yts` which nobody can access. This reduces the total supply of AE over time. 
+        - It will be credited to `ak_11111111111111111111111111111111273Yts` which nobody can access. This reduces the total supply of AE over time.
     - If somebody else outbids you the provided `nameFee` is immediately released and returned to your account.
 
 ### Bid during an auction
@@ -347,7 +347,7 @@ console.log(nameRevokeTx)
 Note:
 
 - On revocation the name enters in a `revoked` state.
-- After a timeout of `2016` keyblocks the name will be available for claiming again. 
+- After a timeout of `2016` keyblocks the name will be available for claiming again.
 
 ## Delegate signature to contract (AENS interface)
 It is possible to authorize a Sophia contract to manage an AENS name on behalf of your account. In order to achieve that you need to provide a delegation signature to the contract. The contract will then be able to use the [AENS interface](https://github.com/aeternity/aesophia/blob/v6.0.1/docs/sophia.md#aens-interface) and perform AENS related actions on behalf of your account.
@@ -363,20 +363,13 @@ const client = await Universal({ ... }) // init instance of Universal Stamp
 const contractId = 'ct_asd2ks...'
 // AENS name
 const name = 'example.chain'
+// Sign with a specific account
+const onAccount = await client.address()
 
 // this signature will allow the contract to perform a pre-claim on your behalf
-const sig = await client.delegateNamePreclaimSignature(contractId)
+const sig = await client.createAensDelegationSignature(contractId, { onAccount })
 
 // this signature will allow the contract to perform
 // any name related transaction for a specific name that you own
-const sig = await client.delegateNameClaimSignature(contractId, name)
+const sig = await client.createAensDelegationSignature(contractId, name, { onAccount })
 ```
-
-Note:
-
-- If required you can pass an additional options object like `{ onAccount: <account> }` to these functions in order to sign with a specific account.
-- The SDK currently also provides two other functions to generate a delegation signature:
-    - `delegateNameTransferSignature`
-    - `delegateNameRevokeSignature`
-- Both of these functions produce the same signature as `delegateNameClaimSignature` which can be confusing. There is an open issue that proposes to change that:
-    - https://github.com/aeternity/aepp-sdk-js/issues/1237

--- a/docs/guides/aens.md
+++ b/docs/guides/aens.md
@@ -367,9 +367,9 @@ const name = 'example.chain'
 const onAccount = await client.address()
 
 // this signature will allow the contract to perform a pre-claim on your behalf
-const sig = await client.createAensDelegationSignature(contractId, { onAccount })
+const preClaimSig = await client.createAensDelegationSignature({ contractId }, { onAccount })
 
 // this signature will allow the contract to perform
 // any name related transaction for a specific name that you own
-const sig = await client.createAensDelegationSignature(contractId, name, { onAccount })
+const aensDelegationSig = await client.createAensDelegationSignature({ contractId, name }, { onAccount })
 ```

--- a/src/ae/contract.js
+++ b/src/ae/contract.js
@@ -307,6 +307,15 @@ async function delegateSignatureCommon (ids = [], opt = {}) {
  * @param {String} [name] The name
  * @param {{ onAccount: String | Object }} [opt={}] opt Options
  * @return {Promise<String>} Signature for delegation
+ * @example
+ * const client = await Universal({ ... })
+ * const contractId = 'ct_asd2ks...' // contract address
+ * const name = 'example.chain' // AENS name
+ * const onAccount = await client.address() Sign with a specific account
+ * // Preclaim signature
+ * const preclaimSig = await client.createAensDelegationSignature(contractId, { onAccount: current })
+ * // Claim, transfer and revoke signature
+ * const sig = await contract.createAensDelegationSignature(contractAddress, name, { onAccount: current })
  */
 async function createAensDelegationSignature (contractId, name, opt = {}) {
   return (typeof name === 'string')

--- a/src/ae/contract.js
+++ b/src/ae/contract.js
@@ -311,56 +311,41 @@ async function delegateSignatureCommon (ids = [], opt = {}) {
  * const client = await Universal({ ... })
  * const contractId = 'ct_asd2ks...' // contract address
  * const name = 'example.chain' // AENS name
- * const onAccount = await client.address() Sign with a specific account
+ * const onAccount = await client.address() // Sign with a specific account
  * // Preclaim signature
- * const preclaimSig = await client.createAensDelegationSignature(contractId, { onAccount: current })
+ * const params = { contractId }
+ * const preclaimSig = await client.createAensDelegationSignature(params, { onAccount: current })
  * // Claim, transfer and revoke signature
- * const sig = await contract.createAensDelegationSignature(contractAddress, name, { onAccount: current })
+ * const params = { contractId, name }
+ * const aensDelegationSig = await contract.createAensDelegationSignature(params, name, { onAccount: current })
  */
-async function createAensDelegationSignature (contractId, name, opt = {}) {
-  return (typeof name === 'string')
-    ? this.delegateSignatureCommon([produceNameId(name), contractId], opt)
-    : this.delegateSignatureCommon([contractId], opt)
+async function createAensDelegationSignature ({ contractId, name }, opt = {}) {
+  return this.delegateSignatureCommon([...name ? [produceNameId(name)] : [], contractId], opt)
 }
 
 /**
- * Helper to generate a signature to delegate a Oracle register to a contract.
+ * Helper to generate a signature to delegate register/extend/respond of a Oracle to a contract.
  * @function
  * @alias module:@aeternity/aepp-sdk/es/ae/contract
  * @category async
  * @param {String} contractId Contract Id
+ * @param {String} [queryId] Oracle Query Id
  * @param {{ onAccount: String | Object }} [opt={}] opt Options
  * @return {Promise<String>} Signature for delegation
+ * @example
+ * const client = await Universal({ ... })
+ * const contractId = 'ct_asd2ks...' // contract address
+ * const queryId = 'oq_...' // Oracle Query Id
+ * const onAccount = await client.address() // Sign with a specific account
+ * // Oracle register and extend signature
+ * const params = { contractId }
+ * const oracleDelegationSig = await contract.createOracleDelegationSignature(params, { onAccount })
+ * // Oracle respond signature
+ * const params = { contractId, queryId }
+ * const respondSig = await contract.createOracleDelegationSignature(params, queryId)
  */
-async function delegateOracleRegisterSignature (contractId, opt = {}) {
-  return this.delegateSignatureCommon([contractId], opt)
-}
-
-/**
- * Helper to generate a signature to delegate a Oracle extend to a contract.
- * @function
- * @alias module:@aeternity/aepp-sdk/es/ae/contract
- * @category async
- * @param {String} contractId Contract Id
- * @param {{ onAccount: String | Object }} [opt={}] opt Options
- * @return {Promise<String>} Signature for delegation
- */
-async function delegateOracleExtendSignature (contractId, opt = {}) {
-  return this.delegateSignatureCommon([contractId], opt)
-}
-
-/**
- * Helper to generate a signature to delegate a Oracle respond to a contract.
- * @function
- * @alias module:@aeternity/aepp-sdk/es/ae/contract
- * @category async
- * @param {String} queryId Oracle Query Id
- * @param {String} contractId Contract Id
- * @param {{ onAccount: String | Object }} [opt={}] opt Options
- * @return {Promise<String>} Signature for delegation
- */
-async function delegateOracleRespondSignature (queryId, contractId, opt = {}) {
-  return this.delegateSignatureCommon([queryId, contractId], opt)
+async function createOracleDelegationSignature ({ contractId, queryId }, opt = {}) {
+  return this.delegateSignatureCommon([...queryId ? [queryId] : [], contractId], opt)
 }
 
 /**
@@ -408,9 +393,7 @@ export const ContractAPI = Ae.compose(ContractBase, {
     // AENS
     createAensDelegationSignature,
     // Oracle
-    delegateOracleRegisterSignature,
-    delegateOracleExtendSignature,
-    delegateOracleRespondSignature
+    createOracleDelegationSignature
   },
   deepProps: {
     Ae: {

--- a/src/ae/contract.js
+++ b/src/ae/contract.js
@@ -290,7 +290,7 @@ async function delegateSignatureCommon (ids = [], opt = {}) {
     Buffer.concat(
       [
         Buffer.from(this.getNetworkId(opt)),
-        decode(await this.address(opt)),
+        ...(Object.prototype.hasOwnProperty.call(opt, 'onAccount') ? [decode(await this.address(opt))] : []),
         ...ids.map(e => decode(e))
       ]
     ),

--- a/src/ae/contract.js
+++ b/src/ae/contract.js
@@ -299,58 +299,19 @@ async function delegateSignatureCommon (ids = [], opt = {}) {
 }
 
 /**
- * Helper to generate a signature to delegate a name pre-claim to a contract.
+ * Helper to generate a signature to delegate pre-claim/claim/transfer/revoke of a name to a contract.
  * @function
  * @alias module:@aeternity/aepp-sdk/es/ae/contract
  * @category async
  * @param {String} contractId Contract Id
+ * @param {String} [name] The name
  * @param {{ onAccount: String | Object }} [opt={}] opt Options
  * @return {Promise<String>} Signature for delegation
  */
-async function delegateNamePreclaimSignature (contractId, opt = {}) {
-  return this.delegateSignatureCommon([contractId], opt)
-}
-
-/**
- * Helper to generate a signature to delegate a name claim to a contract.
- * @function
- * @alias module:@aeternity/aepp-sdk/es/ae/contract
- * @category async
- * @param {String} name The name being claimed
- * @param {String} contractId Contract Id
- * @param {{ onAccount: String | Object }} [opt={}] opt Options
- * @return {Promise<String>} Signature for delegation
- */
-async function delegateNameClaimSignature (contractId, name, opt = {}) {
-  return this.delegateSignatureCommon([produceNameId(name), contractId], opt)
-}
-
-/**
- * Helper to generate a signature to delegate a name transfer to a contract.
- * @function
- * @alias module:@aeternity/aepp-sdk/es/ae/contract
- * @category async
- * @param {String} contractId Contract Id
- * @param {String} name The name being transferred
- * @param {{ onAccount: String | Object }} [opt={}] opt Options
- * @return {Promise<String>} Signature for delegation
- */
-async function delegateNameTransferSignature (contractId, name, opt = {}) {
-  return this.delegateSignatureCommon([produceNameId(name), contractId], opt)
-}
-
-/**
- * Helper to generate a signature to delegate a name revoke to a contract.
- * @function
- * @alias module:@aeternity/aepp-sdk/es/ae/contract
- * @category async
- * @param {String} contractId Contract Id
- * @param {String} name The name being revoked
- * @param {{ onAccount: String | Object }} [opt={}] opt Options
- * @return {Promise<String>} Signature for delegation
- */
-async function delegateNameRevokeSignature (contractId, name, opt = {}) {
-  return this.delegateSignatureCommon([produceNameId(name), contractId], opt)
+async function createAensDelegationSignature (contractId, name, opt = {}) {
+  return (typeof name === 'string')
+    ? this.delegateSignatureCommon([produceNameId(name), contractId], opt)
+    : this.delegateSignatureCommon([contractId], opt)
 }
 
 /**
@@ -434,12 +395,9 @@ export const ContractAPI = Ae.compose(ContractBase, {
     _handleCallError,
     _sendAndProcess,
     // Delegation for contract
-    // AENS
     delegateSignatureCommon,
-    delegateNamePreclaimSignature,
-    delegateNameClaimSignature,
-    delegateNameTransferSignature,
-    delegateNameRevokeSignature,
+    // AENS
+    createAensDelegationSignature,
     // Oracle
     delegateOracleRegisterSignature,
     delegateOracleExtendSignature,

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -217,26 +217,26 @@ describe('Contract', function () {
       const { salt: _salt } = await contract.aensPreclaim(name)
       // @TODO enable after next HF
       // const commitmentId = commitmentHash(name, _salt)
-      const preclaimSig = await contract.delegateNamePreclaimSignature(contractAddress, { onAccount: current })
+      const preclaimSig = await contract.createAensDelegationSignature(contractAddress, { onAccount: current })
       console.log(`preclaimSig -> ${preclaimSig}`)
       // const preclaim = await cInstance.methods.signedPreclaim(await contract.address(), commitmentId, preclaimSig)
       // preclaim.result.returnType.should.be.equal('ok')
       await contract.awaitHeight((await contract.height()) + 2)
       // claim
-      const claimSig = await contract.delegateNameClaimSignature(contractAddress, name, { onAccount: current })
+      const claimSig = await contract.createAensDelegationSignature(contractAddress, name, { onAccount: current })
       const claim = await cInstance.methods.signedClaim(await contract.address(), name, _salt, nameFee, claimSig)
       claim.result.returnType.should.be.equal('ok')
       await contract.awaitHeight((await contract.height()) + 2)
 
       // transfer
-      const transferSig = await contract.delegateNameTransferSignature(contractAddress, name, { onAccount: current })
+      const transferSig = await contract.createAensDelegationSignature(contractAddress, name, { onAccount: current })
       const onAccount = contract.addresses().find(acc => acc !== current)
       const transfer = await cInstance.methods.signedTransfer(await contract.address(), onAccount, name, transferSig)
       transfer.result.returnType.should.be.equal('ok')
 
       await contract.awaitHeight((await contract.height()) + 2)
       // revoke
-      const revokeSig = await contract.delegateNameRevokeSignature(contractAddress, name, { onAccount })
+      const revokeSig = await contract.createAensDelegationSignature(contractAddress, name, { onAccount })
       const revoke = await cInstance.methods.signedRevoke(onAccount, name, revokeSig)
       revoke.result.returnType.should.be.equal('ok')
 

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -217,19 +217,19 @@ describe('Contract', function () {
       const { salt: _salt } = await contract.aensPreclaim(name)
       // @TODO enable after next HF
       // const commitmentId = commitmentHash(name, _salt)
-      const preclaimSig = await contract.delegateNamePreclaimSignature(contractAddress)
+      const preclaimSig = await contract.delegateNamePreclaimSignature(contractAddress, { onAccount: current })
       console.log(`preclaimSig -> ${preclaimSig}`)
       // const preclaim = await cInstance.methods.signedPreclaim(await contract.address(), commitmentId, preclaimSig)
       // preclaim.result.returnType.should.be.equal('ok')
       await contract.awaitHeight((await contract.height()) + 2)
       // claim
-      const claimSig = await contract.delegateNameClaimSignature(contractAddress, name)
+      const claimSig = await contract.delegateNameClaimSignature(contractAddress, name, { onAccount: current })
       const claim = await cInstance.methods.signedClaim(await contract.address(), name, _salt, nameFee, claimSig)
       claim.result.returnType.should.be.equal('ok')
       await contract.awaitHeight((await contract.height()) + 2)
 
       // transfer
-      const transferSig = await contract.delegateNameTransferSignature(contractAddress, name)
+      const transferSig = await contract.delegateNameTransferSignature(contractAddress, name, { onAccount: current })
       const onAccount = contract.addresses().find(acc => acc !== current)
       const transfer = await cInstance.methods.signedTransfer(await contract.address(), onAccount, name, transferSig)
       transfer.result.returnType.should.be.equal('ok')

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -267,25 +267,24 @@ describe('Contract', function () {
       console.log(oracleExtended)
       oracleExtended.ttl.should.be.equal(oracle.ttl + 50)
 
-      // TODO ask core about this
-      // // create query
-      // const q = 'Hello!'
-      // const newOracle = await contract.registerOracle('string', 'int', { onAccount, queryFee: qFee })
-      // const query = await cInstanceOracle.methods.createQuery(newOracle.id, q, 1000 + qFee, ttl, ttl, { onAccount, amount: 5 * qFee })
-      // query.should.be.an('object')
-      // const queryObject = await contract.getQueryObject(newOracle.id, query.decodedResult)
-      // queryObject.should.be.an('object')
-      // queryObject.decodedQuery.should.be.equal(q)
-      // console.log(queryObject)
-      //
-      // // respond to query
-      // const r = 'Hi!'
-      // const respondSig = await contract.delegateOracleRespondSignature(newOracle.id, queryObject.id, contractAddress, { onAccount })
-      // const response = await cInstanceOracle.methods.respond(newOracle.id, queryObject.id, respondSig, r, { onAccount })
-      // console.log(response)
-      // const queryObject2 = await contract.getQueryObject(newOracle.id, queryObject.id)
-      // console.log(queryObject2)
-      // queryObject2.decodedResponse.should.be.equal(r)
+      // create query
+      const q = 'Hello!'
+      const newOracle = await contract.registerOracle('string', 'int', { queryFee: qFee })
+      const query = await cInstanceOracle.methods.createQuery(newOracle.id, q, 1000 + qFee, ttl, ttl, { onAccount, amount: 5 * qFee })
+      query.should.be.an('object')
+      const queryObject = await contract.getQueryObject(newOracle.id, query.decodedResult)
+      queryObject.should.be.an('object')
+      queryObject.decodedQuery.should.be.equal(q)
+      console.log(queryObject)
+
+      // respond to query
+      const r = 'Hi!'
+      const respondSig = await contract.delegateOracleRespondSignature(queryObject.id, contractAddress)
+      const response = await cInstanceOracle.methods.respond(newOracle.id, queryObject.id, respondSig, r, { onAccount })
+      console.log(response)
+      const queryObject2 = await contract.getQueryObject(newOracle.id, queryObject.id)
+      console.log(queryObject2)
+      queryObject2.decodedResponse.should.be.equal(r)
     })
   })
   it('precompiled bytecode can be deployed', async () => {

--- a/test/integration/oracle.js
+++ b/test/integration/oracle.js
@@ -17,16 +17,20 @@
 
 import { describe, it, before } from 'mocha'
 import { getSdk } from './'
-import { encodeBase64Check } from '../../src/utils/crypto'
+import { encodeBase64Check, generateKeyPair } from '../../src/utils/crypto'
+import MemoryAccount from '../../src/account/memory'
 
 describe('Oracle', function () {
   let client
   let oracle
   let query
   const queryResponse = "{'tmp': 30}"
+  const account = generateKeyPair()
 
   before(async function () {
     client = await getSdk()
+    await client.spend('1' + '0'.repeat(20), account.publicKey)
+    client.addAccount(MemoryAccount({ keypair: account }), { select: true })
   })
 
   it('Register Oracle with 5000 TTL', async () => {


### PR DESCRIPTION
Oracle delegation signature issue: #1242 
Aens delegation signature issue: #1237 


Design & solution: All the AENS and Oracle delegation methods use the common method `delegateSignatureCommon` for signing. The common method used to include the address for signing even if the `onAccount` is not set in the options.  Hence the solution is to modify the common method to use the address for signing only if the `onAccount` key exists in the options.

This will resolve @marc0olo comment https://github.com/aeternity/aepp-sdk-js/issues/1242#issuecomment-918335331 on `delegateOracleRespondSignature`

Further updates on the changes:
* Javascript doesn't support function overloading. The new approach is `Accept params as Object` to merge the common signature delegation methods
* Update AENS & Oracle documentation
* Update AENS and Oracle delegation tests to incorporate new implementation
* Use a different account in Oracle tests to overcome the register oracle conflict over an account






