### PR TITLE
feat(utils): migrate hd-wallet.js to TS

### DIFF
--- a/src/typings/bip32-path/index.d.ts
+++ b/src/typings/bip32-path/index.d.ts
@@ -1,0 +1,33 @@
+// TODO: remove after solving https://github.com/axic/bip32-path/issues/5
+
+declare module 'bip32-path' {
+  interface BipPath {
+    toPathArray: () => number[]
+    /**
+     * returns a text encoded path. Set to noRoot to true to omit the m/ prefix.
+     * Set oldStyle true to use h instead of ' for marking hardened nodes.
+     */
+    toString: (noRoot: boolean, oldStyle: boolean) => string
+
+    /**
+     * returns true if the input is a valid path string
+     */
+    validateString: (path: string) => boolean
+
+    /**
+     * returns true if the input is a valid binary path array
+     */
+    validatePathArray: (path: string) => boolean
+  }
+
+  /**
+   * creates an instance from a path written as text.
+   * Set reqRoot to true if the m/ prefix is mandatory.
+   */
+  export const fromString: (text: string, reqRoot?: boolean) => BipPath
+
+  /**
+   * creates an instance from a binary path array
+   */
+  export const fromPathArray: (path: string) => BipPath
+}

--- a/src/typings/tweetnacl-auth/index.d.ts
+++ b/src/typings/tweetnacl-auth/index.d.ts
@@ -1,0 +1,14 @@
+// TODO: remove after solving https://github.com/dchest/tweetnacl-auth-js/issues/3
+
+declare module 'tweetnacl-auth' {
+  /**
+   * Authenticates the given message with the secret key.
+   * (In other words, returns HMAC-SHA-512-256 of the message under the key.)
+   */
+  export default function (message: Uint8Array, key: Uint8Array): Uint8Array
+
+  /**
+   * Returns HMAC-SHA-512 (without truncation) of the message under the key
+   */
+  export const full: (message: Uint8Array, key: Uint8Array) => Uint8Array
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -167,13 +167,13 @@ export function encryptKey (password: string, binaryData: Uint8Array): Uint8Arra
  * @rtype (password: String, encrypted: String) => Uint8Array
  * @param {String} password - Password to decrypt with
  * @param {Uint8Array} encrypted - Data to decrypt
- * @return {Buffer} Decrypted data
+ * @return {Uint8Array} Decrypted data
  */
-export function decryptKey (password: string, encrypted: Uint8Array): Buffer {
+export function decryptKey (password: string, encrypted: Uint8Array): Uint8Array {
   const encryptedBytes = Buffer.from(encrypted)
   const hashedPasswordBytes = sha256hash(password)
   const aesEcb = new Ecb(hashedPasswordBytes)
-  return Buffer.from(aesEcb.decrypt(encryptedBytes))
+  return aesEcb.decrypt(encryptedBytes)
 }
 
 // SIGNATURES

--- a/src/utils/encoder.ts
+++ b/src/utils/encoder.ts
@@ -28,7 +28,7 @@ const typesLength: { [name: string]: number } = {
   ok: 32
 } as const
 
-function ensureValidLength (data: Buffer | string, type: string): void {
+function ensureValidLength (data: Uint8Array | string, type: string): void {
   if (typesLength[type] == null) return
   if (data.length === typesLength[type]) return
   throw new PayloadLengthError(`Payload should be ${typesLength[type]} bytes, got ${data.length} instead`)
@@ -37,7 +37,7 @@ function ensureValidLength (data: Buffer | string, type: string): void {
 const getChecksum = (payload: Buffer | string): Buffer =>
   sha256hash(sha256hash(payload)).slice(0, 4)
 
-const addChecksum = (input: Buffer | string): Buffer => {
+const addChecksum = (input: Uint8Array | string): Buffer => {
   const payload = Buffer.from(input)
   return Buffer.concat([payload, getChecksum(payload)])
 }
@@ -49,12 +49,12 @@ function getPayload (buffer: Buffer): Buffer {
 }
 
 const base64 = {
-  encode: (buffer: Buffer | string) => addChecksum(buffer).toString('base64'),
+  encode: (buffer: Uint8Array | string) => addChecksum(buffer).toString('base64'),
   decode: (string: string) => getPayload(Buffer.from(string, 'base64'))
 }
 
 const base58 = {
-  encode: (buffer: Buffer | string) => bs58Encode(addChecksum(buffer)),
+  encode: (buffer: Uint8Array | string) => bs58Encode(addChecksum(buffer)),
   decode: (string: string) => getPayload(bs58Decode(string))
 }
 
@@ -91,7 +91,7 @@ export function decode (data: string, requiredPrefix?: string): Buffer {
  * @param {string} type Prefix of Transaction
  * @return {String} Encoded string Base58check or Base64check data
  */
-export function encode (data: Buffer | string, type: string): string {
+export function encode (data: Uint8Array | string, type: string): string {
   const encoder = (base64Types.includes(type) && base64.encode) ||
     (base58Types.includes(type) && base58.encode)
   if (encoder === false) {

--- a/src/utils/hd-wallet.ts
+++ b/src/utils/hd-wallet.ts
@@ -2,7 +2,7 @@ import nacl from 'tweetnacl'
 import { full as hmac } from 'tweetnacl-auth'
 import { fromString } from 'bip32-path'
 import { decryptKey, encryptKey } from './crypto'
-import { encode } from '../tx/builder/helpers'
+import { encode } from './encoder'
 import {
   InvalidDerivationPathError, NotHardenedSegmentError, UnsupportedChildIndexError
 } from './errors'
@@ -10,9 +10,24 @@ import {
 const ED25519_CURVE = Buffer.from('ed25519 seed')
 const HARDENED_OFFSET = 0x80000000
 
-const toHex = (buffer) => Buffer.from(buffer).toString('hex')
+const toHex = (buffer: Uint8Array): string => Buffer.from(buffer).toString('hex')
 
-export function derivePathFromKey (path, key) {
+interface KeyTreeNode {
+  secretKey: Uint8Array
+  chainCode: Uint8Array
+}
+
+interface HDWallet {
+  secretKey: string
+  chainCode: string
+}
+
+interface Account {
+  secretKey: string
+  publicKey: string
+}
+
+export function derivePathFromKey (path: string, key: KeyTreeNode): KeyTreeNode {
   const segments = path === '' ? [] : fromString(path).toPathArray()
   segments.forEach((segment, i) => {
     if (segment < HARDENED_OFFSET) {
@@ -23,7 +38,7 @@ export function derivePathFromKey (path, key) {
   return segments.reduce((parentKey, segment) => deriveChild(parentKey, segment), key)
 }
 
-export function derivePathFromSeed (path, seed) {
+export function derivePathFromSeed (path: string, seed: Uint8Array): KeyTreeNode {
   if (!['m', 'm/'].includes(path.slice(0, 2))) {
     throw new InvalidDerivationPathError()
   }
@@ -31,7 +46,7 @@ export function derivePathFromSeed (path, seed) {
   return derivePathFromKey(path.slice(2), masterKey)
 }
 
-function formatAccount (keys) {
+function formatAccount (keys: nacl.SignKeyPair): Account {
   const { secretKey, publicKey } = keys
   return {
     secretKey: toHex(secretKey),
@@ -39,11 +54,11 @@ function formatAccount (keys) {
   }
 }
 
-export function getKeyPair (secretKey) {
+export function getKeyPair (secretKey: Uint8Array): nacl.SignKeyPair {
   return nacl.sign.keyPair.fromSeed(secretKey)
 }
 
-export function getMasterKeyFromSeed (seed) {
+export function getMasterKeyFromSeed (seed: Uint8Array): KeyTreeNode {
   const I = hmac(seed, ED25519_CURVE)
   const IL = I.slice(0, 32)
   const IR = I.slice(32)
@@ -53,14 +68,14 @@ export function getMasterKeyFromSeed (seed) {
   }
 }
 
-export function deriveChild ({ secretKey, chainCode }, index) {
+export function deriveChild ({ secretKey, chainCode }: KeyTreeNode, index: number): KeyTreeNode {
   if (index < HARDENED_OFFSET) {
-    throw new UnsupportedChildIndexError(index)
+    throw new UnsupportedChildIndexError(index.toString())
   }
   const indexBuffer = Buffer.allocUnsafe(4)
   indexBuffer.writeUInt32BE(index, 0)
 
-  const data = Buffer.concat([Buffer.alloc(1, 0), Buffer.from(secretKey), Buffer.from(indexBuffer)])
+  const data = Buffer.concat([Buffer.alloc(1, 0), secretKey, indexBuffer])
 
   const I = hmac(data, chainCode)
   const IL = I.slice(0, 32)
@@ -71,7 +86,7 @@ export function deriveChild ({ secretKey, chainCode }, index) {
   }
 }
 
-export function generateSaveHDWalletFromSeed (seed, password) {
+export function generateSaveHDWalletFromSeed (seed: Uint8Array, password: string): HDWallet {
   const walletKey = derivePathFromSeed('m/44h/457h', seed)
   return {
     secretKey: toHex(encryptKey(password, walletKey.secretKey)),
@@ -79,17 +94,21 @@ export function generateSaveHDWalletFromSeed (seed, password) {
   }
 }
 
-export function getSaveHDWalletAccounts (saveHDWallet, password, accountCount) {
+export function getSaveHDWalletAccounts (
+  saveHDWallet: HDWallet, password: string, accountCount: number
+): Account[] {
   const walletKey = {
     secretKey: decryptKey(password, Buffer.from(saveHDWallet.secretKey, 'hex')),
     chainCode: decryptKey(password, Buffer.from(saveHDWallet.chainCode, 'hex'))
   }
-  return (new Array(accountCount)).fill()
+  return (new Array(accountCount)).fill(undefined)
     .map((_, idx) =>
       formatAccount(getKeyPair(derivePathFromKey(`${idx}h/0h/0h`, walletKey).secretKey)))
 }
 
-export const getHdWalletAccountFromSeed = (seed, accountIdx) => {
+export const getHdWalletAccountFromSeed = (
+  seed: Uint8Array, accountIdx: number
+): Account & { idx: number } => {
   const walletKey = derivePathFromSeed('m/44h/457h', seed)
   const derived = derivePathFromKey(`${accountIdx}h/0h/0h`, walletKey)
   const keyPair = getKeyPair(derived.secretKey)

--- a/test/unit/hd-wallet.ts
+++ b/test/unit/hd-wallet.ts
@@ -22,7 +22,7 @@ import {
   getMasterKeyFromSeed,
   getSaveHDWalletAccounts
 } from '../../src/utils/hd-wallet'
-import { encode, decode } from '../../src/tx/builder/helpers'
+import { encode, decode } from '../../src/utils/encoder'
 import { InvalidDerivationPathError } from '../../src/utils/errors'
 
 describe('hd wallet', () => {
@@ -178,6 +178,6 @@ describe('hd wallet', () => {
   })
 
   it('Derive child with invalid path', () => {
-    expect(() => derivePathFromSeed('asd')).to.throw(InvalidDerivationPathError, 'Invalid path')
+    expect(() => derivePathFromSeed('asd', Buffer.from([]))).to.throw(InvalidDerivationPathError, 'Invalid path')
   })
 })


### PR DESCRIPTION
closes #1475 

This PR migrates the `hd-wallet.js` util together with its corresponding test files to TS. It also adds types for the `bip32-path` and `tweetnacl-auth` modules