### PR TITLE
feat(NodeInvocationError): store tx-encoded transaction

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -388,10 +388,12 @@ export class MissingFunctionNameError extends ContractError {
 }
 
 export class NodeInvocationError extends ContractError {
-  constructor (message?: string) {
-    message = message ?? ''
-    super(`Invocation failed${message === '' ? '' : `: "${message}"`}`)
+  transaction: string
+
+  constructor (message: string, transaction: string) {
+    super(`Invocation failed${message == null ? '' : `: "${message}"`}`)
     this.name = 'NodeInvocationError'
+    this.transaction = transaction
   }
 }
 


### PR DESCRIPTION
closes #1315 

I think to expose just a transaction is enough, if necessary it can be transformed to transaction hash using `buildTxHash`
https://github.com/aeternity/aepp-sdk-js/blob/7b3d0e3b7f6d62c3099b9ffb3d5cca98ccec1dba/src/tx/builder/index.js#L451
or decoded using `unpackTx`
https://github.com/aeternity/aepp-sdk-js/blob/7b3d0e3b7f6d62c3099b9ffb3d5cca98ccec1dba/src/tx/builder/index.js#L433