### PR TITLE
chore: don't minimize node build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,6 @@ function configure(filename, opts = {}) {
       fallback: {
         buffer: require.resolve('buffer/'),
       },
-      alias: {
-        'js-yaml': false,
-      },
     },
     plugins: [
       ...opts.target === 'node'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,9 @@ function configure(filename, opts = {}) {
         },
       ],
     },
+    optimization: {
+      minimize: opts.target !== 'node',
+    },
     resolve: {
       extensions: ['.ts', '.js'],
       fallback: {


### PR DESCRIPTION
`dist/aepp-sdk.js` still used in some cases. It is intended for non-browser usage, so package size is not a priority. Disabling minification would simplify debugging. For example, developer may add some debug printing on sdk side. If unhandled exception thrown by sdk, node print the line, it is much more readable with disabled minification.