### PR TITLE
chore: limit scopes that can be used in commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,21 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-enum': [
+      2,
+      'always',
+      [
+        'aens',
+        'aepp',
+        'chain',
+        'channel',
+        'compiler',
+        'contract',
+        'node',
+        'oracle',
+        'tx-builder',
+        'wallet',
+      ],
+    ],
+  },
 };


### PR DESCRIPTION
based on scopes used in the latest release: https://github.com/aeternity/aepp-sdk-js/blob/develop/docs/CHANGELOG.md#1200-2022-06-17