### PR TITLE
refactor!: remove `verifyMessage` from accounts and AeSdkBase

### DIFF
--- a/src/AeSdkBase.ts
+++ b/src/AeSdkBase.ts
@@ -219,14 +219,6 @@ class AeSdkBase {
     return this._resolveAccount(onAccount).signMessage(message, options);
   }
 
-  async verifyMessage(
-    message: string,
-    signature: string | Uint8Array,
-    { onAccount, ...options }: { onAccount?: Account } & Parameters<AccountBase['verifyMessage']>[2] = {},
-  ): Promise<boolean> {
-    return this._resolveAccount(onAccount).verifyMessage(message, signature, options);
-  }
-
   /**
    * Resolves an account
    * @param account - ak-address, instance of AccountBase, or keypair

--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -14,7 +14,7 @@
  *  OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  *  PERFORMANCE OF THIS SOFTWARE.
  */
-import { messageToHash, verifyMessage as verifyMessageCrypto, hash } from '../utils/crypto';
+import { messageToHash, hash } from '../utils/crypto';
 import { buildTx } from '../tx/builder';
 import { decode, Encoded } from '../utils/encoder';
 import { Tag } from '../tx/builder/constants';
@@ -84,24 +84,6 @@ export default abstract class AccountBase {
    */
   async signMessage(message: string, options?: any): Promise<Uint8Array> {
     return this.sign(messageToHash(message), options);
-  }
-
-  /**
-   * Verify message
-   * @param message - Message to verify
-   * @param signature - Signature
-   * @param options - Options
-   */
-  async verifyMessage(
-    message: string,
-    signature: string | Uint8Array,
-    options?: object,
-  ): Promise<boolean> {
-    return verifyMessageCrypto(
-      message,
-      typeof signature === 'string' ? Buffer.from(signature, 'hex') : signature,
-      decode(await this.address(options)),
-    );
   }
 
   /**

--- a/src/tx/validator.ts
+++ b/src/tx/validator.ts
@@ -12,9 +12,7 @@ import { Tag } from './builder/constants';
 import { TxUnpacked, unpackTx } from './builder';
 import { UnsupportedProtocolError } from '../utils/errors';
 import { concatBuffers, isAccountNotFoundError, isKeyOfObject } from '../utils/other';
-import {
-  decode, encode, Encoded, Encoding,
-} from '../utils/encoder';
+import { encode, Encoded, Encoding } from '../utils/encoder';
 import Node, { TransformNodeType } from '../Node';
 import { Account } from '../apis/node';
 
@@ -118,9 +116,8 @@ validators.push(
     ].join('-'));
     const txWithNetworkId = concatBuffers([prefix, encodedTx.rlpEncoded]);
     const txHashWithNetworkId = concatBuffers([prefix, hash(encodedTx.rlpEncoded)]);
-    const decodedPub = decode(account.id);
-    if (verify(txWithNetworkId, signatures[0], decodedPub)
-      || verify(txHashWithNetworkId, signatures[0], decodedPub)) return [];
+    if (verify(txWithNetworkId, signatures[0], account.id)
+      || verify(txHashWithNetworkId, signatures[0], account.id)) return [];
     return [{
       message: 'Signature cannot be verified, please ensure that you transaction have'
         + ' the correct prefix and the correct private key for the sender address',

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -156,18 +156,17 @@ export function sign(data: string | Uint8Array, privateKey: string | Uint8Array)
 
 /**
  * Verify that signature was signed by public key
- * @param data - Data to verify
- * @param signature - Signature to verify
- * @param publicKey - Key to verify against
- * @returns Valid?
+ * @param data - Data that was signed
+ * @param signature - Signature of data
+ * @param address - Address to verify against
+ * @returns is data was signed by address
  */
 export function verify(
   data: Uint8Array,
   signature: Uint8Array,
-  publicKey: string | Uint8Array,
+  address: Encoded.AccountAddress,
 ): boolean {
-  const publicKeyBuffer = typeof publicKey === 'string' ? str2buf(publicKey) : publicKey;
-  return nacl.sign.detached.verify(data, signature, publicKeyBuffer);
+  return nacl.sign.detached.verify(data, signature, decode(address));
 }
 
 export function messageToHash(message: string): Buffer {
@@ -180,12 +179,19 @@ export function signMessage(message: string, privateKey: string | Buffer): Uint8
   return sign(messageToHash(message), privateKey);
 }
 
+/**
+ * Verify that message was signed by address
+ * @param message - Message that was signed
+ * @param signature - Signature of message
+ * @param address - Address to verify against
+ * @returns is data was signed by address
+ */
 export function verifyMessage(
-  str: string,
+  message: string,
   signature: Uint8Array,
-  publicKey: string | Uint8Array,
+  address: Encoded.AccountAddress,
 ): boolean {
-  return verify(messageToHash(str), signature, publicKey);
+  return verify(messageToHash(message), signature, address);
 }
 
 /**
@@ -202,5 +208,6 @@ export function isValidKeypair(
 ): boolean {
   const message = Buffer.from('TheMessage');
   const signature = sign(message, privateKey);
-  return verify(message, signature, publicKey);
+  const publicKeyBuffer = typeof publicKey === 'string' ? str2buf(publicKey) : publicKey;
+  return verify(message, signature, encode(publicKeyBuffer, Encoding.AccountAddress));
 }

--- a/test/integration/rpc.ts
+++ b/test/integration/rpc.ts
@@ -44,6 +44,7 @@ import {
   UnknownRpcClientError,
   UnsubscribedAccountError,
   AccountBase,
+  verifyMessage,
 } from '../../src';
 import { concatBuffers } from '../../src/utils/other';
 import { ImplPostMessage } from '../../src/aepp-wallet-communication/connection/BrowserWindowMessage';
@@ -289,8 +290,7 @@ describe('Aepp<->Wallet', function aeppWallet() {
       const unpackedTx = unpackTx(signedTx, Tag.SignedTx);
       const { tx: { signatures: [signature], encodedTx: { rlpEncoded } } } = unpackedTx;
       const txWithNetwork = concatBuffers([Buffer.from(networkId), hash(rlpEncoded)]);
-      const valid = verify(txWithNetwork, signature, decode(address));
-      valid.should.be.equal(true);
+      expect(verify(txWithNetwork, signature, address)).to.be.equal(true);
     });
 
     it('Try to sign using unpermited account', async () => {
@@ -335,10 +335,10 @@ describe('Aepp<->Wallet', function aeppWallet() {
 
     it('Sign message', async () => {
       wallet.onMessageSign = async () => {};
-      const messageSig = await aepp.signMessage('test');
+      const messageSig = await aepp.signMessage('test') as Uint8Array;
       messageSig.should.be.instanceof(Buffer);
-      const isValid = await aepp.verifyMessage('test', messageSig);
-      isValid.should.be.equal(true);
+      expect(verifyMessage('test', messageSig, await aepp.address()))
+        .to.be.equal(true);
     });
 
     it('Sign message using custom account', async () => {
@@ -349,10 +349,10 @@ describe('Aepp<->Wallet', function aeppWallet() {
         throw new Error('Shouldn\'t be reachable');
       };
       const onAccount = accountAddress;
-      const messageSig = await aepp.signMessage('test', { onAccount });
+      const messageSig = await aepp.signMessage('test', { onAccount }) as Uint8Array;
       messageSig.should.be.instanceof(Buffer);
-      const isValid = await aepp.verifyMessage('test', messageSig, { onAccount });
-      isValid.should.be.equal(true);
+      expect(verifyMessage('test', messageSig, accountAddress))
+        .to.be.equal(true);
     });
 
     it('Sign and broadcast invalid transaction', async () => {

--- a/test/unit/crypto.ts
+++ b/test/unit/crypto.ts
@@ -18,16 +18,18 @@
 import '..';
 import { describe, it } from 'mocha';
 import { assert, expect } from 'chai';
-import * as Crypto from '../../src/utils/crypto';
-import { buildTxHash, unpackTx, decode } from '../../src';
+import {
+  buildTxHash, unpackTx,
+  generateKeyPair, getAddressFromPriv, verifyMessage, isValidKeypair, isAddressValid, hash, genSalt,
+  sign, verify, messageToHash, signMessage,
+} from '../../src';
 import { Encoded } from '../../src/utils/encoder';
 
 // These keys are fixations for the encryption lifecycle tests and will
 // not be used for signing
 const privateKeyAsHex = '4d881dd1917036cc231f9881a0db978c8899dd76a817252418606b02bf6ab9d22378f892b7cc82c2d2739e994ec9953aa36461f1eb5a4a49a5b0de17b3d23ae8';
 const privateKey = Buffer.from(privateKeyAsHex, 'hex');
-const publicKeyWithPrefix: Encoded.AccountAddress = 'ak_Gd6iMVsoonGuTF8LeswwDDN2NF5wYHAoTRtzwdEcfS32LWoxm';
-const publicKey = decode(publicKeyWithPrefix);
+const address: Encoded.AccountAddress = 'ak_Gd6iMVsoonGuTF8LeswwDDN2NF5wYHAoTRtzwdEcfS32LWoxm';
 
 const txBinaryAsArray = [
   248, 76, 12, 1, 160, 35, 120, 248, 146, 183, 204, 130, 194, 210, 115, 158, 153, 78, 201, 149, 58,
@@ -49,41 +51,42 @@ const expectedHash = 'th_HZMNgTvEiyKeATpauJjjeWwZcyHapKG8bDgy2S1sCUEUQnbwK';
 describe('crypto', () => {
   describe('generateKeyPair', () => {
     it('generates an account key pair', () => {
-      const keyPair = Crypto.generateKeyPair();
+      const keyPair = generateKeyPair();
       assert.ok(keyPair);
       expect(keyPair.publicKey).to.satisfy((b: string) => b.startsWith('ak_'));
       assert.isAtLeast(keyPair.publicKey.length, 51);
       assert.isAtMost(keyPair.publicKey.length, 53);
     });
+
     it('Address from secret', () => {
-      Crypto.getAddressFromPriv(privateKeyAsHex).should.be.equal(publicKeyWithPrefix);
+      getAddressFromPriv(privateKeyAsHex).should.be.equal(address);
     });
   });
 
   describe('isValidKeypair', () => {
     it('verify the generated key pair', () => {
-      const keyPair = Crypto.generateKeyPair(true);
+      const keyPair = generateKeyPair(true);
       assert.ok(keyPair);
-      const verifyResult = Crypto.isValidKeypair(keyPair.secretKey, keyPair.publicKey);
+      const verifyResult = isValidKeypair(keyPair.secretKey, keyPair.publicKey);
       assert.isTrue(verifyResult);
     });
   });
 
   it('isAddressValid', () => {
-    expect(Crypto.isAddressValid('test')).to.be.equal(false);
-    expect(Crypto.isAddressValid('ak_11111111111111111111111111111111273Yts')).to.be.equal(true);
+    expect(isAddressValid('test')).to.be.equal(false);
+    expect(isAddressValid('ak_11111111111111111111111111111111273Yts')).to.be.equal(true);
   });
 
   describe('sign', () => {
     it('should produce correct signature', () => {
-      const s = Crypto.sign(txBinary, privateKey);
+      const s = sign(txBinary, privateKey);
       expect(s).to.eql(signature);
     });
   });
 
   describe('verify', () => {
     it('should verify tx with correct signature', () => {
-      const result = Crypto.verify(txBinary, signature, publicKey);
+      const result = verify(txBinary, signature, address);
       assert.isTrue(result);
     });
   });
@@ -100,45 +103,47 @@ describe('crypto', () => {
     const longMessage = 'test'.repeat(256);
     const longMessageHash = Buffer.from('J9bibOHrlicf0tYQxe1lW69LdDAxETwPmrafKjjQwvs=', 'base64');
 
-    it('calculates a hash of a long message', () => expect(Crypto.messageToHash(longMessage)).to.eql(longMessageHash));
+    it('calculates a hash of a long message', () => expect(messageToHash(longMessage)).to.eql(longMessageHash));
 
     describe('sign', () => {
       it('should produce correct signature of message', () => {
-        const s = Crypto.signMessage(message, privateKey);
+        const s = signMessage(message, privateKey);
         expect(s).to.eql(messageSignature);
       });
 
       it('should produce correct signature of message with non-ASCII chars', () => {
-        const s = Crypto.signMessage(messageNonASCII, privateKey);
+        const s = signMessage(messageNonASCII, privateKey);
         expect(s).to.eql(messageNonASCIISignature);
       });
     });
 
     describe('verify', () => {
       it('should verify message', () => {
-        const result = Crypto.verifyMessage(message, messageSignature, publicKey);
+        const result = verifyMessage(message, messageSignature, address);
         assert.isTrue(result);
       });
 
       it('should verify message with non-ASCII chars', () => {
-        const result = Crypto.verifyMessage(messageNonASCII, messageNonASCIISignature, publicKey);
+        const result = verifyMessage(messageNonASCII, messageNonASCIISignature, address);
         assert.isTrue(result);
       });
     });
   });
 
   it('hashing produces 256 bit blake2b byte buffers', () => {
-    const hash = Crypto.hash('foobar');
-    hash.should.be.a('Uint8Array');
-    Buffer.from(hash).toString('hex').should.be.equal('93a0e84a8cdd4166267dbe1263e937f08087723ac24e7dcc35b3d5941775ef47');
+    const h = hash('foobar');
+    h.should.be.a('Uint8Array');
+    Buffer.from(h).toString('hex').should.be.equal('93a0e84a8cdd4166267dbe1263e937f08087723ac24e7dcc35b3d5941775ef47');
   });
+
   it('salt produces random sequences every time', () => {
-    const salt1 = Crypto.genSalt();
-    const salt2 = Crypto.genSalt();
+    const salt1 = genSalt();
+    const salt2 = genSalt();
     salt1.should.be.a('Number');
     salt2.should.be.a('Number');
     salt1.should.not.be.equal(salt2);
   });
+
   it('Can produce tx hash', () => {
     const rlpEncodedTx = unpackTx(txRaw).rlpEncoded;
     buildTxHash(txRaw).should.be.equal(expectedHash);

--- a/test/unit/memory-account.ts
+++ b/test/unit/memory-account.ts
@@ -19,7 +19,9 @@ import '..';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import MemoryAccount from '../../src/account/Memory';
-import { generateKeyPair, InvalidKeypairError, DecodeError } from '../../src';
+import {
+  generateKeyPair, InvalidKeypairError, DecodeError, verifyMessage,
+} from '../../src';
 import { Encoded } from '../../src/utils/encoder';
 
 const testAcc = generateKeyPair();
@@ -59,12 +61,8 @@ describe('MemoryAccount', () => {
 
   it('Sign message', async () => {
     const message = 'test';
-    const acc = new MemoryAccount({ keypair: testAcc });
-    const sig = await acc.signMessage(message);
-    const sigHex = Buffer.from(sig).toString('hex');
-    const isValid = await acc.verifyMessage(message, sig);
-    const isValidHex = await acc.verifyMessage(message, sigHex);
-    isValid.should.be.equal(true);
-    isValidHex.should.be.equal(true);
+    const account = new MemoryAccount({ keypair: testAcc });
+    const signature = await account.signMessage(message);
+    expect(verifyMessage(message, signature, testAcc.publicKey)).to.equal(true);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: `verifyMessage` removed from accounts and AeSdkBase
Use `verifyMessage` exported in root instead.

BREAKING CHANGE: `verify` and `verifyMessage` accepts address instead of hex string or Uint8Array
Convert public key in Uint8Array to address using `encode(pk, 'ak')`.
Convert public key in hex to address using `encode(Buffer.from(pk, 'hex'), 'ak')`.