### PR TITLE
refactor(node)!: drop duplicate `url` property

### DIFF
--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -150,7 +150,7 @@ export default class AeSdkWallet extends AeSdk {
 
   _getNode(): { node: Network['node'] } {
     this.ensureNodeConnected();
-    return { node: { url: this.api.url, name: this.selectedNodeName } };
+    return { node: { url: this.api.$host, name: this.selectedNodeName } };
   }
 
   async selectNode(name: string): Promise<void> {

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -118,8 +118,6 @@ export interface NodeInfo {
 }
 
 export default class Node extends (NodeTransformed as unknown as NodeTransformedApi) {
-  url: string;
-
   /**
    * @param url - Url for node API
    * @param options - Options
@@ -139,7 +137,6 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
       ],
       ...options,
     });
-    this.url = url;
     if (!ignoreVersion) {
       const versionPromise = this.getStatus().then(({ nodeVersion }) => nodeVersion);
       this.pipeline.addPolicy(
@@ -164,7 +161,7 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
       )
       .version;
     return {
-      url: this.url,
+      url: this.$host,
       nodeNetworkId,
       version,
       consensusProtocolVersion,


### PR DESCRIPTION
BREAKING CHANGE: `url` property of `Node` removed
Use autorest's `$host` property instead.