### PR TITLE
Remove node stream polyfill

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -72,7 +72,6 @@ AeError
 │   │   InvalidChecksumError
 │   │   InvalidDerivationPathError
 │   │   InvalidKeyError
-│   │   InvalidMnemonicError
 │   │   InvalidPasswordError
 │   │   MerkleTreeHashMismatchError
 │   │   MessageLimitError

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "process": "^0.11.10",
         "rlp": "^3.0.0",
         "sha.js": "^2.4.11",
-        "stream-browserify": "^3.0.0",
         "swagger-client": "^3.18.4",
         "tweetnacl": "^1.0.3",
         "tweetnacl-auth": "^1.0.1",
@@ -3783,11 +3782,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
-    },
-    "node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -9637,6 +9631,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10418,15 +10413,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "dependencies": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
     "node_modules/stream-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
@@ -10473,6 +10459,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -11264,7 +11251,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -14708,11 +14696,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
-    },
-    "bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -19097,6 +19080,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -19692,15 +19676,6 @@
         }
       }
     },
-    "stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "requires": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
     "stream-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
@@ -19740,6 +19715,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -20338,7 +20314,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aeternity/aepp-calldata": "^1.1.0",
+        "@aeternity/aepp-calldata": "github:aeternity/aepp-calldata-js#a623a44a259cc53e99b1e358ecc7b3f88edcb45c",
         "@aeternity/argon2-browser": "^0.1.1",
         "@aeternity/json-bigint": "^0.3.1",
         "@aeternity/uuid": "^0.0.1",
@@ -73,22 +73,21 @@
     },
     "node_modules/@aeternity/aepp-calldata": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/aepp-calldata/-/aepp-calldata-1.1.0.tgz",
-      "integrity": "sha512-welvt4Lrg2T9O+wHqQqlXQ6R4zkctqxJw5IzMvAGSa0Mjxg+9Ts/tTfXekA3nY5H3xCsV7jWZMicIM/3gZM7hA==",
+      "resolved": "git+ssh://git@github.com/aeternity/aepp-calldata-js.git#a623a44a259cc53e99b1e358ecc7b3f88edcb45c",
+      "integrity": "sha512-PWlIVrbKSFbMQ7e7LlvK+MxL97S6kzVp1BMwao2FJKs7em81ozx0VigmmEzPKwHl1YOu/R2JM+fcWgiAHzwEhw==",
+      "license": "ISC",
       "dependencies": {
-        "blakejs": "^1.1.0",
-        "bs58check": "^2.1.2",
-        "rlp": "^2.2.4",
+        "blakejs": "^1.1.1",
+        "bs58": "^4.0.1",
+        "rlp": "^3.0.0",
+        "safe-buffer": "^5.2.1",
         "sha.js": "^2.4.11"
       }
     },
     "node_modules/@aeternity/aepp-calldata/node_modules/rlp": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      },
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-3.0.0.tgz",
+      "integrity": "sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw==",
       "bin": {
         "rlp": "bin/rlp"
       }
@@ -3849,16 +3848,6 @@
         "base-x": "^3.0.2"
       }
     },
-    "node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "node_modules/btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
@@ -4120,15 +4109,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/clean-stack": {
@@ -4880,18 +4860,6 @@
         "@types/node": "*",
         "cosmiconfig": ">=7",
         "typescript": ">=3"
-      }
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
       }
     },
     "node_modules/create-require": {
@@ -6843,19 +6811,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/hasha": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -8299,16 +8254,6 @@
       },
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/mdurl": {
@@ -10027,15 +9972,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
       }
     },
     "node_modules/rlp": {
@@ -12035,23 +11971,21 @@
   },
   "dependencies": {
     "@aeternity/aepp-calldata": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/aepp-calldata/-/aepp-calldata-1.1.0.tgz",
-      "integrity": "sha512-welvt4Lrg2T9O+wHqQqlXQ6R4zkctqxJw5IzMvAGSa0Mjxg+9Ts/tTfXekA3nY5H3xCsV7jWZMicIM/3gZM7hA==",
+      "version": "git+ssh://git@github.com/aeternity/aepp-calldata-js.git#a623a44a259cc53e99b1e358ecc7b3f88edcb45c",
+      "integrity": "sha512-PWlIVrbKSFbMQ7e7LlvK+MxL97S6kzVp1BMwao2FJKs7em81ozx0VigmmEzPKwHl1YOu/R2JM+fcWgiAHzwEhw==",
+      "from": "@aeternity/aepp-calldata@github:aeternity/aepp-calldata-js#a623a44a259cc53e99b1e358ecc7b3f88edcb45c",
       "requires": {
-        "blakejs": "^1.1.0",
-        "bs58check": "^2.1.2",
-        "rlp": "^2.2.4",
+        "blakejs": "^1.1.1",
+        "bs58": "^4.0.1",
+        "rlp": "^3.0.0",
+        "safe-buffer": "^5.2.1",
         "sha.js": "^2.4.11"
       },
       "dependencies": {
         "rlp": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-          "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-          "requires": {
-            "bn.js": "^5.2.0"
-          }
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-3.0.0.tgz",
+          "integrity": "sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw=="
         }
       }
     },
@@ -14826,16 +14760,6 @@
         "base-x": "^3.0.2"
       }
     },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
@@ -15015,15 +14939,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -15619,18 +15534,6 @@
       "requires": {
         "cosmiconfig": "^7",
         "ts-node": "^10.4.0"
-      }
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
       }
     },
     "create-require": {
@@ -17106,16 +17009,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      }
-    },
     "hasha": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -18194,16 +18087,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
       "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true
-    },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
     },
     "mdurl": {
       "version": "1.0.1",
@@ -19470,15 +19353,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
       }
     },
     "rlp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "bignumber.js": "^9.0.2",
         "bip32-path": "^0.4.2",
         "blakejs": "^1.1.1",
-        "bs58check": "^2.1.2",
+        "bs58": "^4.0.1",
         "buffer": "^6.0.3",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aeternity/aepp-calldata": "^1.1.0",
         "@aeternity/argon2-browser": "^0.1.1",
-        "@aeternity/bip39": "^0.1.0",
         "@aeternity/json-bigint": "^0.3.1",
         "@aeternity/uuid": "^0.0.1",
         "@babel/runtime-corejs3": "^7.17.2",
@@ -98,17 +97,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@aeternity/argon2-browser/-/argon2-browser-0.1.1.tgz",
       "integrity": "sha512-Bdh/qhA6y6Jj6gnIMjBL0Tg7oCOxUjdlOnaFFpWmdADRH3+soIkGSDK5WCFTznlBiHocLsUKrkRCjVX70QHAtg=="
-    },
-    "node_modules/@aeternity/bip39": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/bip39/-/bip39-0.1.0.tgz",
-      "integrity": "sha512-ppRs0WTPpBAFJ2sDxt9eT0risarxeD8ByQO2qFmoAkaeA7galyWkx82AL0G5QrqGPC8DC+0gjc6l6Q8ueuD3hA==",
-      "dependencies": {
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "node_modules/@aeternity/json-bigint": {
       "version": "0.3.1",
@@ -4906,19 +4894,6 @@
         "sha.js": "^2.4.0"
       }
     },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -9360,21 +9335,6 @@
         "node": "*"
       }
     },
-    "node_modules/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
-      "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -9594,6 +9554,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -12098,17 +12059,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@aeternity/argon2-browser/-/argon2-browser-0.1.1.tgz",
       "integrity": "sha512-Bdh/qhA6y6Jj6gnIMjBL0Tg7oCOxUjdlOnaFFpWmdADRH3+soIkGSDK5WCFTznlBiHocLsUKrkRCjVX70QHAtg=="
-    },
-    "@aeternity/bip39": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/bip39/-/bip39-0.1.0.tgz",
-      "integrity": "sha512-ppRs0WTPpBAFJ2sDxt9eT0risarxeD8ByQO2qFmoAkaeA7galyWkx82AL0G5QrqGPC8DC+0gjc6l6Q8ueuD3hA==",
-      "requires": {
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "@aeternity/json-bigint": {
       "version": "0.3.1",
@@ -15683,19 +15633,6 @@
         "sha.js": "^2.4.0"
       }
     },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -19023,18 +18960,6 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
-    "pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -19180,6 +19105,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "SDK"
   ],
   "dependencies": {
-    "@aeternity/aepp-calldata": "^1.1.0",
+    "@aeternity/aepp-calldata": "github:aeternity/aepp-calldata-js#a623a44a259cc53e99b1e358ecc7b3f88edcb45c",
     "@aeternity/argon2-browser": "^0.1.1",
     "@aeternity/json-bigint": "^0.3.1",
     "@aeternity/uuid": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bignumber.js": "^9.0.2",
     "bip32-path": "^0.4.2",
     "blakejs": "^1.1.1",
-    "bs58check": "^2.1.2",
+    "bs58": "^4.0.1",
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
     "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@aeternity/aepp-calldata": "^1.1.0",
     "@aeternity/argon2-browser": "^0.1.1",
-    "@aeternity/bip39": "^0.1.0",
     "@aeternity/json-bigint": "^0.3.1",
     "@aeternity/uuid": "^0.0.1",
     "@babel/runtime-corejs3": "^7.17.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "process": "^0.11.10",
     "rlp": "^3.0.0",
     "sha.js": "^2.4.11",
-    "stream-browserify": "^3.0.0",
     "swagger-client": "^3.18.4",
     "tweetnacl": "^1.0.3",
     "tweetnacl-auth": "^1.0.1",

--- a/src/channel/handlers.js
+++ b/src/channel/handlers.js
@@ -15,7 +15,7 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 
-import { generateKeyPair, encodeContractAddress, encodeBase64Check } from '../utils/crypto'
+import { generateKeyPair, encodeContractAddress } from '../utils/crypto'
 import {
   options,
   changeStatus,
@@ -28,6 +28,7 @@ import {
   fsmId
 } from './internal'
 import { unpackTx, buildTx } from '../tx/builder'
+import { encode } from '../tx/builder/helpers'
 import {
   IllegalArgumentError,
   InsufficientBalanceError,
@@ -35,19 +36,15 @@ import {
   UnexpectedChannelMessageError
 } from '../utils/errors'
 
-function encodeRlpTx (rlpBinary) {
-  return `tx_${encodeBase64Check(rlpBinary)}`
-}
-
 async function appendSignature (tx, signFn) {
   const { signatures, encodedTx } = unpackTx(tx).tx
-  const result = await signFn(encodeRlpTx(encodedTx.rlpEncoded))
+  const result = await signFn(encode(encodedTx.rlpEncoded, 'tx'))
   if (typeof result === 'string') {
     const { tx: signedTx, txType } = unpackTx(result)
-    return encodeRlpTx(buildTx({
+    return buildTx({
       signatures: signatures.concat(signedTx.signatures),
       encodedTx: signedTx.encodedTx.rlpEncoded
-    }, txType).rlpEncoded)
+    }, txType).tx
   }
   return result
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import * as TxBuilder from './tx/builder'
 import * as TxBuilderHelper from './tx/builder/helpers'
 import * as SCHEMA from './tx/builder/schema'
 import * as AmountFormatter from './utils/amount-formatter'
-import HdWallet from './utils/hd-wallet'
+import * as HdWallet from './utils/hd-wallet'
 
 import Ae from './ae'
 import Chain from './chain'

--- a/src/tx/builder/helpers.js
+++ b/src/tx/builder/helpers.js
@@ -110,7 +110,7 @@ export function produceNameId (name) {
  */
 export function commitmentHash (name, salt = createSalt()) {
   ensureNameValid(name)
-  return `cm_${encodeBase58Check(hash(Buffer.concat([Buffer.from(name.toLowerCase()), formatSalt(salt)])))}`
+  return encode(hash(Buffer.concat([Buffer.from(name.toLowerCase()), formatSalt(salt)])), 'cm')
 }
 
 // based on https://github.com/aeternity/protocol/blob/master/node/api/api_encoding.md

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -27,7 +27,7 @@ import aesjs from 'aes-js'
 import shajs from 'sha.js'
 
 import { str2buf } from './bytes'
-import { decode } from '../tx/builder/helpers'
+import { encode, decode } from '../tx/builder/helpers'
 import { hash } from './crypto-ts'
 import { InvalidChecksumError, MessageLimitError } from './errors'
 
@@ -44,7 +44,7 @@ const Ecb = aesjs.ModeOfOperation.ecb
 export function getAddressFromPriv (secret) {
   const keys = nacl.sign.keyPair.fromSecretKey(str2buf(secret))
   const publicBuffer = Buffer.from(keys.publicKey)
-  return `ak_${encodeBase58Check(publicBuffer)}`
+  return encode(publicBuffer, 'ak')
 }
 
 /**
@@ -166,7 +166,7 @@ export function encodeUnsigned (value) {
 export function encodeContractAddress (owner, nonce) {
   const publicKey = decode(owner, 'ak')
   const binary = Buffer.concat([publicKey, encodeUnsigned(nonce)])
-  return `ct_${encodeBase58Check(hash(binary))}`
+  return encode(hash(binary), 'ct')
 }
 
 // KEY-PAIR HELPERS
@@ -201,7 +201,7 @@ export function generateKeyPair (raw = false) {
     }
   } else {
     return {
-      publicKey: `ak_${encodeBase58Check(publicBuffer)}`,
+      publicKey: encode(publicBuffer, 'ak'),
       secretKey: secretBuffer.toString('hex')
     }
   }

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -21,7 +21,6 @@
  * @example import { Crypto } from '@aeternity/aepp-sdk'
  */
 
-import bs58 from 'bs58'
 import nacl from 'tweetnacl'
 import aesjs from 'aes-js'
 import shajs from 'sha.js'
@@ -29,7 +28,7 @@ import shajs from 'sha.js'
 import { str2buf } from './bytes'
 import { encode, decode } from '../tx/builder/helpers'
 import { hash } from './crypto-ts'
-import { InvalidChecksumError, MessageLimitError } from './errors'
+import { MessageLimitError } from './errors'
 
 export * from './crypto-ts'
 
@@ -80,59 +79,6 @@ export function sha256hash (input) {
  */
 export function salt () {
   return Math.floor(Math.random() * Math.floor(Number.MAX_SAFE_INTEGER))
-}
-
-const getChecksum = payload => sha256hash(sha256hash(payload)).slice(0, 4)
-
-const addChecksum = (input) => {
-  const payload = Buffer.from(input)
-  return Buffer.concat([payload, getChecksum(payload)])
-}
-
-function getPayload (buffer) {
-  const payload = buffer.slice(0, -4)
-  if (!getChecksum(payload).equals(buffer.slice(-4))) throw new InvalidChecksumError()
-  return payload
-}
-
-/**
- * Base64check encode given `input`
- * @rtype (input: Buffer) => String
- * @param {Buffer} input - Data to encode
- * @return {String} Base64check encoded data
- */
-export function encodeBase64Check (input) {
-  return addChecksum(input).toString('base64')
-}
-
-/**
- * Base64check decode given `str`
- * @rtype (str: String) => Buffer
- * @param {String} str - Data to decode
- * @return {Buffer} Base64check decoded data
- */
-export function decodeBase64Check (str) {
-  return getPayload(Buffer.from(str, 'base64'))
-}
-
-/**
- * Base58 encode given `input`
- * @rtype (input: Buffer) => String
- * @param {Buffer} input - Data to encode
- * @return {String} Base58 encoded data
- */
-export function encodeBase58Check (input) {
-  return bs58.encode(addChecksum(input))
-}
-
-/**
- * Base58 decode given `str`
- * @rtype (str: String) => Buffer
- * @param {String} str - Data to decode
- * @return {Buffer} Base58 decoded data
- */
-export function decodeBase58Check (str) {
-  return getPayload(bs58.decode(str))
 }
 
 /**

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -476,13 +476,6 @@ export class InvalidKeyError extends CryptographyError {
   }
 }
 
-export class InvalidMnemonicError extends CryptographyError {
-  constructor () {
-    super('Invalid mnemonic')
-    this.name = 'InvalidMnemonicError'
-  }
-}
-
 export class InvalidPasswordError extends CryptographyError {
   constructor (msg: string) {
     super(msg)

--- a/src/utils/hd-wallet.js
+++ b/src/utils/hd-wallet.js
@@ -2,7 +2,8 @@ import nacl from 'tweetnacl'
 import { full as hmac } from 'tweetnacl-auth'
 import { fromString } from 'bip32-path'
 import { validateMnemonic, mnemonicToSeed, generateMnemonic as genMnemonic } from '@aeternity/bip39'
-import { decryptKey, encodeBase58Check, encryptKey } from './crypto'
+import { decryptKey, encryptKey } from './crypto'
+import { encode } from '../tx/builder/helpers'
 import {
   InvalidDerivationPathError,
   NotHardenedSegmentError,
@@ -38,7 +39,7 @@ function formatAccount (keys) {
   const { secretKey, publicKey } = keys
   return {
     secretKey: toHex(secretKey),
-    publicKey: `ak_${encodeBase58Check(publicKey)}`
+    publicKey: encode(publicKey, 'ak')
   }
 }
 

--- a/src/utils/hd-wallet.js
+++ b/src/utils/hd-wallet.js
@@ -1,14 +1,10 @@
 import nacl from 'tweetnacl'
 import { full as hmac } from 'tweetnacl-auth'
 import { fromString } from 'bip32-path'
-import { validateMnemonic, mnemonicToSeed, generateMnemonic as genMnemonic } from '@aeternity/bip39'
 import { decryptKey, encryptKey } from './crypto'
 import { encode } from '../tx/builder/helpers'
 import {
-  InvalidDerivationPathError,
-  NotHardenedSegmentError,
-  UnsupportedChildIndexError,
-  InvalidMnemonicError
+  InvalidDerivationPathError, NotHardenedSegmentError, UnsupportedChildIndexError
 } from './errors'
 
 const ED25519_CURVE = Buffer.from('ed25519 seed')
@@ -47,10 +43,6 @@ export function getKeyPair (secretKey) {
   return nacl.sign.keyPair.fromSeed(secretKey)
 }
 
-export function generateMnemonic () {
-  return genMnemonic()
-}
-
 export function getMasterKeyFromSeed (seed) {
   const I = hmac(seed, ED25519_CURVE)
   const IL = I.slice(0, 32)
@@ -79,11 +71,7 @@ export function deriveChild ({ secretKey, chainCode }, index) {
   }
 }
 
-export function generateSaveHDWallet (mnemonic, password) {
-  if (!validateMnemonic(mnemonic)) {
-    throw new InvalidMnemonicError()
-  }
-  const seed = mnemonicToSeed(mnemonic)
+export function generateSaveHDWalletFromSeed (seed, password) {
   const walletKey = derivePathFromSeed('m/44h/457h', seed)
   return {
     secretKey: toHex(encryptKey(password, walletKey.secretKey)),
@@ -101,8 +89,7 @@ export function getSaveHDWalletAccounts (saveHDWallet, password, accountCount) {
       formatAccount(getKeyPair(derivePathFromKey(`${idx}h/0h/0h`, walletKey).secretKey)))
 }
 
-export const getHdWalletAccountFromMnemonic = (mnemonic, accountIdx) => {
-  const seed = mnemonicToSeed(mnemonic)
+export const getHdWalletAccountFromSeed = (seed, accountIdx) => {
   const walletKey = derivePathFromSeed('m/44h/457h', seed)
   const derived = derivePathFromKey(`${accountIdx}h/0h/0h`, walletKey)
   const keyPair = getKeyPair(derived.secretKey)

--- a/src/utils/hd-wallet.js
+++ b/src/utils/hd-wallet.js
@@ -111,12 +111,3 @@ export const getHdWalletAccountFromMnemonic = (mnemonic, accountIdx) => {
     idx: accountIdx
   }
 }
-
-export default {
-  getHdWalletAccountFromMnemonic,
-  getSaveHDWalletAccounts,
-  generateSaveHDWallet,
-  generateMnemonic,
-  deriveChild,
-  getMasterKeyFromSeed
-}

--- a/src/utils/keystore.js
+++ b/src/utils/keystore.js
@@ -1,7 +1,7 @@
 import nacl from 'tweetnacl'
 import { v4 as uuid } from '@aeternity/uuid'
 import { ArgonType, hash } from '@aeternity/argon2-browser/dist/argon2-bundled.min.js'
-import { encodeBase58Check } from './crypto'
+import { encode } from '../tx/builder/helpers'
 import { str2buf } from './bytes'
 import {
   IllegalArgumentError,
@@ -149,7 +149,7 @@ function marshal (name, derivedKey, privateKey, nonce, salt, options = {}) {
 export function getAddressFromPriv (secret) {
   const keys = nacl.sign.keyPair.fromSecretKey(str2buf(secret))
   const publicBuffer = Buffer.from(keys.publicKey)
-  return `ak_${encodeBase58Check(publicBuffer)}`
+  return encode(publicBuffer, 'ak')
 }
 
 /**

--- a/test/integration/channel.js
+++ b/test/integration/channel.js
@@ -21,7 +21,7 @@ import { expect } from 'chai'
 import * as sinon from 'sinon'
 import BigNumber from 'bignumber.js'
 import { getSdk, BaseAe, networkId } from './'
-import { generateKeyPair, encodeBase64Check } from '../../src/utils/crypto'
+import { generateKeyPair } from '../../src/utils/crypto'
 import { unpackTx, buildTx, buildTxHash } from '../../src/tx/builder'
 import { decode } from '../../src/tx/builder/helpers'
 import Channel from '../../src/channel'
@@ -1131,11 +1131,10 @@ describe('Channel', function () {
   it('can post backchannel update', async () => {
     async function appendSignature (target, source) {
       const { txType, tx: { signatures, encodedTx: { rlpEncoded } } } = unpackTx(target)
-      const tx = buildTx({
+      return buildTx({
         signatures: signatures.concat(unpackTx(source).tx.signatures),
         encodedTx: rlpEncoded
-      }, txType)
-      return `tx_${encodeBase64Check(tx.rlpEncoded)}`
+      }, txType).tx
     }
 
     initiatorCh.disconnect()

--- a/test/integration/oracle.js
+++ b/test/integration/oracle.js
@@ -18,9 +18,10 @@
 import { describe, it, before } from 'mocha'
 import { expect } from 'chai'
 import { getSdk } from './'
-import { encodeBase64Check, generateKeyPair } from '../../src/utils/crypto'
+import { generateKeyPair } from '../../src/utils/crypto'
 import MemoryAccount from '../../src/account/memory'
 import { QUERY_FEE } from '../../src/tx/builder/schema'
+import { decode } from '../../src/tx/builder/helpers'
 
 describe('Oracle', function () {
   let sdk
@@ -76,7 +77,7 @@ describe('Oracle', function () {
     query = await oracle.getQuery(query.id)
 
     expect(query.decodedResponse).to.be.equal(queryResponse)
-    expect(query.response.slice(3)).to.be.equal(encodeBase64Check(queryResponse))
+    expect(decode(query.response, 'or').toString()).to.be.equal(queryResponse)
   })
 
   it('Poll for response', async () => {

--- a/test/integration/transaction.js
+++ b/test/integration/transaction.js
@@ -16,9 +16,9 @@
  */
 
 import { describe, it, before } from 'mocha'
-import { encodeBase64Check, generateKeyPair, salt } from '../../src/utils/crypto'
+import { generateKeyPair, salt } from '../../src/utils/crypto'
 import { getSdk } from './index'
-import { commitmentHash, oracleQueryId } from '../../src/tx/builder/helpers'
+import { commitmentHash, oracleQueryId, encode } from '../../src/tx/builder/helpers'
 import { GAS_MAX, MIN_GAS_PRICE } from '../../src/tx/builder/schema'
 import { MemoryAccount } from '../../src'
 import { AE_AMOUNT_FORMATS } from '../../src/utils/amount-formatter'
@@ -234,7 +234,7 @@ describe('Native Transaction', function () {
     await sdk.send(nativeTx)
 
     const orQuery = (await sdk.api.getOracleQueryByPubkeyAndQueryId(oracleId, queryId))
-    orQuery.response.should.be.equal(`or_${encodeBase64Check(queryResponse)}`)
+    orQuery.response.should.be.equal(encode(queryResponse, 'or'))
   })
   it('Get next account nonce', async () => {
     const accountId = await sdk.address()

--- a/test/unit/crypto.js
+++ b/test/unit/crypto.js
@@ -75,16 +75,6 @@ describe('crypto', () => {
     expect(Crypto.isAddressValid('ak_11111111111111111111111111111111273Yts')).to.be.equal(true)
   })
 
-  describe('encodeBase', () => {
-    it('can be encoded and decoded', () => {
-      const input = 'helloword010101023'
-      const inputBuffer = Buffer.from(input)
-      const encoded = Crypto.encodeBase58Check(inputBuffer)
-      const decoded = Crypto.decodeBase58Check(encoded)
-      assert.equal(input, decoded)
-    })
-  })
-
   describe('sign', () => {
     it('should produce correct signature', () => {
       const s = Crypto.sign(txBinary, privateKey)

--- a/test/unit/crypto.js
+++ b/test/unit/crypto.js
@@ -20,13 +20,14 @@ import { describe, it } from 'mocha'
 import { assert, expect } from 'chai'
 import * as Crypto from '../../src/utils/crypto'
 import { buildTxHash, unpackTx } from '../../src/tx/builder'
+import { decode } from '../../src/tx/builder/helpers'
 
 // These keys are fixations for the encryption lifecycle tests and will
 // not be used for signing
 const privateKeyAsHex = '4d881dd1917036cc231f9881a0db978c8899dd76a817252418606b02bf6ab9d22378f892b7cc82c2d2739e994ec9953aa36461f1eb5a4a49a5b0de17b3d23ae8'
 const privateKey = Buffer.from(privateKeyAsHex, 'hex')
 const publicKeyWithPrefix = 'ak_Gd6iMVsoonGuTF8LeswwDDN2NF5wYHAoTRtzwdEcfS32LWoxm'
-const publicKey = Buffer.from(Crypto.decodeBase58Check(publicKeyWithPrefix.split('_')[1]))
+const publicKey = decode(publicKeyWithPrefix, 'ak')
 
 const txBinaryAsArray = [
   248, 76, 12, 1, 160, 35, 120, 248, 146, 183, 204, 130, 194, 210, 115, 158, 153, 78, 201, 149, 58,

--- a/test/unit/hd-wallet.js
+++ b/test/unit/hd-wallet.js
@@ -22,7 +22,7 @@ import {
   getMasterKeyFromSeed,
   getSaveHDWalletAccounts
 } from '../../src/utils/hd-wallet'
-import { encodeBase58Check } from '../../src/utils/crypto'
+import { encode } from '../../src/tx/builder/helpers'
 import { InvalidDerivationPathError, InvalidMnemonicError } from '../../src/utils/errors'
 
 describe('hd wallet', () => {
@@ -63,7 +63,7 @@ describe('hd wallet', () => {
 
       expect(accounts).to.eql(testAccounts.map(acc => ({
         secretKey: acc.secretKey,
-        publicKey: `ak_${encodeBase58Check(Buffer.from(acc.publicKey, 'hex'))}`
+        publicKey: encode(Buffer.from(acc.publicKey, 'hex'), 'ak')
       })))
     }))
 

--- a/test/unit/hd-wallet.js
+++ b/test/unit/hd-wallet.js
@@ -17,16 +17,16 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 import {
-  deriveChild, derivePathFromKey, derivePathFromSeed, generateMnemonic,
-  generateSaveHDWallet, getHdWalletAccountFromMnemonic, getKeyPair,
+  deriveChild, derivePathFromKey, derivePathFromSeed,
+  generateSaveHDWalletFromSeed, getHdWalletAccountFromSeed, getKeyPair,
   getMasterKeyFromSeed,
   getSaveHDWalletAccounts
 } from '../../src/utils/hd-wallet'
-import { encode } from '../../src/tx/builder/helpers'
-import { InvalidDerivationPathError, InvalidMnemonicError } from '../../src/utils/errors'
+import { encode, decode } from '../../src/tx/builder/helpers'
+import { InvalidDerivationPathError } from '../../src/utils/errors'
 
 describe('hd wallet', () => {
-  const testMnemonic = 'eye quarter chapter suit cruel scrub verify stuff volume control learn dust'
+  const testMnemonicSeed = Buffer.from('Git7bFJkmfC1Ho+6YFSFuxSzmDZydmjzk8FubrPDz4PmrkORlBDlfnPTk02Wq9Pj2ZdQ5cTA0SxHKGrq3xSjOw==', 'base64')
   const testPassword = 'test-password'
   const testSaveHDWallet = {
     chainCode: 'dd5cb572e8bddab36882ebbf87854e3b66f565447f20cfac874a5d3d7dd6d0d5',
@@ -51,9 +51,9 @@ describe('hd wallet', () => {
     chainCode: Buffer.from('1fa9899b84631aaadf1daba7f7cf780e2fecfb8dd34a2edf6568eb1a9bb2f627', 'hex')
   }
 
-  describe('generateSaveHDWallet', () =>
+  describe('generateSaveHDWalletFromSeed', () =>
     it('generates encrypted extended wallet key', () => {
-      const walletKeys = generateSaveHDWallet(testMnemonic, testPassword)
+      const walletKeys = generateSaveHDWalletFromSeed(testMnemonicSeed, testPassword)
       expect(walletKeys).to.eql(testSaveHDWallet)
     }))
 
@@ -172,14 +172,9 @@ describe('hd wallet', () => {
       })
   )
 
-  it('Generate mnemonic', () => {
-    const mnemonic = generateMnemonic()
-    const wallet = getHdWalletAccountFromMnemonic(mnemonic, 0)
-    wallet.publicKey.split('_')[0].should.be.equal('ak')
-  })
-
-  it('Try to get wallet from invalid mnemonic', () => {
-    expect(() => generateSaveHDWallet('asdasdasdasdas')).to.throw(InvalidMnemonicError, 'Invalid mnemonic')
+  it('get HdWalletAccount from seed', () => {
+    const wallet = getHdWalletAccountFromSeed(testMnemonicSeed, 0)
+    decode(wallet.publicKey, 'ak')
   })
 
   it('Derive child with invalid path', () => {

--- a/test/unit/tx.js
+++ b/test/unit/tx.js
@@ -100,7 +100,12 @@ describe('Tx', function () {
     it('don\'t throws exception', () => isNameValid('asdasdasd.chain').should.be.equal(true))
   })
 
+  const payload = Buffer.from([1, 2, 42])
   describe('decode', () => {
+    it('decodes base64check', () => expect(decode('ba_AQIq9Y55kw==')).to.be.eql(payload))
+
+    it('decodes base58check', () => expect(decode('bf_3DZUwMat2')).to.be.eql(payload))
+
     it('throws if not a string', () => expect(() => decode({}))
       .to.throw('Encoded should be a string, got [object Object] instead'))
 
@@ -118,11 +123,13 @@ describe('Tx', function () {
 
     it('throws if invalid size', () => expect(() => decode('ak_An6Ui6sE1F'))
       .to.throw('Payload should be 32 bytes, got 4 instead'))
-
-    it('decodes', () => expect(decode('cb_DA6sWJo=')).to.be.eql(Buffer.from([12])))
   })
 
   describe('encode', () => {
+    it('encodes base64check', () => expect(encode(payload, 'ba')).to.be.equal('ba_AQIq9Y55kw=='))
+
+    it('encodes base58check', () => expect(encode(payload, 'bf')).to.be.equal('bf_3DZUwMat2'))
+
     it('throws if unknown type', () => expect(() => encode([1, 2, 3, 4], 'aa'))
       .to.throw('Unknown type: aa'))
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,8 +19,7 @@ function configure (filename, opts = {}) {
     resolve: {
       extensions: ['.ts', '.js'],
       fallback: {
-        buffer: require.resolve('buffer/'),
-        stream: require.resolve('stream-browserify')
+        buffer: require.resolve('buffer/')
       },
       alias: {
         'js-yaml': false


### PR DESCRIPTION
I'm planning to rename `TxBuildHelper.decode/encode` to something more general, but it is not ready yet.

The need to switch from `bs58check` to `bs58` is explained in https://github.com/aeternity/aepp-calldata-js/pull/122.

[bip39](https://www.npmjs.com/package/bip39) package can be configured to support different languages and this is not up to SDK to decide which of them should be included. Also, it depends on a set of unnecessary crypto libraries that is not easy to get rid of: https://github.com/bitcoinjs/bip39/issues/170. It has a quite simple blockchain-agnostic interface. Our `@aeternity/bip39` didn't get updates in 3 years and probably shouldn't be used. So, I'm proposing to make the wallet developer use `bip39` package by himself and remove it from sdk.
