### PR TITLE
Revert "chore(npm scripts): don't build on installing dependencies"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             ~/.npm
             ~/.autorest
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Run Commitlint
         env:
           EVENT_TYPE: ${{ github.event_name }}

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -3,6 +3,6 @@ import subprocess
 
 def pre_build(**kwargs):
   if not os.path.exists('node_modules'):
-    subprocess.run(['npm', 'install'], check=True)
+    subprocess.run(['npm', 'install', '--ignore-scripts'], check=True)
   subprocess.run(['npm', 'run', 'docs:examples'], check=True)
   # subprocess.run(['npm', 'run', 'docs:api'], check=True)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:integration": "nyc mocha './test/integration/'",
     "test:unit": "nyc mocha './test/unit/'",
     "test:watch": "mocha './test/unit/' './test/integration/' --watch",
-    "prepack": "npm run build",
+    "prepare": "npm run build",
     "prepublishOnly": "test/examples.sh && npm run docs:examples",
     "release": "standard-version --skip.tag --infile docs/CHANGELOG.md"
   },


### PR DESCRIPTION
well, the last change didn't work, this is still an issue, the only fix we have is `--ignore-scripts`, https://github.com/npm/rfcs/discussions/261 https://stackoverflow.com/questions/44499912/why-is-npm-running-prepare-script-after-npm-install-and-how-can-i-stop-it
reverts #1454 
This reverts commit 2099ea5b33571aa3761b24e444b87feb57936b47.