### PR TITLE
fix(awaitHeight): allow to wait for arbitrary number of blocks

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -178,8 +178,8 @@ export class NoSerializerFoundError extends BaseError {
  * @category exception
  */
 export class RequestTimedOutError extends BaseError {
-  constructor(requestTime: number) {
-    super(`Giving up after ${Math.round(requestTime)} ms`);
+  constructor(height: number) {
+    super(`Giving up at height ${height}`);
     this.name = 'RequestTimedOutError';
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -178,12 +178,8 @@ export class NoSerializerFoundError extends BaseError {
  * @category exception
  */
 export class RequestTimedOutError extends BaseError {
-  constructor(requestTime: number, currentHeight?: number, height?: number) {
-    if (currentHeight !== undefined && height !== undefined) {
-      super(`Giving up after ${requestTime}ms, current height: ${currentHeight}, desired height: ${height}`);
-    } else {
-      super(`Giving up after ${requestTime} ms`);
-    }
+  constructor(requestTime: number) {
+    super(`Giving up after ${Math.round(requestTime)} ms`);
     this.name = 'RequestTimedOutError';
   }
 }


### PR DESCRIPTION
`awaitHeight` was accepting the amount of attempts by default equal to 20 that actually should
depend on a difference between current and desired heights. Usually we assume that used node is
being synced therefore any height should be reachable. We are not doing a real-time operating
system, so we don't care about riching a height in a limited time.

Docs related to a similar change in oracles: https://github.com/aeternity/protocol/blob/71cf111ac6b5cc5830999bd130fa0bd753504195/oracles/oracle_transactions.md