### PR TITLE
Combine derivation errors to a single class, add Bip32Path type

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -67,14 +67,12 @@ BaseError
 │
 └───CryptographyError
 │   │   InvalidChecksumError
-│   │   InvalidDerivationPathError
+│   │   DerivationError
 │   │   InvalidPasswordError
 │   │   MerkleTreeHashMismatchError
 │   │   MissingNodeInTreeError
-│   │   NotHardenedSegmentError
 │   │   UnknownNodeLengthError
 │   │   UnknownPathNibbleError
-│   │   UnsupportedChildIndexError
 │
 └───NodeError
 │   │   DisconnectedError

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -441,13 +441,6 @@ export class InvalidChecksumError extends CryptographyError {
   }
 }
 
-export class InvalidDerivationPathError extends CryptographyError {
-  constructor () {
-    super('Invalid path')
-    this.name = 'InvalidDerivationPathError'
-  }
-}
-
 export class InvalidPasswordError extends CryptographyError {
   constructor () {
     super('Invalid password or nonce')
@@ -469,13 +462,6 @@ export class MissingNodeInTreeError extends CryptographyError {
   }
 }
 
-export class NotHardenedSegmentError extends CryptographyError {
-  constructor (message: string) {
-    super(message)
-    this.name = 'NotHardenedSegmentError'
-  }
-}
-
 export class UnknownNodeLengthError extends CryptographyError {
   constructor (nodeLength: number) {
     super(`Unknown node length: ${nodeLength}`)
@@ -487,13 +473,6 @@ export class UnknownPathNibbleError extends CryptographyError {
   constructor (nibble: number) {
     super(`Unknown path nibble: ${nibble}`)
     this.name = 'UnknownPathNibbleError'
-  }
-}
-
-export class UnsupportedChildIndexError extends CryptographyError {
-  constructor (index: string) {
-    super(`Child index #${index} is not supported`)
-    this.name = 'UnsupportedChildIndexError'
   }
 }
 

--- a/src/utils/hd-wallet.ts
+++ b/src/utils/hd-wallet.ts
@@ -4,6 +4,7 @@ import { fromString } from 'bip32-path'
 import { decryptKey, encryptKey } from './crypto'
 import { encode } from './encoder'
 import { CryptographyError } from './errors'
+import { bytesToHex } from './bytes'
 
 export class DerivationError extends CryptographyError {
   constructor (message: string) {
@@ -14,8 +15,6 @@ export class DerivationError extends CryptographyError {
 
 const ED25519_CURVE = Buffer.from('ed25519 seed')
 const HARDENED_OFFSET = 0x80000000
-
-const toHex = (buffer: Uint8Array): string => Buffer.from(buffer).toString('hex')
 
 interface KeyTreeNode {
   secretKey: Uint8Array
@@ -54,7 +53,7 @@ export function derivePathFromSeed (path: string, seed: Uint8Array): KeyTreeNode
 function formatAccount (keys: nacl.SignKeyPair): Account {
   const { secretKey, publicKey } = keys
   return {
-    secretKey: toHex(secretKey),
+    secretKey: bytesToHex(secretKey),
     publicKey: encode(publicKey, 'ak')
   }
 }
@@ -94,8 +93,8 @@ export function deriveChild ({ secretKey, chainCode }: KeyTreeNode, index: numbe
 export function generateSaveHDWalletFromSeed (seed: Uint8Array, password: string): HDWallet {
   const walletKey = derivePathFromSeed('m/44h/457h', seed)
   return {
-    secretKey: toHex(encryptKey(password, walletKey.secretKey)),
-    chainCode: toHex(encryptKey(password, walletKey.chainCode))
+    secretKey: bytesToHex(encryptKey(password, walletKey.secretKey)),
+    chainCode: bytesToHex(encryptKey(password, walletKey.chainCode))
   }
 }
 

--- a/test/unit/hd-wallet.ts
+++ b/test/unit/hd-wallet.ts
@@ -81,7 +81,7 @@ describe('hd wallet', () => {
 
   describe('derivePathFromKey', () =>
     it('derives correct child key by path and key', () => {
-      const childKey = derivePathFromKey(testChildPath.replace('m/', ''), testMasterKey)
+      const childKey = derivePathFromKey(testChildPath.replace('m/', '') as '0h', testMasterKey)
       expect(childKey).to.eql(testChildKey)
     }))
 
@@ -92,7 +92,7 @@ describe('hd wallet', () => {
     }))
 
   describe('check on test vectors for ed25519 from SLIP-0010', () =>
-    [{
+    ([{
       seed: Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex'),
       tests: [{
         path: 'm',
@@ -158,7 +158,7 @@ describe('hd wallet', () => {
         prv: Buffer.from('551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d', 'hex'),
         pub: Buffer.from('0047150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0', 'hex')
       }]
-    }]
+    }] as const)
       .forEach(({ seed, tests }, idx) => {
         describe(`vector ${idx + 1}`, () =>
           tests.forEach(test =>
@@ -178,6 +178,6 @@ describe('hd wallet', () => {
   })
 
   it('Derive child with invalid path', () => {
-    expect(() => derivePathFromSeed('asd', Buffer.from([]))).to.throw(DerivationError, 'Root element is required')
+    expect(() => derivePathFromSeed('asd' as 'm', Buffer.from([]))).to.throw(DerivationError, 'Root element is required')
   })
 })

--- a/test/unit/hd-wallet.ts
+++ b/test/unit/hd-wallet.ts
@@ -20,10 +20,10 @@ import {
   deriveChild, derivePathFromKey, derivePathFromSeed,
   generateSaveHDWalletFromSeed, getHdWalletAccountFromSeed, getKeyPair,
   getMasterKeyFromSeed,
-  getSaveHDWalletAccounts
+  getSaveHDWalletAccounts,
+  DerivationError
 } from '../../src/utils/hd-wallet'
 import { encode, decode } from '../../src/utils/encoder'
-import { InvalidDerivationPathError } from '../../src/utils/errors'
 
 describe('hd wallet', () => {
   const testMnemonicSeed = Buffer.from('Git7bFJkmfC1Ho+6YFSFuxSzmDZydmjzk8FubrPDz4PmrkORlBDlfnPTk02Wq9Pj2ZdQ5cTA0SxHKGrq3xSjOw==', 'base64')
@@ -178,6 +178,6 @@ describe('hd wallet', () => {
   })
 
   it('Derive child with invalid path', () => {
-    expect(() => derivePathFromSeed('asd', Buffer.from([]))).to.throw(InvalidDerivationPathError, 'Invalid path')
+    expect(() => derivePathFromSeed('asd', Buffer.from([]))).to.throw(DerivationError, 'Root element is required')
   })
 })


### PR DESCRIPTION
I'm sure that `NotHardenedSegmentError` and `UnsupportedChildIndexError` should be combined because they actually refers to the same issue. But do we need to be able to distinglish between invalid derivation path root and not hardened segment in the path on the level of classes? We already have a lot of error classes, I don't think that we need 3 of them for derivation.