### PR TITLE
Import specific versions of blakejs and sha.js

### DIFF
--- a/src/typings/blakejs/index.d.ts
+++ b/src/typings/blakejs/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'blakejs' {
+declare module 'blakejs/blake2b.js' {
   interface Context {
     b: Uint8Array;
     h: Uint32Array;
@@ -20,14 +20,4 @@ declare module 'blakejs' {
   export const blake2bInit: (outlen?: number, key?: Key) => Context;
 
   export const blake2bUpdate: (context: Context, data: Data) => void;
-
-  export const blake2s: (data: Data, key?: Key, outlen?: number) => Uint8Array;
-
-  export const blake2sFinal: (context: Context) => Uint8Array;
-
-  export const blake2sHex: (data: Data, key?: Key, outlen?: number) => string;
-
-  export const blake2sInit: (outlen?: number, key?: Key) => Context;
-
-  export const blake2sUpdate: (context: Context, data: Data) => void;
 }

--- a/src/typings/sha-js/index.d.ts
+++ b/src/typings/sha-js/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'sha.js/sha256.js' {
+  import { sha256 } from 'sha.js';
+
+  export default sha256;
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -15,7 +15,9 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 import nacl, { SignKeyPair } from 'tweetnacl';
-import { blake2b, Data } from 'blakejs';
+// js extension is required for mjs build, not importing the whole package to reduce bundle size
+// eslint-disable-next-line import/extensions
+import { blake2b, Data } from 'blakejs/blake2b.js';
 import { encode as varuintEncode } from 'varuint-bitcoin';
 
 import { str2buf } from './bytes';

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -15,17 +15,14 @@
  *  PERFORMANCE OF THIS SOFTWARE.
  */
 import nacl, { SignKeyPair } from 'tweetnacl';
-import aesjs from 'aes-js';
 import { blake2b, Data } from 'blakejs';
 import { encode as varuintEncode } from 'varuint-bitcoin';
 
 import { str2buf } from './bytes';
 import { concatBuffers } from './other';
 import {
-  decode, encode, Encoded, Encoding, sha256hash,
+  decode, encode, Encoded, Encoding,
 } from './encoder';
-
-const Ecb = aesjs.ModeOfOperation.ecb;
 
 /**
  * Generate address from secret key
@@ -140,31 +137,6 @@ export function generateKeyPair(raw = false): {
     publicKey: encode(publicBuffer, Encoding.AccountAddress),
     secretKey: secretBuffer.toString('hex'),
   };
-}
-
-/**
- * Encrypt given data using `password`
- * @param password - Password to encrypt with
- * @param binaryData - Data to encrypt
- * @returns Encrypted data
- */
-export function encryptKey(password: string, binaryData: Uint8Array): Uint8Array {
-  const hashedPasswordBytes = sha256hash(password);
-  const aesEcb = new Ecb(hashedPasswordBytes);
-  return aesEcb.encrypt(binaryData);
-}
-
-/**
- * Decrypt given data using `password`
- * @param password - Password to decrypt with
- * @param encrypted - Data to decrypt
- * @returns Decrypted data
- */
-export function decryptKey(password: string, encrypted: Uint8Array): Uint8Array {
-  const encryptedBytes = Buffer.from(encrypted);
-  const hashedPasswordBytes = sha256hash(password);
-  const aesEcb = new Ecb(hashedPasswordBytes);
-  return aesEcb.decrypt(encryptedBytes);
 }
 
 // SIGNATURES

--- a/src/utils/encoder.ts
+++ b/src/utils/encoder.ts
@@ -1,5 +1,7 @@
 import { encode as bs58Encode, decode as bs58Decode } from 'bs58';
-import { sha256 as Sha256 } from 'sha.js';
+// js extension is required for mjs build, not importing the whole package to reduce bundle size
+// eslint-disable-next-line import/extensions
+import Sha256 from 'sha.js/sha256.js';
 import {
   DecodeError,
   ArgumentError,

--- a/src/utils/encoder.ts
+++ b/src/utils/encoder.ts
@@ -16,6 +16,7 @@ export { Encoded, Encoding };
  * Calculate SHA256 hash of `input`
  * @param input - Data to hash
  * @returns Hash
+ * @deprecated use `SubtleCrypto.digest` or `sha.js` package instead
  */
 export function sha256hash(input: Uint8Array | string): Buffer {
   return new Sha256().update(input).digest();

--- a/src/utils/hd-wallet.ts
+++ b/src/utils/hd-wallet.ts
@@ -1,11 +1,41 @@
 import nacl from 'tweetnacl';
 import { full as hmac } from 'tweetnacl-auth';
 import { fromString } from 'bip32-path';
-import { decryptKey, encryptKey } from './crypto';
-import { encode, Encoding } from './encoder';
+import aesjs from 'aes-js';
+import { sha256hash, encode, Encoding } from './encoder';
 import { CryptographyError } from './errors';
 import { bytesToHex } from './bytes';
 import { concatBuffers } from './other';
+
+const Ecb = aesjs.ModeOfOperation.ecb;
+
+// TODO: at least don't export `encryptKey` and `decryptKey`
+/**
+ * Encrypt given data using `password`
+ * @param password - Password to encrypt with
+ * @param binaryData - Data to encrypt
+ * @returns Encrypted data
+ * @deprecated use 'sha.js' and 'aes-js' packages directly instead
+ */
+export function encryptKey(password: string, binaryData: Uint8Array): Uint8Array {
+  const hashedPasswordBytes = sha256hash(password);
+  const aesEcb = new Ecb(hashedPasswordBytes);
+  return aesEcb.encrypt(binaryData);
+}
+
+/**
+ * Decrypt given data using `password`
+ * @param password - Password to decrypt with
+ * @param encrypted - Data to decrypt
+ * @returns Decrypted data
+ * @deprecated use 'sha.js' and 'aes-js' packages directly instead
+ */
+export function decryptKey(password: string, encrypted: Uint8Array): Uint8Array {
+  const encryptedBytes = Buffer.from(encrypted);
+  const hashedPasswordBytes = sha256hash(password);
+  const aesEcb = new Ecb(hashedPasswordBytes);
+  return aesEcb.decrypt(encryptedBytes);
+}
 
 /**
  * @category exception


### PR DESCRIPTION
![Screenshot 2022-07-26 at 18 25 33 copy](https://user-images.githubusercontent.com/9007851/181066149-5d888ad7-1f2c-414a-8ff7-c5ea08115a03.png)
Initial idea was to get rid of `aes-js`, but the best would be to drop `encryptKey`, `decryptKey` functions firstly.