### PR TITLE
refactor(wallet rpc)!: don't pass networkId from aepp to wallet

### DIFF
--- a/src/account/base.js
+++ b/src/account/base.js
@@ -119,10 +119,8 @@ async function verifyMessage (message, signature, opt = {}) {
  * @return {Object} Account instance
  */
 export default stampit({
-  init ({ networkId }) { // NETWORK_ID using for signing transaction's
-    if (!this.networkId && networkId) {
-      this.networkId = networkId
-    }
+  init ({ networkId }) {
+    this.networkId ??= networkId
   },
   methods: { signTransaction, getNetworkId, signMessage, verifyMessage }
 }, required({

--- a/src/account/rpc.js
+++ b/src/account/rpc.js
@@ -40,8 +40,7 @@ export default AccountBase.compose({
         ...options,
         onAccount: this._address,
         tx,
-        returnSigned: true,
-        networkId: this.getNetworkId(options)
+        returnSigned: true
       })
     },
     /**

--- a/src/node.js
+++ b/src/node.js
@@ -36,9 +36,9 @@ import { MissingParamError, UnsupportedVersionError } from './utils/errors'
  */
 export function getNetworkId ({ networkId, force = false } = {}) {
   const res = networkId || this.networkId || this.selectedNode?.networkId
-  if (!force && !res) throw new MissingParamError('networkId is not provided')
-  if (force && !res) return null
-  return res
+  if (res) return res
+  if (force) return null
+  else throw new MissingParamError('networkId is not provided')
 }
 
 /**

--- a/src/node.js
+++ b/src/node.js
@@ -34,11 +34,10 @@ import { MissingParamError, UnsupportedVersionError } from './utils/errors'
  * @rtype () => networkId: String
  * @return {String} NetworkId
  */
-export function getNetworkId ({ networkId, force = false } = {}) {
+export function getNetworkId ({ networkId } = {}) {
   const res = networkId || this.networkId || this.selectedNode?.networkId
   if (res) return res
-  if (force) return null
-  else throw new MissingParamError('networkId is not provided')
+  throw new MissingParamError('networkId is not provided')
 }
 
 /**

--- a/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js
+++ b/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js
@@ -32,8 +32,7 @@ const NOTIFICATIONS = {
     },
   [METHODS.updateNetwork]: (instance) =>
     async ({ params }) => {
-      const { networkId, node } = params
-      instance.rpcClient.info.networkId = networkId
+      const { node } = params
       if (node) instance.addNode(node.name, await Node(node), true)
       instance.onNetworkChange(params)
     },
@@ -158,7 +157,6 @@ export default AccountResolver.compose({
       if (this.rpcClient?.isConnected()) throw new AlreadyConnectedError('You are already connected to wallet ' + this.rpcClient)
       this.rpcClient = RpcClient({
         connection,
-        networkId: this.getNetworkId({ force: true }),
         ...connection.connectionInfo,
         id: uuid(),
         handlers: [handleMessage(this), this.onDisconnect]
@@ -223,7 +221,6 @@ export default AccountResolver.compose({
         METHODS.connect, {
           name: this.name,
           version: VERSION,
-          networkId: this.getNetworkId({ force: true }),
           connectNode
         }
       )

--- a/src/utils/aepp-wallet-communication/rpc/rpc-client.js
+++ b/src/utils/aepp-wallet-communication/rpc/rpc-client.js
@@ -31,10 +31,10 @@ import {
  * @return {Object}
  */
 export default stampit({
-  init ({ id, name, networkId, icons, connection, handlers: [onMessage, onDisconnect] }) {
+  init ({ id, name, icons, connection, handlers: [onMessage, onDisconnect] }) {
     this.id = id
     this.connection = connection
-    this.info = { name, networkId, icons }
+    this.info = { name, icons }
     // {
     //    [msg.id]: { resolve, reject }
     // }

--- a/src/utils/aepp-wallet-communication/rpc/wallet-rpc.js
+++ b/src/utils/aepp-wallet-communication/rpc/wallet-rpc.js
@@ -43,14 +43,13 @@ const REQUESTS = {
     callInstance,
     instance,
     client,
-    { name, networkId, version, icons, connectNode }) {
+    { name, version, icons, connectNode }) {
     // Check if protocol and network is compatible with wallet
     if (version !== VERSION) return { error: ERRORS.unsupportedProtocol() }
     // Store new AEPP and wait for connection approve
     client.updateInfo({
       status: RPC_STATUS.WAITING_FOR_CONNECTION_APPROVE,
       name,
-      networkId,
       icons,
       version,
       origin: window.location.origin,
@@ -60,7 +59,7 @@ const REQUESTS = {
     // Call onConnection callBack to notice Wallet about new AEPP
     return callInstance(
       'onConnection',
-      { name, networkId, version },
+      { name, version },
       ({ shareNode } = {}) => {
         client.updateInfo({ status: shareNode ? RPC_STATUS.NODE_BINDED : RPC_STATUS.CONNECTED })
         return {
@@ -121,19 +120,13 @@ const REQUESTS = {
     )
   },
   [METHODS.sign] (callInstance, instance, client, options) {
-    const { tx, onAccount, networkId, returnSigned = false } = options
+    const { tx, onAccount, returnSigned = false } = options
     const address = onAccount || client.currentAccount
-    // Update client with new networkId
-    networkId && client.updateInfo({ networkId })
     // Authorization check
     if (!client.isConnected()) return { error: ERRORS.notAuthorize() }
     // Account permission check
     if (!client.hasAccessToAccount(address)) {
       return { error: ERRORS.permissionDeny(address) }
-    }
-    // NetworkId check
-    if (!networkId || networkId !== instance.getNetworkId()) {
-      return { error: ERRORS.unsupportedNetwork() }
     }
 
     return callInstance(
@@ -308,7 +301,7 @@ export default Ae.compose(AccountMultiple, {
           client.sendMessage(
             message(METHODS.updateNetwork, {
               networkId: this.getNetworkId(),
-              ...(client.info.status === RPC_STATUS.NODE_BINDED && { node: this.selectedNode })
+              ...client.info.status === RPC_STATUS.NODE_BINDED && { node: this.selectedNode }
             }), true)
         })
     }

--- a/src/utils/aepp-wallet-communication/schema.ts
+++ b/src/utils/aepp-wallet-communication/schema.ts
@@ -72,9 +72,5 @@ export const ERRORS = {
   unsupportedProtocol: () => ({
     code: 5,
     message: 'Unsupported Protocol Version'
-  }),
-  unsupportedNetwork: () => ({
-    code: 8,
-    message: 'Unsupported Network'
   })
 }

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -413,23 +413,8 @@ describe('Aepp<->Wallet', function () {
 
     it('Try to connect unsupported protocol', async () => {
       await expect(aepp.rpcClient.request(
-        METHODS.connect, {
-          name: 'test-aepp',
-          version: 2,
-          networkId: aepp.getNetworkId()
-        }
+        METHODS.connect, { name: 'test-aepp', version: 2 }
       )).to.be.eventually.rejectedWith('Unsupported Protocol Version').with.property('code', 5)
-    })
-
-    it.skip('Try to connect unsupported network', async () => {
-      // TODO: fix this assertion
-      await expect(aepp.rpcClient.request(
-        METHODS.connect, {
-          name: 'test-aepp',
-          version: 1,
-          networkId: 'ae_test'
-        }
-      )).to.be.eventually.rejectedWith('Unsupported Network').with.property('code', 8)
     })
 
     it('Process response ', () => {


### PR DESCRIPTION
Originally Nikita asked is it possible to sign transaction for a different networks with no switching (passing `networkId`). We find out that the option is ignored in https://github.com/aeternity/aepp-sdk-js/blob/7a96386a1b9be8f4ca428f713b6a7e48f70b010f/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js#L225 But it doesn't make sense to introduce this because of the check

https://github.com/aeternity/aepp-sdk-js/blob/dfbab5957dc3e7769427737f8f0b31fc1e63d20a/src/utils/aepp-wallet-communication/rpc/wallet-rpc.js#L134-L136

In general looks like it is enough to pass the `networkId` only from wallet to aepp. I can't find a reasonable case when we need to notify wallet about the network id that aepp uses.