### PR TITLE
feat(aepp): support external accounts in onAccount

### DIFF
--- a/src/account/base.js
+++ b/src/account/base.js
@@ -36,7 +36,8 @@ import { getNetworkId } from '../node'
  * @param {Object} acc - Object to check
  * @return {Boolean}
  */
-export const isAccountBase = (acc) => !['sign', 'address'].find(f => typeof acc[f] !== 'function')
+export const isAccountBase = (acc) => !['sign', 'address', 'signTransaction', 'signMessage']
+  .find(f => typeof acc[f] !== 'function')
 
 /**
  * Sign encoded transaction

--- a/src/account/multiple.js
+++ b/src/account/multiple.js
@@ -139,23 +139,17 @@ export default AccountBase.compose(AsyncInit, {
      * @private
      */
     _resolveAccount (account) {
-      if (account === null) {
-        throw new TypeError(
-          'Account should be an address (ak-prefixed string), ' +
-          'keypair, or instance of account base, got null instead')
-      } else {
-        switch (typeof account) {
-          case 'string':
-            decode(account, 'ak')
-            if (!this.accounts[account]) throw new UnavailableAccountError(account)
-            return this.accounts[account]
-          case 'object':
-            return isAccountBase(account) ? account : MemoryAccount({ keypair: account })
-          default:
-            throw new TypeError(
-              'Account should be an address (ak-prefixed string), ' +
-              `keypair, or instance of account base, got ${account} instead`)
-        }
+      switch (account !== null && typeof account) {
+        case 'string':
+          decode(account, 'ak')
+          if (!this.accounts[account]) throw new UnavailableAccountError(account)
+          return this.accounts[account]
+        case 'object':
+          return isAccountBase(account) ? account : MemoryAccount({ keypair: account })
+        default:
+          throw new TypeError(
+            'Account should be an address (ak-prefixed string), ' +
+            `keypair, or instance of account base, got ${account} instead`)
       }
     }
   }

--- a/src/account/multiple.js
+++ b/src/account/multiple.js
@@ -149,7 +149,7 @@ export default AccountBase.compose(AsyncInit, {
         default:
           throw new TypeError(
             'Account should be an address (ak-prefixed string), ' +
-            `keypair, or instance of account base, got ${account} instead`)
+            `keypair, or instance of AccountBase, got ${account} instead`)
       }
     }
   }

--- a/src/account/multiple.js
+++ b/src/account/multiple.js
@@ -22,13 +22,9 @@
  */
 
 import AsyncInit from '../utils/async-init'
-import MemoryAccount from './memory'
-import { decode } from '../tx/builder/helpers'
-import AccountBase, { isAccountBase } from './base'
-import {
-  UnavailableAccountError,
-  TypeError
-} from '../utils/errors'
+import { decode } from '../utils/encoder'
+import AccountResolver from './resolver'
+import { UnavailableAccountError } from '../utils/errors'
 
 /**
  * AccountMultiple stamp
@@ -53,13 +49,23 @@ import {
  * accounts.selectAccount(address) // Select account
  * accounts.addresses() // Get available accounts
  */
-export default AccountBase.compose(AsyncInit, {
+export default AccountResolver.compose(AsyncInit, {
   async init ({ accounts = [], address }) {
     this.accounts = Object.fromEntries(await Promise.all(
       accounts.map(async a => [await a.address(), a])
     ))
     address = address || Object.keys(this.accounts)[0]
     if (address) this.selectAccount(address)
+
+    const resolveAccountBase = this._resolveAccount
+    this._resolveAccount = (account = this.selectedAddress) => {
+      if (typeof account === 'string') {
+        decode(account, 'ak')
+        if (!this.accounts[account]) throw new UnavailableAccountError(account)
+        account = this.accounts[account]
+      }
+      return resolveAccountBase(account)
+    }
   },
   props: {
     accounts: {}
@@ -68,12 +74,6 @@ export default AccountBase.compose(AsyncInit, {
     selectedAddress: null
   },
   methods: {
-    async address ({ onAccount = this.selectedAddress } = {}) {
-      return this._resolveAccount(onAccount).address()
-    },
-    async sign (data, { onAccount = this.selectedAddress } = {}) {
-      return this._resolveAccount(onAccount).sign(data)
-    },
     /**
      * Get accounts addresses
      * @alias module:@aeternity/aepp-sdk/es/accounts/multiple
@@ -131,26 +131,6 @@ export default AccountBase.compose(AsyncInit, {
       decode(address, 'ak')
       if (!this.accounts[address]) throw new UnavailableAccountError(address)
       this.selectedAddress = address
-    },
-    /**
-     * Resolves an account
-     * @param account account address (should exist in sdk instance), MemoryAccount or keypair
-     * @returns {AccountBase}
-     * @private
-     */
-    _resolveAccount (account) {
-      switch (account !== null && typeof account) {
-        case 'string':
-          decode(account, 'ak')
-          if (!this.accounts[account]) throw new UnavailableAccountError(account)
-          return this.accounts[account]
-        case 'object':
-          return isAccountBase(account) ? account : MemoryAccount({ keypair: account })
-        default:
-          throw new TypeError(
-            'Account should be an address (ak-prefixed string), ' +
-            `keypair, or instance of AccountBase, got ${account} instead`)
-      }
     }
   }
 })

--- a/src/account/resolver.js
+++ b/src/account/resolver.js
@@ -1,0 +1,56 @@
+/**
+ * AccountResolver module
+ * @module @aeternity/aepp-sdk/es/accounts/resolver
+ * @export AccountResolver
+ */
+
+import MemoryAccount from './memory'
+import AccountBase, { isAccountBase } from './base'
+import { NotImplementedError, TypeError } from '../utils/errors'
+
+/**
+ * Stateless resolver of account passed in `onAccount` option
+ * @function
+ * @alias module:@aeternity/aepp-sdk/es/accounts/resolver
+ * @rtype Stamp
+ * @return {Object} AccountResolver instance
+ * @example
+ * const resolver = AccountResolver()
+ * account = MemoryAccount({ keypair: 'keypair_object' })
+ * resolver.address({ onAccount: account }) // Get account's address
+ */
+export default AccountBase.compose({
+  methods: {
+    async address ({ onAccount } = {}) {
+      return this._resolveAccount(onAccount).address()
+    },
+    async sign (data, { onAccount } = {}) {
+      return this._resolveAccount(onAccount).sign(data)
+    },
+    async signTransaction (tx, { onAccount, ...options } = {}) {
+      return this._resolveAccount(onAccount)
+        .signTransaction(tx, { ...options, networkId: this.getNetworkId(options) })
+    },
+    async signMessage (message, { onAccount, ...options } = {}) {
+      return this._resolveAccount(onAccount).signMessage(message, options)
+    },
+    /**
+     * Resolves an account
+     * @param {Object} account ak-address, instance of AccountBase, or keypair
+     * @returns {AccountBase}
+     * @private
+     */
+    _resolveAccount (account) {
+      switch (account !== null && typeof account) {
+        case 'string':
+          throw new NotImplementedError('Address in AccountResolver')
+        case 'object':
+          return isAccountBase(account) ? account : MemoryAccount({ keypair: account })
+        default:
+          throw new TypeError(
+            'Account should be an address (ak-prefixed string), ' +
+            `keypair, or instance of AccountBase, got ${account} instead`)
+      }
+    }
+  }
+})

--- a/src/account/rpc.js
+++ b/src/account/rpc.js
@@ -1,0 +1,59 @@
+/**
+ * AccountRpc module
+ * @module @aeternity/aepp-sdk/es/account/rpc
+ * @export AccountRpc
+ */
+import AccountBase from './base'
+import { METHODS } from '../utils/aepp-wallet-communication/schema'
+import { NotImplementedError } from '../utils/errors'
+
+/**
+ * Account provided by wallet
+ * @alias module:@aeternity/aepp-sdk/es/account/rpc
+ * @function
+ * @rtype Stamp
+ * @param {Object} param Init params object
+ * @param {Object} param.rpcClient RpcClient instance
+ * @param {Object} param.address RPC account address
+ * @return {Object} AccountRpc instance
+ */
+export default AccountBase.compose({
+  init ({ rpcClient, address }) {
+    this._rpcClient = rpcClient
+    this._address = address
+  },
+  methods: {
+    sign () {
+      throw new NotImplementedError('RAW signing using wallet')
+    },
+    async address () {
+      return this._address
+    },
+    /**
+     * @function signTransaction
+     * @instance
+     * @rtype (tx: String, options = {}) => Promise
+     * @return {Promise<String>} Signed transaction
+     */
+    async signTransaction (tx, options) {
+      return this._rpcClient.request(METHODS.sign, {
+        ...options,
+        onAccount: this._address,
+        tx,
+        returnSigned: true,
+        networkId: this.getNetworkId(options)
+      })
+    },
+    /**
+     * @function signMessage
+     * @instance
+     * @rtype (message: String, options = {}) => Promise
+     * @return {Promise<String>} Signed message
+     */
+    async signMessage (message, options) {
+      return this._rpcClient.request(
+        METHODS.signMessage, { ...options, onAccount: this._address, message }
+      )
+    }
+  }
+})

--- a/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js
+++ b/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js
@@ -122,7 +122,6 @@ export default Ae.compose({
       await this.connectToWallet(connection)
     }
   },
-  deepProps: { Ae: { defaults: { walletBroadcast: true } } },
   methods: {
     sign () {
     },
@@ -249,32 +248,6 @@ export default Ae.compose({
           networkId: this.getNetworkId({ force: true }),
           connectNode
         }
-      )
-    },
-    /**
-     * Overwriting of `send` AE method
-     * All sdk API which use it will be send notification to wallet and wait for callBack
-     * This method will sign, broadcast and wait until transaction will be accepted using rpc
-     * communication with wallet
-     * @function send
-     * @instance
-     * @rtype (tx: String, options = {}) => Promise
-     * @param {String} tx
-     * @param {Object} [options={}]
-     * @param {Object} [options.walletBroadcast=true]
-     * @return {Promise<Object>} Transaction broadcast result
-     */
-    async send (tx, options = {}) {
-      this._ensureConnected()
-      this._ensureAccountAccess(options.onAccount)
-      const opt = { ...this.Ae.defaults, ...options }
-      if (!opt.walletBroadcast) {
-        const signed = await this.signTransaction(tx, { onAccount: opt.onAccount })
-        return this.sendTransaction(signed, opt)
-      }
-      return this.rpcClient.request(
-        METHODS.sign,
-        { onAccount: opt.onAccount, tx, returnSigned: false, networkId: this.getNetworkId() }
       )
     },
     _ensureConnected () {

--- a/test/integration/accounts.js
+++ b/test/integration/accounts.js
@@ -170,7 +170,7 @@ describe('Accounts', function () {
       return expect(aeSdk.spend(1, await aeSdk.address(), { onAccount: 1 }))
         .to.be.rejectedWith(
           TypeError,
-          'Account should be an address (ak-prefixed string), keypair, or instance of account base, got 1 instead')
+          'Account should be an address (ak-prefixed string), keypair, or instance of AccountBase, got 1 instead')
     })
 
     it('Fail on non exist account', async () => {
@@ -184,14 +184,14 @@ describe('Accounts', function () {
       return expect(aeSdkWithoutAccount.spend(1, await aeSdk.address()))
         .to.be.rejectedWith(
           TypeError,
-          'Account should be an address (ak-prefixed string), keypair, or instance of account base, got null instead')
+          'Account should be an address (ak-prefixed string), keypair, or instance of AccountBase, got null instead')
     })
 
     it('Invalid on account options', () => {
       return expect(aeSdk.sign('tx_Aasdasd', { onAccount: 123 }))
         .to.be.rejectedWith(
           TypeError,
-          'Account should be an address (ak-prefixed string), keypair, or instance of account base, got 123 instead')
+          'Account should be an address (ak-prefixed string), keypair, or instance of AccountBase, got 123 instead')
     })
     it('Make operation on account using keyPair/MemoryAccount', async () => {
       const keypair = generateKeyPair()

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -54,7 +54,7 @@ export const BaseAe = async (params = {}, compose = {}) => Universal
     nodes: [{ name: 'test', instance: await Node({ url, internalUrl, ignoreVersion }) }]
   })
 
-const spendPromise = (async () => {
+export const spendPromise = (async () => {
   const ae = await BaseAe({ networkId, withoutGenesisAccount: false })
   await ae.awaitHeight(2)
   await ae.spend(1e26, account.publicKey)

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -286,19 +286,6 @@ describe('Aepp<->Wallet', function () {
         .with.property('code', 11)
     })
 
-    it('Sign and broadcast transaction by wallet', async () => {
-      const address = await aepp.address()
-      const tx = await aepp.spendTx({
-        senderId: address,
-        recipientId: address,
-        amount: 0,
-        payload: 'zerospend'
-      })
-
-      const { blockHeight } = await aepp.send(tx)
-      blockHeight.should.be.a('number')
-    })
-
     it('Sign by wallet and broadcast transaction by aepp ', async () => {
       const address = await aepp.address()
       wallet.onSign = (aepp, action) => {
@@ -316,7 +303,7 @@ describe('Aepp<->Wallet', function () {
         amount: 0,
         payload: 'zerospend'
       })
-      const res = await aepp.send(tx, { walletBroadcast: false })
+      const res = await aepp.send(tx)
       decode(res.tx.payload).toString().should.be.equal('zerospend2')
       res.blockHeight.should.be.a('number')
     })
@@ -375,8 +362,8 @@ describe('Aepp<->Wallet', function () {
         payload: 'zerospend'
       })
 
-      await expect(aepp.send(tx)).to.be.eventually
-        .rejectedWith('Invalid transaction').with.property('code', 2)
+      await expect(aepp.send(tx)).to.be
+        .rejectedWith('Transaction verification errors: Fee 123 is too low, minimum fee for this transaction is 16840000000000')
     })
 
     it('Add new account to wallet: receive notification for update accounts', async () => {
@@ -619,7 +606,7 @@ describe('Aepp<->Wallet', function () {
         amount: 0,
         payload: 'zerospend'
       })
-      const res = await aepp.send(tx, { walletBroadcast: false })
+      const res = await aepp.send(tx)
       decode(res.tx.payload).toString().should.be.equal('zerospend2')
       res.blockHeight.should.be.a('number')
     })

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -24,7 +24,7 @@ import BrowserWindowMessageConnection from '../../src/utils/aepp-wallet-communic
 import { getBrowserAPI, getHandler } from '../../src/utils/aepp-wallet-communication/helpers'
 import { METHODS, RPC_STATUS } from '../../src/utils/aepp-wallet-communication/schema'
 import { generateKeyPair, verify, hash } from '../../src/utils/crypto'
-import { compilerUrl, genesisAccount, internalUrl, networkId, publicKey, url, ignoreVersion } from './'
+import { compilerUrl, account, internalUrl, networkId, url, ignoreVersion, spendPromise } from './'
 import {
   NoBrowserFoundError,
   NoWalletConnectedError,
@@ -62,9 +62,10 @@ describe('Aepp<->Wallet', function () {
     let wallet
 
     before(async () => {
+      await spendPromise
       wallet = await RpcWallet({
         compilerUrl,
-        accounts: [genesisAccount],
+        accounts: [MemoryAccount({ keypair: account })],
         nodes: [{ name: 'local', instance: node }],
         name: 'Wallet',
         onConnection (aepp, { accept, deny }) {
@@ -185,7 +186,7 @@ describe('Aepp<->Wallet', function () {
       subscriptionResponse.subscription.should.be.an('array')
       subscriptionResponse.subscription.filter(e => e === 'connected').length.should.be.equal(1)
       subscriptionResponse.address.current.should.be.an('object')
-      Object.keys(subscriptionResponse.address.current)[0].should.be.equal(publicKey)
+      Object.keys(subscriptionResponse.address.current)[0].should.be.equal(account.publicKey)
       subscriptionResponse.address.connected.should.be.an('object')
       Object.keys(subscriptionResponse.address.connected).length.should.be.equal(1)
     })
@@ -196,8 +197,12 @@ describe('Aepp<->Wallet', function () {
         .to.be.rejectedWith(UnAuthorizedAccountError, `You do not have access to account ${publicKey}`)
     })
 
+    it('aepp accepts key pairs in onAccount', async () => {
+      await aepp.spend(100, await aepp.address(), { onAccount: account })
+    })
+
     it('Get address: subscribed for accounts', async () => {
-      (await aepp.address()).should.be.equal(publicKey)
+      (await aepp.address()).should.be.equal(account.publicKey)
     })
 
     it('Ask for address: subscribed for accounts -> wallet deny', async () => {
@@ -214,7 +219,7 @@ describe('Aepp<->Wallet', function () {
       }
       const addressees = await aepp.askAddresses()
       addressees.length.should.be.equal(2)
-      addressees[0].should.be.equal(publicKey)
+      addressees[0].should.be.equal(account.publicKey)
     })
 
     it('Not authorize', async () => {
@@ -533,7 +538,7 @@ describe('Aepp<->Wallet', function () {
     before(async () => {
       wallet = await RpcWallet({
         compilerUrl,
-        accounts: [genesisAccount],
+        accounts: [MemoryAccount({ keypair: account })],
         nodes: [{ name: 'local', instance: node }],
         name: 'Wallet',
         onConnection (aepp, { accept, deny }) {
@@ -584,7 +589,7 @@ describe('Aepp<->Wallet', function () {
       subscriptionResponse.subscription.should.be.an('array')
       subscriptionResponse.subscription.filter(e => e === 'connected').length.should.be.equal(1)
       subscriptionResponse.address.current.should.be.an('object')
-      Object.keys(subscriptionResponse.address.current)[0].should.be.equal(publicKey)
+      Object.keys(subscriptionResponse.address.current)[0].should.be.equal(account.publicKey)
       subscriptionResponse.address.connected.should.be.an('object')
       Object.keys(subscriptionResponse.address.connected).length.should.be.equal(1)
     })


### PR DESCRIPTION
closes #1390 

I'm proposing switch the default behaviour from transaction 
 broadcasting by wallet to broadcasting by aepp and to remove the code for the first to simplify things.
I can't recall why broadcasting by wallet was introduced, but broadcasting by aepp is more natural from code perspective and also it would provide a better stack trase in case of failure.