### PR TITLE
Web wallet extension: shouldn't open connections to pages that not using it 

### DIFF
--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -73,7 +73,6 @@ import {
     aeSdk.addRpcClient(connection)
     // share wallet details
     aeSdk.shareWalletInfo(port.postMessage.bind(port))
-    setInterval(() => aeSdk.shareWalletInfo(port.postMessage.bind(port)), 3000)
   })
 
   console.log('Wallet initialized!')

--- a/examples/browser/wallet-web-extension/src/content-script.js
+++ b/examples/browser/wallet-web-extension/src/content-script.js
@@ -1,5 +1,3 @@
-/* global browser */
-
 import {
   BrowserRuntimeConnection, BrowserWindowMessageConnection, MESSAGE_DIRECTION, ContentScriptBridge
 } from '@aeternity/aepp-sdk'
@@ -16,13 +14,11 @@ import {
   })
   console.log('Document is ready')
 
-  const port = browser.runtime.connect()
   const extConnection = BrowserRuntimeConnection({
     connectionInfo: {
       description: 'Content Script to Extension connection',
       origin: window.origin
-    },
-    port
+    }
   })
   const pageConnection = BrowserWindowMessageConnection({
     connectionInfo: {

--- a/src/utils/aepp-wallet-communication/connection/browser-runtime.js
+++ b/src/utils/aepp-wallet-communication/connection/browser-runtime.js
@@ -1,6 +1,6 @@
 /*
  * ISC License (ISC)
- * Copyright (c) 2018 aeternity developers
+ * Copyright (c) 2022 aeternity developers
  *
  *  Permission to use, copy, modify, and/or distribute this software for any
  *  purpose with or without fee is hereby granted, provided that the above
@@ -60,6 +60,7 @@ function disconnect () {
  */
 function connect (onMessage, onDisconnect) {
   if (this.isConnected()) throw new AlreadyConnectedError('You already connected')
+  this.port = this.port ?? getBrowserAPI().runtime.connect(...[this.connectionInfo.id || undefined])
   this.handler = (msg, source) => {
     if (this.debug) console.log('Receive message: ', msg)
     onMessage(msg, source)
@@ -93,7 +94,11 @@ function sendMessage (msg) {
  * @return {Boolean} Is connected
  */
 function isConnected () {
-  return typeof this.port.onMessage.hasListeners === 'function' ? this.port.onMessage.hasListeners() : this.port.onMessage.hasListener(this.handler)
+  if (this.port) {
+    return typeof this.port.onMessage.hasListeners === 'function'
+      ? this.port.onMessage.hasListeners()
+      : this.port.onMessage.hasListener(this.handler)
+  } else return false
 }
 
 /**
@@ -113,7 +118,7 @@ export default stampit({
     if (!getBrowserAPI().runtime) throw new RpcConnectionError('Runtime is not accessible in your environment')
     this.debug = debug
     this.connectionInfo = connectionInfo
-    this.port = port || getBrowserAPI().runtime.connect(...[connectionInfo.id || undefined])
+    this.port = port
   },
   methods: { connect, sendMessage, disconnect, isConnected }
 }, WalletConnection)

--- a/src/utils/aepp-wallet-communication/connection/browser-window-message.js
+++ b/src/utils/aepp-wallet-communication/connection/browser-window-message.js
@@ -1,6 +1,6 @@
 /*
  * ISC License (ISC)
- * Copyright (c) 2018 aeternity developers
+ * Copyright (c) 2022 aeternity developers
  *
  *  Permission to use, copy, modify, and/or distribute this software for any
  *  purpose with or without fee is hereby granted, provided that the above
@@ -112,7 +112,7 @@ const getTarget = () => {
   // When we is the main page we need to decide the target by our self
   // Probably can be implemented some algo for checking DOM for Iframes and somehow decide which
   // Iframe to talk
-  return isInIframe() ? window.parent : undefined
+  return isInIframe() ? window.parent : window
 }
 
 /**
@@ -159,7 +159,7 @@ export default stampit({
     this.receiveDirection = receiveDirection
     this.subscribeFn = (listener) => selfP.addEventListener('message', listener, false)
     this.unsubscribeFn = (listener) => selfP.removeEventListener('message', listener, false)
-    this.postFn = (msg) => targetP.postMessage(msg, this.origin || '*')
+    this.postFn = (msg) => targetP.postMessage(JSON.parse(JSON.stringify(msg)), this.origin || '*')
   },
   methods: { connect, sendMessage, disconnect, isConnected }
 }, WalletConnection)

--- a/src/utils/aepp-wallet-communication/content-script-bridge.js
+++ b/src/utils/aepp-wallet-communication/content-script-bridge.js
@@ -1,6 +1,6 @@
 /*
  * ISC License (ISC)
- * Copyright (c) 2018 aeternity developers
+ * Copyright (c) 2022 aeternity developers
  *
  *  Permission to use, copy, modify, and/or distribute this software for any
  *  purpose with or without fee is hereby granted, provided that the above
@@ -26,6 +26,7 @@
  */
 import stampit from '@stamp/it'
 import { UnsupportedPlatformError, MissingParamError } from '../errors'
+import { METHODS } from './schema'
 
 /**
  * Start message proxy
@@ -35,12 +36,14 @@ import { UnsupportedPlatformError, MissingParamError } from '../errors'
  */
 function run () {
   const allowCrossOrigin = this.allowCrossOrigin
-  // Connect to extension using runtime
-  this.extConnection.connect((msg) => {
-    this.pageConnection.sendMessage(msg)
-  })
   // Connect to page using window.postMessage
   this.pageConnection.connect((msg, origin, source) => {
+    // Connect to extension using runtime
+    if (!this.extConnection.isConnected() && msg.method === METHODS.scan) {
+      this.extConnection.connect((msg) => {
+        this.pageConnection.sendMessage(msg)
+      })
+    }
     if (!allowCrossOrigin && source !== window) return
     this.extConnection.sendMessage(msg)
   })

--- a/src/utils/aepp-wallet-communication/schema.ts
+++ b/src/utils/aepp-wallet-communication/schema.ts
@@ -16,6 +16,7 @@ export const enum SUBSCRIPTION_TYPES {
 }
 
 export const enum METHODS {
+  scan = 'connection.scan',
   readyToConnect = 'connection.announcePresence',
   updateAddress = 'address.update',
   address = 'address.get',

--- a/src/utils/aepp-wallet-communication/wallet-detector.js
+++ b/src/utils/aepp-wallet-communication/wallet-detector.js
@@ -1,6 +1,6 @@
 /*
  * ISC License (ISC)
- * Copyright (c) 2018 aeternity developers
+ * Copyright (c) 2022 aeternity developers
  *
  *  Permission to use, copy, modify, and/or distribute this software for any
  *  purpose with or without fee is hereby granted, provided that the above
@@ -77,6 +77,9 @@ export default stampit({
         onDetected({ wallets, newWallet: wallet })
       })
       if (Object.keys(wallets).length) onDetected({ wallets })
+      this.connection.sendMessage({
+        method: METHODS.scan, params: {}, jsonrpc: '2.0'
+      })
     },
 
     /**

--- a/src/utils/encoder.ts
+++ b/src/utils/encoder.ts
@@ -40,7 +40,7 @@ const getChecksum = (payload: Uint8Array): Buffer =>
   sha256hash(sha256hash(payload)).slice(0, 4)
 
 const addChecksum = (payload: Uint8Array): Buffer => {
-  return Buffer.concat([payload, getChecksum(payload)])
+  return Buffer.from(new Uint8Array([...payload, ...getChecksum(payload)]))
 }
 
 function getPayload (buffer: Buffer): Buffer {


### PR DESCRIPTION
Closes #1417, #907 

Solution: is to move ` const port = browser.runtime.connect()` this from content script to content script bridge.

Side effects: Aepps will work without any change to the existing codebase.

Implementation: The `scan` method from the wallet detector sends an additional request via postMessage to the window. The content script bridge will then will establish the bridge between the page and the wallet. Now the wallet will not simply connect to all the tabs open in the browser instead opens connections to the aepps only when requested(via wallet detector). This fix also stops the continuous polling of wallet information to the tabs. A lot of CPU cycles are being saved since the wallet connects to only requested pages.

Fixed encoder type errors too.

