### PR TITLE
refactor!: throw error if account not found in `removeAccount`

### DIFF
--- a/src/AeSdk.ts
+++ b/src/AeSdk.ts
@@ -47,10 +47,7 @@ export default class AeSdk extends AeSdkBase {
    * @example removeAccount(address)
    */
   removeAccount(address: Encoded.AccountAddress): void {
-    if (this.accounts[address] == null) {
-      console.warn(`removeAccount: Account for ${address} not available`);
-      return;
-    }
+    if (this.accounts[address] == null) throw new UnavailableAccountError(address);
     delete this.accounts[address]; // eslint-disable-line @typescript-eslint/no-dynamic-delete
     if (this.selectedAddress === address) delete this.selectedAddress;
   }


### PR DESCRIPTION
BREAKING CHANGE: `removeAccount` throws error if account not found

This is made to prevent unintended behaviour and to enable "no-console" rule in future.