### PR TITLE
feat(package): build es version compatible with node

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -4,7 +4,6 @@
     "@babel/preset-typescript"
   ],
   "plugins": [
-    ["@babel/plugin-transform-runtime", { "corejs": 3 }],
-    "ramda"
+    ["@babel/plugin-transform-runtime", { "corejs": 3 }]
   ]
 }

--- a/babel.esm.config.js
+++ b/babel.esm.config.js
@@ -1,5 +1,7 @@
 const config = require('./babel.config.json')
 
 config.presets[0] = ['@babel/preset-env', { modules: false }]
+config.plugins.push(['add-import-extension', { extension: 'mjs' }])
+config.plugins.push('transform-default-named-imports')
 
 module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "@typescript-eslint/eslint-plugin": "^5.3.1",
         "@typescript-eslint/parser": "^5.3.1",
         "babel-loader": "^8.2.3",
+        "babel-plugin-add-import-extension": "^1.6.0",
+        "babel-plugin-transform-default-named-imports": "^1.2.1",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "codecov": "^3.8.3",
@@ -3565,6 +3567,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0"
+      }
+    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -3611,6 +3625,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-transform-default-named-imports": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-default-named-imports/-/babel-plugin-transform-default-named-imports-1.2.1.tgz",
+      "integrity": "sha512-pzb0NH6wIRI1if19IXk9T0iOE5jZiyjj052+qrYh1ztvbV8gMUdTELNmsIOsQR/le8YK2578JK2boxJSTyj/Ng==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "webpack-node-module-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 12.x"
       }
     },
     "node_modules/balanced-match": {
@@ -12044,6 +12072,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/webpack-node-module-types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-node-module-types/-/webpack-node-module-types-1.2.1.tgz",
+      "integrity": "sha512-NNetNoIaw43KTurHH2y5K9hZgVnYz2Dgh25grsA5CukBslnWD6g9IWkTl0OlzEOh11CtL3V01y18GJsmqq5DRA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.x"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
@@ -15018,6 +15055,15 @@
         }
       }
     },
+    "babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -15055,6 +15101,17 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.0"
+      }
+    },
+    "babel-plugin-transform-default-named-imports": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-default-named-imports/-/babel-plugin-transform-default-named-imports-1.2.1.tgz",
+      "integrity": "sha512-pzb0NH6wIRI1if19IXk9T0iOE5jZiyjj052+qrYh1ztvbV8gMUdTELNmsIOsQR/le8YK2578JK2boxJSTyj/Ng==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "webpack-node-module-types": "^1.2.1"
       }
     },
     "balanced-match": {
@@ -21513,6 +21570,12 @@
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
       }
+    },
+    "webpack-node-module-types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-node-module-types/-/webpack-node-module-types-1.2.1.tgz",
+      "integrity": "sha512-NNetNoIaw43KTurHH2y5K9hZgVnYz2Dgh25grsA5CukBslnWD6g9IWkTl0OlzEOh11CtL3V01y18GJsmqq5DRA==",
+      "dev": true
     },
     "webpack-sources": {
       "version": "3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "buffer": "^6.0.3",
         "cross-fetch": "^3.1.4",
         "crypto-browserify": "^3.12.0",
-        "ed2curve": "^0.3.0",
         "events": "^3.3.0",
         "libsodium-wrappers-sumo": "^0.7.9",
         "path-browserify": "^1.0.1",
@@ -55,7 +54,6 @@
         "@typescript-eslint/eslint-plugin": "^5.3.1",
         "@typescript-eslint/parser": "^5.3.1",
         "babel-loader": "^8.2.3",
-        "babel-plugin-ramda": "^2.0.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "codecov": "^3.8.3",
@@ -3615,16 +3613,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-plugin-ramda": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ramda/-/babel-plugin-ramda-2.0.0.tgz",
-      "integrity": "sha512-PZ/6fmNGshCU7Vt33JRWDDSQqZxOsav1DztZ+VBJFOamE3spyoKuIL9Ve0FQd/oXGlH5jHf/WrpCSGn0MR+YVw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "ramda": "*"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5251,14 +5239,6 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
-    },
-    "node_modules/ed2curve": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
-      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
-      "dependencies": {
-        "tweetnacl": "1.x.x"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.7",
@@ -15075,16 +15055,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.0"
-      }
-    },
-    "babel-plugin-ramda": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ramda/-/babel-plugin-ramda-2.0.0.tgz",
-      "integrity": "sha512-PZ/6fmNGshCU7Vt33JRWDDSQqZxOsav1DztZ+VBJFOamE3spyoKuIL9Ve0FQd/oXGlH5jHf/WrpCSGn0MR+YVw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "ramda": "*"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
     "babel-loader": "^8.2.3",
-    "babel-plugin-ramda": "^2.0.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "types": "es/index.d.ts",
-  "module": "es/index.js",
+  "module": "es/index.mjs",
   "browser": {
     "dist/aepp-sdk.js": "./dist/aepp-sdk.browser.js"
   },
   "sideEffects": false,
   "scripts": {
-    "build:es": "tsc && babel src --config-file ./babel.esm.config.js --out-dir es --extensions '.js,.ts' --source-maps true",
+    "build:es": "tsc && babel src --config-file ./babel.esm.config.js --out-dir es --extensions '.js,.ts' --out-file-extension .mjs --source-maps true",
     "build": "webpack --mode=production && npm run build:es",
     "build:dev": "webpack --mode=development && npm run build:es",
     "docs:examples": "node tooling/docs/examples-to-md.js examples/node/*.js",
@@ -83,6 +83,8 @@
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
     "babel-loader": "^8.2.3",
+    "babel-plugin-add-import-extension": "^1.6.0",
+    "babel-plugin-transform-default-named-imports": "^1.2.1",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.8.3",

--- a/src/contract/aci/index.js
+++ b/src/contract/aci/index.js
@@ -22,7 +22,7 @@
  * @export getContractInstance
  */
 
-import * as R from 'ramda'
+import { defaultTo, prop, path } from 'ramda'
 import { Encoder as Calldata } from '@aeternity/aepp-calldata'
 import { decodeEvents } from './transformation'
 import { DRY_RUN_ACCOUNT, DEPOSIT } from '../../tx/builder/schema'
@@ -105,8 +105,8 @@ export default async function getContractInstance ({
   }
 
   const instance = {
-    interface: R.defaultTo(null, R.prop('interface', aci)),
-    aci: R.defaultTo(null, R.path(['encoded_aci', 'contract'], aci)),
+    interface: defaultTo(null, prop('interface', aci)),
+    aci: defaultTo(null, path(['encoded_aci', 'contract'], aci)),
     calldata: new Calldata([aci.encoded_aci, ...aci.external_encoded_aci]),
     externalAci: (aci.external_encoded_aci ?? []).map(a => a.contract || a.namespace),
     source,

--- a/src/tx/builder/helpers.js
+++ b/src/tx/builder/helpers.js
@@ -1,4 +1,4 @@
-import * as R from 'ramda'
+import { cond, lt, always, lte, T } from 'ramda'
 import BigNumber from 'bignumber.js'
 
 import {
@@ -343,11 +343,11 @@ export function computeBidFee (domain, startFee = NAME_FEE, increment = NAME_FEE
  * @return {String} Auction end height
  */
 export function computeAuctionEndBlock (domain, claimHeight) {
-  return R.cond([
-    [R.lt(5), R.always(NAME_BID_TIMEOUTS[4].plus(claimHeight))],
-    [R.lt(9), R.always(NAME_BID_TIMEOUTS[8].plus(claimHeight))],
-    [R.lte(NAME_BID_MAX_LENGTH), R.always(NAME_BID_TIMEOUTS[12].plus(claimHeight))],
-    [R.T, R.always(BigNumber(claimHeight))]
+  return cond([
+    [lt(5), always(NAME_BID_TIMEOUTS[4].plus(claimHeight))],
+    [lt(9), always(NAME_BID_TIMEOUTS[8].plus(claimHeight))],
+    [lte(NAME_BID_MAX_LENGTH), always(NAME_BID_TIMEOUTS[12].plus(claimHeight))],
+    [T, always(BigNumber(claimHeight))]
   ])(domain.replace('.chain', '').length).toString(10)
 }
 

--- a/src/utils/async-init.js
+++ b/src/utils/async-init.js
@@ -16,7 +16,7 @@
  */
 
 import stampit from '@stamp/it'
-import * as R from 'ramda'
+import { without, uniqWith, identical, flatten, path } from 'ramda'
 
 function asyncInit (options = {}, { stamp, args, instance }) {
   return stamp.compose.deepConfiguration.AsyncInit.initializers.reduce(async (instance, init) => {
@@ -33,7 +33,17 @@ const AsyncInit = stampit({
   deepConf: { AsyncInit: { initializers: [] } },
   composers ({ stamp, composables }) {
     const conf = stamp.compose.deepConfiguration.AsyncInit
-    conf.initializers = R.without([asyncInit], R.uniqWith(R.identical, R.flatten(composables.map(c => R.path(['compose', 'deepConfiguration', 'AsyncInit', 'initializers'], c) || (c.compose || c).initializers || []))))
+    conf.initializers = without(
+      [asyncInit],
+      uniqWith(
+        identical,
+        flatten(
+          composables.map(c =>
+            path(['compose', 'deepConfiguration', 'AsyncInit', 'initializers'], c) ||
+            (c.compose || c).initializers ||
+            []))
+      )
+    )
     stamp.compose.initializers = [asyncInit]
   }
 })

--- a/src/utils/keystore.js
+++ b/src/utils/keystore.js
@@ -1,6 +1,6 @@
 import nacl from 'tweetnacl'
 import { v4 as uuid } from 'uuid'
-
+import sodium from 'libsodium-wrappers-sumo'
 import { encodeBase58Check } from './crypto'
 import { str2buf } from './bytes'
 import {
@@ -10,8 +10,6 @@ import {
   UnsupportedKdfError,
   InvalidPasswordError
 } from './errors'
-
-const _sodium = require('libsodium-wrappers-sumo')
 
 /**
  * KeyStore module
@@ -42,20 +40,16 @@ export async function deriveKeyUsingArgon2id (password, salt, options) {
   const { memlimit_kib: memoryCost, opslimit: timeCost } = options.kdf_params
   // const isBrowser = !(typeof module !== 'undefined' && module.exports)
 
-  return _sodium.ready.then(async () => {
-    // tslint:disable-next-line:typedef
-    const sodium = _sodium
-
-    const result = sodium.crypto_pwhash(
-      32,
-      password,
-      salt,
-      timeCost,
-      memoryCost * 1024,
-      sodium.crypto_pwhash_ALG_ARGON2ID13
-    )
-    return Buffer.from(result)
-  })
+  await sodium.ready
+  const result = sodium.crypto_pwhash(
+    32,
+    password,
+    salt,
+    timeCost,
+    memoryCost * 1024,
+    sodium.crypto_pwhash_ALG_ARGON2ID13
+  )
+  return Buffer.from(result)
 }
 
 // CRYPTO PART


### PR DESCRIPTION
depends on #1369 (needed for cli)

So, after this would be possible to do:
```js
import { Crypto } from '@aeternity/aepp-sdk/es/index.mjs'

console.log(Crypto.generateKeyPair())
```
and execute it using plain node:
```
$ node test.mjs
{
  publicKey: 'ak_jnZsCzXTKdGDkdvSpExo46GwuWGv84CkzcvEtd6XdV98gLjd8',
  secretKey: 'cb8556c8ff170c0075c3a8bdfa0343c83782e1ccbca0e7842a0caaee92c10fce61266723868d53aab664039e4088d72df242a1510f2bab2e9c67dbeb768ac1ad'
}
$ node --version                                            
v16.13.0
```