### PR TITLE
test(integration): revert exit flag to speedup tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "commitlint --from 635f1aa --verbose && eslint .",
     "test": "nyc --require @babel/register --require ts-node/register mocha './test/unit/' './test/integration/' --recursive --exit --timeout 40s",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
-    "test:integration": "nyc --require @babel/register --require ts-node/register mocha './test/integration/*' --timeout 40s",
+    "test:integration": "nyc --require @babel/register --require ts-node/register mocha './test/integration/*' --exit --timeout 40s",
     "test:unit": "nyc --require @babel/register --require ts-node/register mocha './test/unit/*'",
     "test:watch": "mocha --recursive --require @babel/register --require ts-node/register --watch --timeout 40s",
     "prepare": "npm run build",


### PR DESCRIPTION
channel tests doesn't stop by themself without `exit` flag, I have accidentally removed it in https://github.com/aeternity/aepp-sdk-js/commit/bf15c1e07980c34b0197dd65b118ba39c3ee3fee#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R22