### PR TITLE
fix: importing in mjs

### DIFF
--- a/src/utils/encoder.ts
+++ b/src/utils/encoder.ts
@@ -1,4 +1,4 @@
-import * as bs58 from 'bs58'
+import { encode as bs58Encode, decode as bs58Decode } from 'bs58'
 import { sha256 } from 'sha.js'
 import {
   DecodeError,
@@ -53,8 +53,8 @@ const base64 = {
 }
 
 const base58 = {
-  encode: (buffer: Buffer | string) => bs58.encode(addChecksum(buffer)),
-  decode: (string: string) => getPayload(bs58.decode(string))
+  encode: (buffer: Buffer | string) => bs58Encode(addChecksum(buffer)),
+  decode: (string: string) => getPayload(bs58Decode(string))
 }
 
 /**


### PR DESCRIPTION
before:
```
$ node test/environment/node.mjs
file:///.../aepp-sdk-js/es/utils/encoder.mjs:57
  decode: string => getPayload(bs58.decode(string))
                                    ^

TypeError: bs58.decode is not a function
    at decode (file:///.../aepp-sdk-js/es/utils/encoder.mjs:57:37)
    at decode (file:///.../aepp-sdk-js/es/utils/encoder.mjs:83:19)
    at Object.init (file:///.../aepp-sdk-js/es/account/memory.mjs:75:36)
    at Stamp (/.../aepp-sdk-js/node_modules/@stamp/compose/index.js:34:41)
    at file:///.../aepp-sdk-js/test/environment/node.mjs:13:16
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

after:
```
$ node test/environment/node.mjs
Height: 582859
Instanceof works correctly for nodes pool true
Contract deployed at ct_24BYktVcMedVCG6MnkeXvkAJbYYQZTNzbjKDg9LvbraFo8jSs8
Call result Map(2) { 'bar' => 43n, 'foo' => 42n }
Instanceof works correctly for returned map true
```