### PR TITLE
Export types for use in aepps

### DIFF
--- a/src/aepp-wallet-communication/wallet-detector.ts
+++ b/src/aepp-wallet-communication/wallet-detector.ts
@@ -20,7 +20,7 @@ import BrowserWindowMessageConnection from './connection/BrowserWindowMessage';
 import { MESSAGE_DIRECTION, METHODS } from './schema';
 import { UnsupportedPlatformError } from '../utils/errors';
 
-interface Wallet {
+export interface Wallet {
   info: {
     id: string;
     type: string;
@@ -28,7 +28,7 @@ interface Wallet {
   };
   getConnection: () => BrowserWindowMessageConnection;
 }
-interface Wallets { [key: string]: Wallet }
+export interface Wallets { [key: string]: Wallet }
 
 /**
  * A function to detect available wallets


### PR DESCRIPTION
When scanning for wallets, it's convenient to store the results in some "store" in the frontend and use this to display buttons etc. for the user to decide to which wallet to connect. Currently the types returned by `walletDetector` are not public and can't be used for typing end user code.