### PR TITLE
refactor!: remove returnHex option in signMessage

### DIFF
--- a/src/AeSdkBase.ts
+++ b/src/AeSdkBase.ts
@@ -216,7 +216,7 @@ class AeSdkBase {
   async signMessage(
     message: string,
     { onAccount, ...options }: { onAccount?: Account } & Parameters<AccountBase['signMessage']>[1] = {},
-  ): Promise<string | Uint8Array> {
+  ): Promise<Uint8Array> {
     return this._resolveAccount(onAccount).signMessage(message, options);
   }
 

--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -299,9 +299,8 @@ export default class AeSdkWallet extends AeSdk {
             const overrides = await this.onMessageSign(id, { message, onAccount }, origin);
             onAccount = overrides?.onAccount ?? onAccount;
             return {
-              // TODO: fix signMessage return type
-              signature: await this.signMessage(message, { onAccount, returnHex: true }) as
-                unknown as string,
+              signature: Buffer.from(await this.signMessage(message, { onAccount }))
+                .toString('hex'),
             };
           },
         },

--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -79,15 +79,11 @@ export default abstract class AccountBase {
   /**
    * Sign message
    * @param message - Message to sign
-   * @param opt - Options
+   * @param options - Options
    * @returns Signature as hex string of Uint8Array
    */
-  async signMessage(
-    message: string,
-    { returnHex = false, ...options }: { returnHex?: boolean } = {},
-  ): Promise<string | Uint8Array> {
-    const sig = await this.sign(messageToHash(message), options);
-    return returnHex ? Buffer.from(sig).toString('hex') : sig;
+  async signMessage(message: string, options?: any): Promise<Uint8Array> {
+    return this.sign(messageToHash(message), options);
   }
 
   /**

--- a/src/account/Rpc.ts
+++ b/src/account/Rpc.ts
@@ -58,12 +58,9 @@ export default class AccountRpc extends AccountBase {
   /**
    * @returns Signed message
    */
-  async signMessage(
-    message: string,
-    { returnHex = false }: Parameters<AccountBase['signMessage']>[1] = {},
-  ): Promise<string | Uint8Array> {
+  async signMessage(message: string): Promise<Uint8Array> {
     const { signature } = await this._rpcClient
       .request(METHODS.signMessage, { onAccount: this._address, message });
-    return returnHex ? signature : Buffer.from(signature, 'hex');
+    return Buffer.from(signature, 'hex');
   }
 }

--- a/test/unit/memory-account.ts
+++ b/test/unit/memory-account.ts
@@ -61,7 +61,7 @@ describe('MemoryAccount', () => {
     const message = 'test';
     const acc = new MemoryAccount({ keypair: testAcc });
     const sig = await acc.signMessage(message);
-    const sigHex = await acc.signMessage(message, { returnHex: true });
+    const sigHex = Buffer.from(sig).toString('hex');
     const isValid = await acc.verifyMessage(message, sig);
     const isValidHex = await acc.verifyMessage(message, sigHex);
     isValid.should.be.equal(true);


### PR DESCRIPTION
BREAKING CHANGE: `signMessage` always return `Uint8Array`
Use `Buffer.from(signature).toString('hex')` to convert it to hex.

closes #1485 