### PR TITLE
feat(swagger): converts operationId in snake case to pascal

### DIFF
--- a/src/utils/swagger.js
+++ b/src/utils/swagger.js
@@ -26,6 +26,7 @@ import fetch from 'cross-fetch'
 import JsonBig from './json-big'
 import { snakizeKeys, pascalizeKeys, mapObject, filterObject } from './other'
 import { SwaggerError } from './errors'
+import { snakeToPascal } from './string'
 
 let warnedAboutInternalApiUsage = false
 
@@ -98,7 +99,7 @@ export default async (
     .reduce((acc, n) => ({ ...acc, [n.operationId]: n }), {})
 
   const api = mapObject(combinedApi, ([opId, handler]) => [
-    opId.slice(0, 1).toLowerCase() + opId.slice(1),
+    opId.slice(0, 1).toLowerCase() + snakeToPascal(opId.slice(1)),
     async (...args) => {
       const opSpec = opSpecs[opId]
       const parameters = [

--- a/test/unit/swagger.js
+++ b/test/unit/swagger.js
@@ -1,0 +1,13 @@
+import '../'
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import genSwaggerClient from '../../src/utils/swagger'
+
+describe('genSwaggerClient', function () {
+  it('converts operationId in snake case to pascal', async () => {
+    const client = await genSwaggerClient('http://example.com', {
+      spec: { paths: { '/test': { get: { operationId: 'get_test' } } } }
+    })
+    expect(client.api.getTest).to.be.a('function')
+  })
+})

--- a/test/unit/swagger.js
+++ b/test/unit/swagger.js
@@ -1,6 +1,8 @@
 import '../'
 import { describe, it } from 'mocha'
 import { expect } from 'chai'
+import { stub } from 'sinon'
+import http from 'http'
 import genSwaggerClient from '../../src/utils/swagger'
 
 describe('genSwaggerClient', function () {
@@ -9,5 +11,32 @@ describe('genSwaggerClient', function () {
       spec: { paths: { '/test': { get: { operationId: 'get_test' } } } }
     })
     expect(client.api.getTest).to.be.a('function')
+  })
+
+  it('accepts optional parameter in path', async () => {
+    let promise
+    stub(http, 'request').callsFake((request) => {
+      promise = Promise.resolve()
+        .then(() => expect(request.path).to.be.equal('/test/test-hash'))
+      return {
+        on: () => {},
+        end: () => {}
+      }
+    })
+    const client = await genSwaggerClient('http://example.com', {
+      spec: {
+        paths: {
+          '/test/{hash}': {
+            get: {
+              operationId: 'getTest',
+              parameters: [{ name: 'hash', in: 'path', required: false }]
+            }
+          }
+        }
+      }
+    })
+    client.api.getTest({ hash: 'test-hash' })
+    await promise
+    http.request.restore()
   })
 })


### PR DESCRIPTION
depends on #1362 
closes #1082
closes #1028

```js
> const client = await genSwaggerClient('https://mainnet.aeternity.io/mdw/swagger/swagger.json')
> console.log(Object.keys(client.api))
[
  'getBlockByHash',      'getBlockByKbi',
  'getBlockByKbiAndMbi', 'getBlocks',
  'getNameById',         'getAllNames',
  'getActiveNames',      'getAllAuctions',
  'getOwnedBy',          'getPointeesById',
  'getPointersById',     'getOracle',
  'getOracles',          'getActiveOracles',
  'getInactiveOracles',  'getStatus',
  'getTxByHash',         'getTxByIndex',
  'getCurrentTxCount',   'getTxCountById',
  'getTxsByDirection',   'getTxsByScopeTypeRange'
]
```