### PR TITLE
fix(wallet): make extension connection on demand

### DIFF
--- a/examples/browser/aepp/src/Connect.vue
+++ b/examples/browser/aepp/src/Connect.vue
@@ -79,7 +79,7 @@ export default {
           }
         }
 
-        const scannerConnection = new BrowserWindowMessageConnection()
+        const scannerConnection = new BrowserWindowMessageConnection({ target: window })
         const stopScan = walletDetector(scannerConnection, handleWallets.bind(this))
       })
     },

--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -68,7 +68,6 @@ import {
     const clientId = aeSdk.addRpcClient(connection);
     // share wallet details
     aeSdk.shareWalletInfo(clientId);
-    setInterval(() => aeSdk.shareWalletInfo(clientId), 3000);
   });
 
   console.log('Wallet initialized!');

--- a/examples/browser/wallet-web-extension/src/content-script.js
+++ b/examples/browser/wallet-web-extension/src/content-script.js
@@ -3,6 +3,7 @@
 import {
   BrowserRuntimeConnection, BrowserWindowMessageConnection, MESSAGE_DIRECTION, connectionProxy,
 } from '@aeternity/aepp-sdk';
+import Browser from 'webextension-polyfill';
 
 (async () => {
   console.log('Waiting until document is ready');
@@ -16,8 +17,7 @@ import {
   });
   console.log('Document is ready');
 
-  const port = browser.runtime.connect();
-  const extConnection = new BrowserRuntimeConnection({ port });
+  const extConnection = new BrowserRuntimeConnection({ setPort: () => Browser.runtime.connect() });
   const pageConnection = new BrowserWindowMessageConnection({
     target: window,
     origin: window.origin,

--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -221,6 +221,7 @@ export default class AeSdkWallet extends AeSdk {
           this.onDisconnect(id, disconnectParams); // also related info
         },
         {
+          [METHODS.scan]: async () => this.shareWalletInfo(id),
           [METHODS.closeConnection]: (params) => {
             disconnectParams = params;
             this._disconnectRpcClient(id);

--- a/src/aepp-wallet-communication/connection-proxy.ts
+++ b/src/aepp-wallet-communication/connection-proxy.ts
@@ -16,6 +16,7 @@
  */
 
 import BrowserConnection from './connection/Browser';
+import { METHODS } from './schema';
 
 /**
  * Browser connection proxy
@@ -26,9 +27,12 @@ import BrowserConnection from './connection/Browser';
  * @returns a function to stop proxying
  */
 export default (con1: BrowserConnection, con2: BrowserConnection): () => void => {
-  con1.connect((msg: any) => con2.sendMessage(msg), () => con2.disconnect());
-  con2.connect((msg: any) => con1.sendMessage(msg), () => con1.disconnect());
-
+  con1.connect((msg: any) => {
+    if (!con2.isConnected() && msg.method === METHODS.scan) {
+      con2.connect((msg: any) => con1.sendMessage(msg), () => con1.disconnect());
+    }
+    con2.sendMessage(msg);
+  }, () => con2.disconnect());
   return () => {
     con1.disconnect();
     con2.disconnect();

--- a/src/aepp-wallet-communication/connection/Browser.ts
+++ b/src/aepp-wallet-communication/connection/Browser.ts
@@ -50,7 +50,7 @@ export default abstract class BrowserConnection {
   }
 
   /**
-   * Send message
+   * Receive message
    */
   protected receiveMessage(message: any): void {
     if (this.debug) console.log('Receive message:', message);

--- a/src/aepp-wallet-communication/rpc/types.ts
+++ b/src/aepp-wallet-communication/rpc/types.ts
@@ -30,6 +30,7 @@ type Icons = Array<{ src: string; sizes?: string; type?: string; purpose?: strin
 export const RPC_VERSION = 1;
 
 export interface WalletApi {
+  [METHODS.scan]: () => Promise<void>;
   [METHODS.connect]: (
     p: { name: string; icons?: Icons; version: typeof RPC_VERSION; connectNode: boolean }
   ) => Promise<WalletInfo & { node?: Node }>;

--- a/src/aepp-wallet-communication/schema.ts
+++ b/src/aepp-wallet-communication/schema.ts
@@ -30,6 +30,7 @@ export const enum SUBSCRIPTION_TYPES {
  * @category aepp wallet communication
  */
 export const enum METHODS {
+  scan = 'connection.scan',
   readyToConnect = 'connection.announcePresence',
   updateAddress = 'address.update',
   address = 'address.get',

--- a/src/aepp-wallet-communication/wallet-detector.ts
+++ b/src/aepp-wallet-communication/wallet-detector.ts
@@ -67,6 +67,8 @@ export default (
     onDetected({ wallets, newWallet: wallet });
   }, () => {});
   if (Object.keys(wallets).length > 0) onDetected({ wallets });
-
+  connection.sendMessage({
+    method: METHODS.scan, params: {}, jsonrpc: '2.0',
+  });
   return () => connection.disconnect();
 };


### PR DESCRIPTION
The `browser.runtime.connect()` code in `content-script.js` file opens a connection with the extension wallet on every page resulting in `n` number of RPC clients where n= number of tabs open. Foreach connection wallet keeps on sending its info on `setInterval`.

Solution: Create a runtime connection only when there is a special request from the webpage. The difference between a standard web page and an aepp page is wallet detector. Added a special request `scan`. Overall the connection is established in the `connection-proxy` file only when a webpage sends `scan` request using wallet detector. Existing interfaces work as it is.

Closes https://github.com/aeternity/aepp-sdk-js/issues/1417, https://github.com/aeternity/aepp-sdk-js/issues/907