### PR TITLE
chore(npm scripts): don't build on installing dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-      - run: npm ci --ignore-scripts
+      - run: npm ci
       - name: Run Commitlint
         env:
           EVENT_TYPE: ${{ github.event_name }}

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -3,6 +3,6 @@ import subprocess
 
 def pre_build(**kwargs):
   if not os.path.exists('node_modules'):
-    subprocess.run(['npm', 'install', '--ignore-scripts'], check=True)
+    subprocess.run(['npm', 'install'], check=True)
   subprocess.run(['npm', 'run', 'docs:examples'], check=True)
   # subprocess.run(['npm', 'run', 'docs:api'], check=True)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:integration": "nyc mocha './test/integration/'",
     "test:unit": "nyc mocha './test/unit/'",
     "test:watch": "mocha './test/unit/' './test/integration/' --watch",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "prepublishOnly": "npm run docs:examples",
     "release": "standard-version --skip.tag --infile docs/CHANGELOG.md"
   },


### PR DESCRIPTION
We are using "prepare" script to build sdk in case it is installed via git repo. It works fine except that "prepare" script are executed also at the end of "npm install". This behaviour is unwanted in some cases, it can be fixed by using "prepack" script instead (according the documentation).

https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts