### PR TITLE
fix(wallet): revert to returning complete tx data instead of just hash in rpc wallet signing

### DIFF
--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -20,6 +20,7 @@ import {
   WalletInfo
 } from './utils/aepp-wallet-communication/rpc/types'
 import { EncodedData } from './utils/encoder'
+import jsonBig from './utils/json-big'
 
 type RpcClientWallet = RpcClient<AeppApi, WalletApi>
 
@@ -264,7 +265,9 @@ export default class AeSdkWallet extends AeSdk {
               return { signedTransaction: await this.signTransaction(tx, { onAccount }) }
             }
             try {
-              return { transactionHash: (await this.send(tx, { onAccount, verify: false })).hash }
+              return jsonBig.parse(jsonBig.stringify({
+                transactionHash: await this.send(tx, { onAccount, verify: false })
+              }))
             } catch (error) {
               const validation = await verifyTransaction(tx, this.api)
               if (validation.length > 0) throw new RpcInvalidTransactionError(validation)

--- a/src/utils/aepp-wallet-communication/rpc/types.ts
+++ b/src/utils/aepp-wallet-communication/rpc/types.ts
@@ -1,3 +1,4 @@
+import { send } from '../../../ae/spend'
 import { EncodedData } from '../../encoder'
 import { METHODS, SUBSCRIPTION_TYPES, WALLET_TYPE } from '../schema'
 
@@ -43,7 +44,14 @@ export interface WalletApi {
 
   [METHODS.sign]: ((
     p: { tx: EncodedData<'tx'>, onAccount: EncodedData<'ak'>, returnSigned: boolean }
-  ) => Promise<{ transactionHash?: EncodedData<'th'>, signedTransaction?: EncodedData<'tx'> }>)
+  ) => Promise<{
+    /**
+     * @deprecated this is not a hash at all, will be removed later at the same time
+     * as dropping ability to broadcast transaction by wallet
+     */
+    transactionHash?: Awaited<ReturnType<typeof send>>
+    signedTransaction?: EncodedData<'tx'>
+  }>)
 
   [METHODS.signMessage]: (
     p: { message: string, onAccount: EncodedData<'ak'> }


### PR DESCRIPTION
Closes #1561
It's a bit misleading and hard to fix since the earlier releases shipped with schema which returns tx blob in `transactionHash` key. 
This is the fix to make aepps using SDK v11 and below compatible with wallets using SDK v12.