### PR TITLE
fix(es): babel build on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build:es": "tsc && babel src --config-file ./babel.esm.config.js --out-dir es --extensions '.js,.ts' --out-file-extension .mjs --source-maps true",
+    "build:es": "tsc && babel src --config-file ./babel.esm.config.js --out-dir es --extensions .js,.ts --out-file-extension .mjs --source-maps true",
     "build": "webpack --mode=production && npm run build:es",
     "build:dev": "webpack --mode=development && npm run build:es",
     "docs:examples": "node tooling/docs/examples-to-md.js examples/node/*.js",


### PR DESCRIPTION
closes #1406 
https://github.com/babel/babel/issues/9803#issuecomment-505435797

I just ensured that it generates mjs files on windows, would be nice to check if it builds fine as a dependency.