### PR TITLE
docs: remove token wording for AE

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -21,8 +21,8 @@ import {
   console.log(`Public key: ${keypair.publicKey}`)
 ```
 
-## 3. Get some _AE_ tokens using the Faucet
-To receive some _AE_ you can use the [Faucet](https://faucet.aepps.com/). Just add your publicKey, and you'll immediately get some test tokens.
+## 3. Get some _AE_ using the Faucet
+To receive some _AE_ you can use the [Faucet](https://faucet.aepps.com/). Just add your publicKey, and you'll immediately get some test coins.
 
 ## 4. Interact with the æternity blockchain
 This example shows:

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,5 +14,5 @@ Create a [new issue](https://github.com/aeternity/aepp-sdk-js/issues/new) to sug
 
 ## NodeJS
 1. [Contract interaction](node/contract-interaction.js)
-2. [Transfer AE Tokens](node/transfer-ae-tokens.js)
+2. [Transfer AE](node/transfer-ae.js)
 3. [PayingForTx](node/paying-for-tx.js)

--- a/examples/node/contract-interaction.js
+++ b/examples/node/contract-interaction.js
@@ -55,7 +55,7 @@ const COMPILER_URL = 'https://compiler.aepps.com';
 //
 //  - The keypair of the account is pre-funded and only used for demonstration purpose
 //      - You should replace it with your own keypair (see [Create a Keypair](../../quick-start.md#2-create-a-keypair))
-//  - In case the account runs out of funds you can request new AE tokens using the [Faucet](https://faucet.aepps.com/)
+//  - In case the account runs out of funds you can always request AE using the [Faucet](https://faucet.aepps.com/)
 
 // ## 3. Open async codeblock
 // Most functions of the SDK return _Promises_, so the recommended way of

--- a/examples/node/paying-for-tx-contract-call-tx.js
+++ b/examples/node/paying-for-tx-contract-call-tx.js
@@ -31,7 +31,7 @@
 //
 // ### UseCases
 // This functionality allows **every service** to let their users interact with their
-// decentralized aepp without having them to buy AE tokens by covering their fees.
+// decentralized aepp without having them to buy AE by covering their fees.
 //
 // Examples:
 //
@@ -81,7 +81,7 @@ const NEW_USER_KEYPAIR = Crypto.generateKeyPair();
 //
 //  - The keypair of the account is pre-funded and only used for demonstration purpose
 //      - You can replace it with your own keypair (see [Create a Keypair](../../quick-start.md#2-create-a-keypair))
-//      - In case the account runs out of funds you can request new AE tokens using the [Faucet](https://faucet.aepps.com/)
+//      - In case the account runs out of funds you can always request AE using the [Faucet](https://faucet.aepps.com/)
 //  - The contract is already deployed at the defined address.
 //  - The `NEW_USER_KEYPAIR` is used to call the contract. The `PayingForTx` allows the new user to perform a contract call without having any funds.
 

--- a/examples/node/paying-for-tx-spend-tx.js
+++ b/examples/node/paying-for-tx-spend-tx.js
@@ -52,7 +52,7 @@ const AMOUNT = 1;
 //
 //  - The keypair of the account is pre-funded and only used for demonstration purpose
 //      - You can replace it with your own keypair (see [Create a Keypair](../../quick-start.md#2-create-a-keypair))
-//      - In case the account runs out of funds you can request new AE tokens using the [Faucet](https://faucet.aepps.com/)
+//      - In case the account runs out of funds you can always request AE using the [Faucet](https://faucet.aepps.com/)
 //  - The `AMOUNT` (in `aettos`) will be send to the new user and returned to the payer.
 
 // ## 3. Open async codeblock

--- a/examples/node/transfer-ae.js
+++ b/examples/node/transfer-ae.js
@@ -16,14 +16,14 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 
-// # Transfer AE tokens
+// # Transfer AE
 //
 // ## Introduction
-// The whole script is [located in the repository](https://github.com/aeternity/aepp-sdk-js/blob/master/examples/node/transfer-ae-tokens.js)
+// The whole script is [located in the repository](https://github.com/aeternity/aepp-sdk-js/blob/master/examples/node/transfer-ae.js)
 // and this page explains in detail how to:
 //
 //  - initialize the SDK with a pre-funded account
-//  - transfer AE tokens to another account
+//  - transfer AE to another account
 
 // ## 1. Specify imports
 // You need to import `Universal`, `Node` and `MemoryAccount` [Stamps](https://stampit.js.org/essentials/what-is-a-stamp) from the SDK.
@@ -46,10 +46,10 @@ const [amount = 1, recipient = ACCOUNT_KEYPAIR.publicKey] = process.argv.slice(2
 //
 //  - The keypair of the account is pre-funded and only used for demonstration purpose
 //      - You should replace it with your own keypair (see [Create a Keypair](../../quick-start.md#2-create-a-keypair))
-//  - In case the account runs out of funds you can request new AE tokens using the [Faucet](https://faucet.aepps.com/)
+//  - In case the account runs out of funds you can always request AE using the [Faucet](https://faucet.aepps.com/)
 //  - By default the script will transfer `1 aetto` and use the demo account itself as recipient
 //      - Optionally you can provide the amount and a different recipient by providing the arguments when executing the script,
-//        e.g. `node transfer-ae-tokens.js 3 ak_6D2uyunJaERXfgbsc94G8vrp79nZrbtorL7VCRXk3sWiFK5jb`
+//        e.g. `node transfer-ae.js 3 ak_6D2uyunJaERXfgbsc94G8vrp79nZrbtorL7VCRXk3sWiFK5jb`
 
 // ## 3. Open async codeblock
 // Most functions of the SDK return _Promises_, so the recommended way of
@@ -78,7 +78,7 @@ const [amount = 1, recipient = ACCOUNT_KEYPAIR.publicKey] = process.argv.slice(2
   const balanceBefore = await client.getBalance(recipient)
   console.log(`Balance of ${recipient} (before): ${balanceBefore} aettos`)
 
-  // ## 6. Transfer AE tokens
+  // ## 6. Transfer AE
   // Calling the `spend` function will create, sign and broadcast a `SpendTx` to the network.
   const tx = await client.spend(amount, recipient)
   console.log('Transaction mined', tx)


### PR DESCRIPTION
to be consistent we remove the token wording for AE in every place