### PR TITLE
chore: fix spacing around | in TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,8 @@ const equivalents = [
   'no-useless-constructor',
   'quotes',
   'semi',
-  'space-before-function-paren'
+  'space-before-function-paren',
+  'space-infix-ops'
 ]
 
 const ruleFromStandard = (name) => {


### PR DESCRIPTION
also I propose a fix to upstream: https://github.com/standard/eslint-config-standard-with-typescript/pull/802