### PR TITLE
fix(messageToHash): support messages longer than 252 chars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "swagger-client": "^3.18.4",
         "tweetnacl": "^1.0.3",
         "tweetnacl-auth": "^1.0.1",
+        "varuint-bitcoin": "^1.1.2",
         "websocket": "^1.0.34"
       },
       "devDependencies": {
@@ -11158,6 +11159,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/walk-back": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
@@ -20100,6 +20109,14 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
       }
     },
     "walk-back": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "swagger-client": "^3.18.4",
     "tweetnacl": "^1.0.3",
     "tweetnacl-auth": "^1.0.1",
+    "varuint-bitcoin": "^1.1.2",
     "websocket": "^1.0.34"
   },
   "repository": {

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -23,11 +23,11 @@
 
 import nacl from 'tweetnacl'
 import aesjs from 'aes-js'
+import { encode as varuintEncode } from 'varuint-bitcoin'
 
 import { str2buf } from './bytes'
 import { encode, decode, sha256hash } from './encoder'
 import { hash } from './crypto-ts'
-import { NotImplementedError } from './errors'
 
 export * from './crypto-ts'
 export { sha256hash }
@@ -191,8 +191,7 @@ export function verify (str, signature, publicKey) {
 export function messageToHash (message) {
   const p = Buffer.from('aeternity Signed Message:\n', 'utf8')
   const msg = Buffer.from(message, 'utf8')
-  if (msg.length >= 0xFD) throw new NotImplementedError('Message too long')
-  return hash(Buffer.concat([Buffer.from([p.length]), p, Buffer.from([msg.length]), msg]))
+  return hash(Buffer.concat([varuintEncode(p.length), p, varuintEncode(msg.length), msg]))
 }
 
 export function signMessage (message, privateKey) {

--- a/test/unit/crypto.js
+++ b/test/unit/crypto.js
@@ -98,6 +98,12 @@ describe('crypto', () => {
     const messageNonASCIISignatureAsHex = 'faa1bdb8a88c529be904036382705ed207bbdde00ece3bdb541f5986d57aebe7babe315a4d95f5882165c28bf41f6149430509ded1cc7dcd9b134e0e1d73cd0b'
     const messageNonASCIISignature = Buffer.from(messageNonASCIISignatureAsHex, 'hex')
 
+    const longMessage = 'test'.repeat(256)
+    const longMessageHash = Buffer.from('J9bibOHrlicf0tYQxe1lW69LdDAxETwPmrafKjjQwvs=', 'base64')
+
+    it('calculates a hash of a long message', () =>
+      expect(Crypto.messageToHash(longMessage)).to.eql(longMessageHash))
+
     describe('sign', () => {
       it('should produce correct signature of message', () => {
         const s = Crypto.signMessage(message, privateKey)


### PR DESCRIPTION
I've added signing ability 5 years ago in 816ceb3368dab517c1418dee8c82c304e2356ab3, it was adopted from Bitcoin, but I didn't figured out the way how long messages should be encoded. Well, I did it now!

To avoid message length limitation, projects hashing the message one more time before signing. This probably would remain the same, but new projects would be able to sign in a simpler way. I don't think that this is a breaking change, but we shouldn't forget to implement the same in Ledger and so.

https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer