### PR TITLE
chore!: add `exports` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "browser": {
     "dist/aepp-sdk.js": "./dist/aepp-sdk.browser.js"
   },
+  "exports": {
+    "import": "./es/index.mjs",
+    "node": "./dist/aepp-sdk.js",
+    "default": "./dist/aepp-sdk.browser.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build:es": "tsc && babel src --config-file ./babel.esm.config.js --out-dir es --extensions .js,.ts --out-file-extension .mjs --source-maps true",


### PR DESCRIPTION
BREAKING CHANGE: Subpaths imports of SDK are not allowed
SDK does versioning only for the API provided in the root export.
Replace subpaths imports with imports of the package root.
```diff
-import MemoryAccount from '@aeternity/aepp-sdk/es/account/Memory.mjs';
+import { MemoryAccount } from '@aeternity/aepp-sdk';
```

closes #1133