### PR TITLE
docs: quickstart height variable

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -47,7 +47,7 @@ const account = MemoryAccount({
      accounts: [ account ]
   })
 
-  await client.height() // get top block height
+  const height = await client.height() // get top block height
   console.log('Current Block Height:', height)
 
   // spend one AE


### PR DESCRIPTION
Declares `height` variable used in `console.log('Current Block Height:', height)`
