### PR TITLE
fix(swagger): detection of empty response

### DIFF
--- a/src/utils/swagger.js
+++ b/src/utils/swagger.js
@@ -66,7 +66,7 @@ export default async (
       url,
       spec,
       responseInterceptor: response => {
-        if (!response.text) return response
+        if (response.text === '' || response.text?.size === 0) return response
         const body = jsonImp.parse(response.text)
         Object.assign(response, {
           body: disableCaseConversion ? body : pascalizeKeys(body)


### PR DESCRIPTION
https://github.com/swagger-api/swagger-js/blob/e5788a8d1233b6cbbc0821d43392393c5a6ec607/src/http/index.js#L112-L114

- node may return 404 error with the empty body and without content-type when requesting `/v3/dry-run`
- swagger-client is unsure about content type and returns the response as Blob instead of string
- our check in `responseInterceptor` fails and sdk tries to parse Blob as JSON that makes unclear errors like:

```
{
  name: 'SyntaxError',
  message: "Unexpected 'o'",
  at: 2,
  text: '[object Blob]'
}
```

closes #1340