### PR TITLE
refactor(node-pool) drop stamp usage 

### DIFF
--- a/docs/guides/batch-requests.md
+++ b/docs/guides/batch-requests.md
@@ -18,7 +18,7 @@ But this isn't the fastest approach, because on each iteration SDK would:
 
 It can be avoided by making spends as:
 ```js
-const base = (await aeSdk.api.getAccountNextNonce(await aeSdk.address())).nextNonce
+const base = (await aeSdk.nodePool.api.getAccountNextNonce(await aeSdk.address())).nextNonce
 await Promise.all(spends.map(({ amount, address }, idx) =>
    aeSdk.spend(amount, address, { nonce: base + idx, verify: false, waitMined: false }))
 )
@@ -35,7 +35,7 @@ for (const d of data) {
 ```
 will make SDK create a new dry-run request for each static call. It may be not efficient because dry-run supports executing multiple transactions at a single request. It can be done by making all calls at once:
 ```js
-const base = (await aeSdk.api.getAccountNextNonce(await aeSdk.address())).nextNonce
+const base = (await aeSdk.nodePool.api.getAccountNextNonce(await aeSdk.address())).nextNonce
 const results = await Promise.all(
   data.map((d, idx) => contractInstance.methods.foo(d, { nonce: base + idx, combine: true }))
 )

--- a/docs/guides/connect-aepp-to-wallet.md
+++ b/docs/guides/connect-aepp-to-wallet.md
@@ -39,8 +39,8 @@ async created () {
     ],
     compilerUrl: COMPILER_URL,
     onNetworkChange: async ({ networkId }) => {
-      this.aeSdk.selectNode(networkId)
-      this.nodeInfo = await this.aeSdk.getNodeInfo()
+      this.aeSdk.nodePool.selectNode(networkId)
+      this.nodeInfo = await this.aeSdk.nodePool.getNodeInfo()
     },
     onAddressChange: async () => {
       this.address = await this.aeSdk.address()
@@ -88,7 +88,7 @@ async connect(wallet) {
   this.connectedAccounts = await this.aeSdk.subscribeAddress('subscribe', 'connected')
   this.address = await this.aeSdk.address()
   this.balance = await this.aeSdk.getBalance(this.address).catch(() => '0')
-  this.nodeInfo = await this.aeSdk.getNodeInfo()
+  this.nodeInfo = await this.aeSdk.nodePool.getNodeInfo()
 }
 ```
 

--- a/docs/guides/contract-events.md
+++ b/docs/guides/contract-events.md
@@ -60,7 +60,7 @@ Of course it is also possible to decode the event log if you request the transac
 ```js
 const txHash = 'th_2YV3AmAz2kXdTnQxXtR2uxQi3KuLS9wfvXyqKkQQ2Y6dE6RnET';
 // aeSdk is an instance of the Universal Stamp
-const txInfo = await aeSdk.api.getTransactionInfoByHash(txHash)
+const txInfo = await aeSdk.nodePool.api.getTransactionInfoByHash(txHash)
 
 // decode events using contract instance
 const decodedUsingInstance = contractInstance.decodeEvents(txInfo.callInfo.log)

--- a/docs/guides/low-vs-high-usage.md
+++ b/docs/guides/low-vs-high-usage.md
@@ -7,7 +7,7 @@
 
 The purist uses the functions generated out of the Swagger
 file. After creating the SDK instance `aeSdk` with the Universal Stamp it exposes a mapping of all `operationId`s as functions, converted to camelCase (from PascalCase). So e.g. in order to get a transaction
-based on its hash you would invoke `aeSdk.api.getTransactionByHash('th_...')`.
+based on its hash you would invoke `aeSdk.nodePool.api.getTransactionByHash('th_...')`.
 
 In this way the SDK is simply a mapping of the raw API calls into
 JavaScript. It's excellent for low-level control, and as a teaching tool to
@@ -60,14 +60,14 @@ async function spend (amount, recipient) {
   const signedTx = await aeSdk.signTransaction(spendTx)
 
   // broadcast the signed tx to the node
-  console.log(await aeSdk.api.postTransaction({tx: signedTx}))
+  console.log(await aeSdk.nodePool.api.postTransaction({tx: signedTx}))
 }
 ```
 
 Following functions are available with the low-level API right now:
 
 ```js
-console.log(aeSdk.api)
+console.log(aeSdk.nodePool.api)
 /*
 {
   getTopHeader: [AsyncFunction (anonymous)],

--- a/docs/guides/migration/12.0.0.md
+++ b/docs/guides/migration/12.0.0.md
@@ -1,0 +1,61 @@
+# Migration to 12.0.0
+This guide describes all breaking changes introduced with `v12.0.0`.
+
+
+## Changes to `nodePool` property access
+`nodePool` is now an instance in aeSdk 
+
+
+`selectedNode`  
+
+rewrite
+```js
+aeSdk.selectedNode
+```
+to
+```js
+aeSdk.nodePool.selectedNode
+```
+`api`  
+
+rewrite
+```js
+aeSdk.api
+```
+to
+```js
+aeSdk.nodePool.api
+```
+
+`addNode`
+rewrite
+```js
+aeSdk.addNode(...args)
+```
+to
+```js
+aeSdk.nodePool.addNode(...args)
+```
+
+ `selectNode`
+
+rewrite
+```js
+aeSdk.selectNode()
+```
+to
+```js
+aeSdk.nodePool.selectNode()
+```
+
+
+`getNodeInfo`
+
+rewrite
+```js
+aeSdk.getNodeInfo()
+```
+to
+```js
+aeSdk.nodePool.getNodeInfo()
+```

--- a/examples/browser/aepp/src/Basic.vue
+++ b/examples/browser/aepp/src/Basic.vue
@@ -83,7 +83,7 @@ export default {
         this.compilerVersion = aeSdk.compilerVersion
         this.balancePromise = aeSdk.getBalance(address)
         this.heightPromise = aeSdk.height()
-        this.nodeInfoPromise = aeSdk.getNodeInfo()
+        this.nodeInfoPromise = aeSdk.nodePool.getNodeInfo()
       },
       { immediate: true }
     )

--- a/examples/browser/aepp/src/Connect.vue
+++ b/examples/browser/aepp/src/Connect.vue
@@ -107,9 +107,9 @@ export default {
           ],
           compilerUrl: COMPILER_URL,
           onNetworkChange: ({ networkId }) => {
-            const [{ name }] = this.aeSdk.getNodesInPool()
+            const [{ name }] = this.aeSdk.nodePool.getNodesInPool()
               .filter(node => node.nodeNetworkId === networkId)
-            this.aeSdk.selectNode(name)
+            this.aeSdk.nodePool.selectNode(name)
             this.$emit('networkId', networkId)
           },
           onAddressChange: ({ current }) => this.$emit('address', Object.keys(current)[0]),

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -20,104 +20,128 @@
     <button @click="disconnect">Disconnect</button>
   </div>
 
-  <iframe
-    v-if="!runningInFrame"
-    ref="aepp"
-    src="http://localhost:9001"
-  />
+  <iframe v-if="!runningInFrame" ref="aepp" src="http://localhost:9001" />
 </template>
 
 <script>
 import {
-  MemoryAccount, RpcWallet, Node, generateKeyPair,
-  BrowserWindowMessageConnection, METHODS
-} from '@aeternity/aepp-sdk'
-import Value from './Value'
+  MemoryAccount,
+  RpcWallet,
+  Node,
+  generateKeyPair,
+  BrowserWindowMessageConnection,
+  METHODS,
+} from "@aeternity/aepp-sdk";
+import Value from "./Value";
 
 export default {
   components: { Value },
-  data () {
+  data() {
     return {
       runningInFrame: window.parent !== window,
       // aeSdk: null, see https://github.com/aeternity/aepp-sdk-js/issues/1347
-      nodeName: '',
-      address: '',
+      nodeName: "",
+      address: "",
       balancePromise: null,
-    }
+    };
   },
   methods: {
-    async shareWalletInfo (postFn, { interval = 5000, attemps = 5 } = {}) {
-      this.aeSdk.shareWalletInfo(postFn)
-      while (attemps -= 1) {
-        await new Promise(resolve => setTimeout(resolve, interval))
-        this.aeSdk.shareWalletInfo(postFn)
+    async shareWalletInfo(postFn, { interval = 5000, attemps = 5 } = {}) {
+      this.aeSdk.shareWalletInfo(postFn);
+      while ((attemps -= 1)) {
+        await new Promise((resolve) => setTimeout(resolve, interval));
+        this.aeSdk.shareWalletInfo(postFn);
       }
-      console.log('Finish sharing wallet info')
+      console.log("Finish sharing wallet info");
     },
-    disconnect () {
-      Object.values(this.aeSdk.rpcClients).forEach(client => {
-        client.sendMessage({ method: METHODS.closeConnection }, true)
-        client.disconnect()
-      })
+    disconnect() {
+      Object.values(this.aeSdk.rpcClients).forEach((client) => {
+        client.sendMessage({ method: METHODS.closeConnection }, true);
+        client.disconnect();
+      });
     },
-    async switchAccount () {
-      this.address = this.aeSdk.addresses().find(a => a !== this.address)
-      this.aeSdk.selectAccount(this.address)
+    async switchAccount() {
+      this.address = this.aeSdk.addresses().find((a) => a !== this.address);
+      this.aeSdk.selectAccount(this.address);
     },
-    async switchNode () {
-      this.nodeName = this.aeSdk.getNodesInPool()
+    async switchNode() {
+      this.nodeName = this.aeSdk.nodePool
+        .getNodesInPool()
         .map(({ name }) => name)
-        .find(name => name !== this.nodeName)
-      this.aeSdk.selectNode(this.nodeName)
-    }
+        .find((name) => name !== this.nodeName);
+      this.aeSdk.nodePool.selectNode(this.nodeName);
+    },
   },
-  async mounted () {
-    const genConfirmCallback = getActionName => (aepp, { accept, deny, params }) => {
-      if (confirm(`Client ${aepp.info.name} with id ${aepp.id} want to ${getActionName(params)}`)) accept()
-      else deny()
-    }
+  async mounted() {
+    const genConfirmCallback =
+      (getActionName) =>
+      (aepp, { accept, deny, params }) => {
+        if (
+          confirm(
+            `Client ${aepp.info.name} with id ${
+              aepp.id
+            } want to ${getActionName(params)}`
+          )
+        )
+          accept();
+        else deny();
+      };
     this.aeSdk = await RpcWallet({
       nodes: [
-        { name: 'ae_uat', instance: await Node({ url: 'https://testnet.aeternity.io' }) },
-        { name: 'ae_mainnet', instance: await Node({ url: 'https://mainnet.aeternity.io' }) },
+        {
+          name: "ae_uat",
+          instance: await Node({ url: "https://testnet.aeternity.io" }),
+        },
+        {
+          name: "ae_mainnet",
+          instance: await Node({ url: "https://mainnet.aeternity.io" }),
+        },
       ],
-      compilerUrl: 'https://compiler.aepps.com',
+      compilerUrl: "https://compiler.aepps.com",
       accounts: [
         MemoryAccount({
           keypair: {
-            publicKey: 'ak_2dATVcZ9KJU5a8hdsVtTv21pYiGWiPbmVcU1Pz72FFqpk9pSRR',
-            secretKey: 'bf66e1c256931870908a649572ed0257876bb84e3cdf71efb12f56c7335fad54d5cf08400e988222f26eb4b02c8f89077457467211a6e6d955edb70749c6a33b',
-          }
+            publicKey: "ak_2dATVcZ9KJU5a8hdsVtTv21pYiGWiPbmVcU1Pz72FFqpk9pSRR",
+            secretKey:
+              "bf66e1c256931870908a649572ed0257876bb84e3cdf71efb12f56c7335fad54d5cf08400e988222f26eb4b02c8f89077457467211a6e6d955edb70749c6a33b",
+          },
         }),
-        MemoryAccount({ keypair: generateKeyPair() })
+        MemoryAccount({ keypair: generateKeyPair() }),
       ],
-      name: 'Wallet Iframe',
-      onConnection: genConfirmCallback(() => 'connect'),
-      onSubscription: genConfirmCallback(() => 'subscription'),
-      onSign: genConfirmCallback(({ returnSigned, tx }) => `${returnSigned ? 'sign' : 'sign and broadcast'} ${JSON.stringify(tx)}`),
-      onMessageSign: genConfirmCallback(() => 'message sign'),
-      onAskAccounts: genConfirmCallback(() => 'get accounts'),
-      onDisconnect (message, client) {
-        this.shareWalletInfo(connection.sendMessage.bind(connection))
-      }
-    })
-    this.nodeName = this.aeSdk.selectedNode.name
-    this.address = this.aeSdk.addresses()[0]
+      name: "Wallet Iframe",
+      onConnection: genConfirmCallback(() => "connect"),
+      onSubscription: genConfirmCallback(() => "subscription"),
+      onSign: genConfirmCallback(
+        ({ returnSigned, tx }) =>
+          `${returnSigned ? "sign" : "sign and broadcast"} ${JSON.stringify(
+            tx
+          )}`
+      ),
+      onMessageSign: genConfirmCallback(() => "message sign"),
+      onAskAccounts: genConfirmCallback(() => "get accounts"),
+      onDisconnect(message, client) {
+        this.shareWalletInfo(connection.sendMessage.bind(connection));
+      },
+    });
+    this.nodeName = this.aeSdk.nodePool.selectedNode.name;
+    this.address = this.aeSdk.addresses()[0];
 
-    const target = this.runningInFrame ? window.parent : this.$refs.aepp.contentWindow
-    const connection = BrowserWindowMessageConnection({ target })
-    this.aeSdk.addRpcClient(connection)
-    this.shareWalletInfo(connection.sendMessage.bind(connection))
+    const target = this.runningInFrame
+      ? window.parent
+      : this.$refs.aepp.contentWindow;
+    const connection = BrowserWindowMessageConnection({ target });
+    this.aeSdk.addRpcClient(connection);
+    this.shareWalletInfo(connection.sendMessage.bind(connection));
 
     this.$watch(
       ({ address, nodeName }) => [address, nodeName],
       ([address]) => {
-        this.balancePromise = this.aeSdk.getBalance(address)
+        this.balancePromise = this.aeSdk.getBalance(address);
       },
       { immediate: true }
-    )
-  }
-}
+    );
+  },
+};
 </script>
 
 <style lang="scss" src="./styles.scss" />

--- a/src/ae/index.js
+++ b/src/ae/index.js
@@ -162,7 +162,11 @@ function destroyInstance () {
  * @param {Object} [options={}] - Initializer object
  * @return {Object} Ae instance
  */
-const Ae = stampit(NodePool, Tx, AccountResolver, {
+const Ae = stampit({
+  init (options) {
+    this.nodePool = new NodePool(options)
+  }
+}, Tx, AccountResolver, {
   methods: {
     send,
     spend,
@@ -177,7 +181,7 @@ const Ae = stampit(NodePool, Tx, AccountResolver, {
         function (...args) {
           const instanceOptions = {
             ...this.Ae.defaults,
-            onNode: this.selectedNode.instance,
+            onNode: this.nodePool.selectedNode.instance,
             onAccount: this
           }
           const lastArg = args[args.length - 1]

--- a/src/contract/aci.js
+++ b/src/contract/aci.js
@@ -142,7 +142,7 @@ export default async function getContractInstance ({
       hash: txData.hash, tx: TxObject({ tx: txData.rawTx }), txData, rawTx: txData.rawTx
     }
     if (!txData.blockHeight) return result
-    const { callInfo } = await this.api.getTransactionInfoByHash(txData.hash)
+    const { callInfo } = await this.nodePool.api.getTransactionInfoByHash(txData.hash)
     Object.assign(result.txData, callInfo) // TODO: don't duplicate data in result
     await handleCallError(callInfo, tx)
     return { ...result, result: callInfo }

--- a/src/node.js
+++ b/src/node.js
@@ -35,7 +35,7 @@ import { MissingParamError, UnsupportedVersionError } from './utils/errors'
  * @return {String} NetworkId
  */
 export function getNetworkId ({ networkId } = {}) {
-  const res = networkId || this.networkId || this.selectedNode?.networkId
+  const res = networkId || this.networkId || this.nodePool.selectedNode?.networkId
   if (res) return res
   throw new MissingParamError('networkId is not provided')
 }

--- a/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js
+++ b/src/utils/aepp-wallet-communication/rpc/aepp-rpc.js
@@ -34,7 +34,7 @@ const NOTIFICATIONS = {
   [METHODS.updateNetwork]: (instance) =>
     async ({ params }) => {
       const { node } = params
-      if (node) instance.addNode(node.name, await Node(node), true)
+      if (node) instance.nodePool.addNode(node.name, await Node(node), true)
       instance.onNetworkChange(params)
     },
   [METHODS.closeConnection]: (instance) =>
@@ -166,7 +166,7 @@ export default AccountResolver.compose(AsyncInit, {
       if (connectNode && !Object.prototype.hasOwnProperty.call(walletInfo, 'node')) {
         throw new RpcConnectionError('Missing URLs of the Node')
       }
-      if (connectNode) this.addNode(name, await Node(walletInfo.node), select)
+      if (connectNode) this.nodePool.addNode(name, await Node(walletInfo.node), select)
       return walletInfo
     },
     /**

--- a/src/utils/aepp-wallet-communication/rpc/wallet-rpc.js
+++ b/src/utils/aepp-wallet-communication/rpc/wallet-rpc.js
@@ -65,7 +65,7 @@ const REQUESTS = {
         return {
           result: {
             ...instance.getWalletInfo(),
-            ...(shareNode && { node: instance.selectedNode })
+            ...(shareNode && { node: instance.nodePool.selectedNode })
           }
         }
       },
@@ -149,7 +149,8 @@ const REQUESTS = {
         } catch (e) {
           if (!returnSigned) {
             // Validate transaction
-            const validation = await verifyTransaction(rawTx || tx, instance.selectedNode.instance)
+            const validation = await verifyTransaction(rawTx || tx,
+              instance.nodePool.selectedNode.instance)
             if (validation.length) return { error: ERRORS.invalidTransaction(validation) }
             // Send broadcast failed error to aepp
             return { error: ERRORS.broadcastFailed(e.message) }
@@ -262,7 +263,7 @@ export default Ae.compose(AccountMultiple, {
 
     const _selectAccount = this.selectAccount.bind(this)
     const _addAccount = this.addAccount.bind(this)
-    const _selectNode = this.selectNode.bind(this)
+    const _selectNode = this.nodePool.selectNode.bind(this.nodePool)
 
     // Overwrite AE methods
     this.selectAccount = (address, { condition = () => true } = {}) => {
@@ -292,7 +293,7 @@ export default Ae.compose(AccountMultiple, {
           }
         }))
     }
-    this.selectNode = (name) => {
+    this.nodePool.selectNode = (name) => {
       _selectNode(name)
       // Send notification 'update.network' to all Aepp which connected
       Object.values(this.rpcClients)
@@ -301,7 +302,8 @@ export default Ae.compose(AccountMultiple, {
           client.sendMessage(
             message(METHODS.updateNetwork, {
               networkId: this.getNetworkId(),
-              ...client.info.status === RPC_STATUS.NODE_BINDED && { node: this.selectedNode }
+              ...client.info.status === RPC_STATUS.NODE_BINDED &&
+              { node: this.nodePool.selectedNode }
             }), true)
         })
     }

--- a/test/environment/browser.html
+++ b/test/environment/browser.html
@@ -29,7 +29,7 @@ contract Test =
   })
 
   console.log('Height:', await sdk.height())
-  console.log('Instanceof works correctly for nodes pool', sdk.pool instanceof Map)
+  console.log('Instanceof works correctly for nodes pool', sdk.nodePool.pool instanceof Map)
 
   const contract = await sdk.getContractInstance({ source: contractSource })
   const deployInfo = await contract.deploy()

--- a/test/environment/node.js
+++ b/test/environment/node.js
@@ -19,7 +19,7 @@ contract Test =
   })
 
   console.log('Height:', await aeSdk.height())
-  console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map)
+  console.log('Instanceof works correctly for nodes pool', aeSdk.nodePool.pool instanceof Map)
 
   const contract = await aeSdk.getContractInstance({ source: contractSource })
   const deployInfo = await contract.deploy()

--- a/test/integration/chain.js
+++ b/test/integration/chain.js
@@ -88,7 +88,7 @@ describe('Node Chain', function () {
       ttl: Number.MAX_SAFE_INTEGER
     })
     const signed = await aeSdk.signTransaction(tx)
-    const { txHash } = await aeSdk.api.postTransaction({ tx: signed })
+    const { txHash } = await aeSdk.nodePool.api.postTransaction({ tx: signed })
 
     await aeSdk.poll(txHash).should.eventually.be.fulfilled
     return aeSdk.poll('th_xxx', { blocks: 1 }).should.eventually.be.rejected
@@ -109,7 +109,7 @@ describe('Node Chain', function () {
   const transactions = []
 
   it('multiple spends from one account', async () => {
-    const { nextNonce } = await aeSdk.api.getAccountNextNonce(await aeSdk.address())
+    const { nextNonce } = await aeSdk.nodePool.api.getAccountNextNonce(await aeSdk.address())
     spy(http, 'request')
     const spends = await Promise.all(accounts.map((account, idx) => aeSdk.spend(
       Math.floor(Math.random() * 1000 + 1e16),
@@ -147,7 +147,7 @@ describe('Node Chain', function () {
     })
     await contract.deploy()
     const { result: { gasUsed: gasLimit } } = await contract.methods.foo(5)
-    const { nextNonce } = await aeSdk.api.getAccountNextNonce(await aeSdk.address())
+    const { nextNonce } = await aeSdk.nodePool.api.getAccountNextNonce(await aeSdk.address())
     spy(http, 'request')
     const numbers = new Array(32).fill().map((v, idx) => idx * 2)
     const results = (await Promise.all(

--- a/test/integration/channel.ts
+++ b/test/integration/channel.ts
@@ -969,7 +969,8 @@ describe('Channel', function () {
       abiVersion: 3
     }, async (tx) => aeSdkInitiatior.signTransaction(tx))
     const hash = buildTxHash(forceTx.tx)
-    const { callInfo: { returnType } } = await aeSdkInitiatior.api.getTransactionInfoByHash(hash)
+    const { callInfo: { returnType } } = await aeSdkInitiatior
+      .nodePool.api.getTransactionInfoByHash(hash)
     expect(returnType).to.be.equal('ok')
   })
 

--- a/test/integration/contract.js
+++ b/test/integration/contract.js
@@ -183,7 +183,7 @@ describe('Contract', function () {
   })
 
   it('Call-Static deploy transaction on specific hash', async () => {
-    const { hash } = await aeSdk.api.getTopHeader()
+    const { hash } = await aeSdk.nodePool.api.getTopHeader()
     const res = await contract.deploy([], { callStatic: true, top: hash })
     res.result.should.have.property('gasUsed')
     res.result.should.have.property('returnType')

--- a/test/integration/node.ts
+++ b/test/integration/node.ts
@@ -54,12 +54,12 @@ describe('Node client', function () {
 
   describe('Node Pool', () => {
     it('Throw error on using API without node', () => {
-      const nodes = NodePool()
+      const nodes = new NodePool()
       expect(() => nodes.api.someAPIfn()).to.throw(NodeNotFoundError, 'You can\'t use Node API. Node is not connected or not defined!')
     })
 
     it('Can change Node', async () => {
-      const nodes = NodePool({
+      const nodes = new NodePool({
         nodes: [
           { name: 'first', instance: await Node({ url, ignoreVersion }) },
           { name: 'second', instance: node }
@@ -73,7 +73,7 @@ describe('Node client', function () {
     })
 
     it('Fail on undefined node', async () => {
-      const nodes = NodePool({
+      const nodes = new NodePool({
         nodes: [
           { name: 'first', instance: await Node({ url, ignoreVersion }) },
           { name: 'second', instance: node }
@@ -83,7 +83,7 @@ describe('Node client', function () {
     })
 
     it('Can get list of nodes', () => {
-      const nodes = NodePool({
+      const nodes = new NodePool({
         nodes: [
           { name: 'first', instance: node }
         ]

--- a/test/integration/rpc.js
+++ b/test/integration/rpc.js
@@ -391,9 +391,9 @@ describe('Aepp<->Wallet', function () {
       const received = await new Promise((resolve) => {
         aepp.onNetworkChange = (msg) => {
           msg.networkId.should.be.equal(networkId)
-          resolve(wallet.selectedNode.name === 'second_node')
+          resolve(wallet.nodePool.selectedNode.name === 'second_node')
         }
-        wallet.addNode('second_node', node, true)
+        wallet.nodePool.addNode('second_node', node, true)
       })
       received.should.be.equal(true)
     })
@@ -591,9 +591,9 @@ describe('Aepp<->Wallet', function () {
         aepp.onNetworkChange = (msg) => {
           msg.networkId.should.be.equal(networkId)
           msg.node.should.be.an('object')
-          resolve(wallet.selectedNode.name === 'second_node')
+          resolve(wallet.nodePool.selectedNode.name === 'second_node')
         }
-        wallet.addNode('second_node', node, true)
+        wallet.nodePool.addNode('second_node', node, true)
       })
       received.should.be.equal(true)
     })

--- a/test/integration/transaction.js
+++ b/test/integration/transaction.js
@@ -162,7 +162,7 @@ describe('Transaction', function () {
     }))
 
   it('Get next account nonce', async () => {
-    const { nonce: accountNonce } = await aeSdk.api.getAccountByPubkey(address)
+    const { nonce: accountNonce } = await aeSdk.nodePool.api.getAccountByPubkey(address)
     expect(await aeSdk.getAccountNonce(address)).to.be.equal(accountNonce + 1)
     expect(await aeSdk.getAccountNonce(address, 1)).to.be.equal(1)
   })

--- a/test/integration/txVerification.js
+++ b/test/integration/txVerification.js
@@ -11,7 +11,7 @@ describe('Verify Transaction', function () {
 
   before(async () => {
     aeSdk = await getSdk()
-    node = aeSdk.selectedNode.instance
+    node = aeSdk.nodePool.selectedNode.instance
     await aeSdk.spend(1234, 'ak_LAqgfAAjAbpt4hhyrAfHyVg9xfVQWsk1kaHaii6fYXt6AJAGe')
   })
 


### PR DESCRIPTION
closes #1521

This PR drops stamp usage on node-pool and also assigns its usage as an entity instead of composition. For example, in order to access `selectedNode`, it shall be done now as `this.nodePool.selectedNode` instead of  `this.selectedNode`