### PR TITLE
fix: use crypto random to generate salt

### DIFF
--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -60,7 +60,8 @@ export function isAddressValid(
  * @returns random salt
  */
 export function genSalt(): number {
-  return Math.floor(Math.random() * Math.floor(Number.MAX_SAFE_INTEGER));
+  const [random] = new BigUint64Array(nacl.randomBytes(8).buffer);
+  return Number(random % BigInt(Number.MAX_SAFE_INTEGER));
 }
 
 /**


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
`MAX_SAFE_INTEGER` is 2^53 – 1, so it is 53 bits long. 64 bits enough to generate a value between 0 and this `MAX_SAFE_INTEGER`.