### PR TITLE
feat(channel): add helper to get contract address created by other peer

### DIFF
--- a/src/channel/Base.ts
+++ b/src/channel/Base.ts
@@ -33,6 +33,7 @@ import {
   ChannelAction,
   ChannelStatus,
   ChannelFsm,
+  ChannelMessage,
 } from './internal';
 import { ChannelError } from '../utils/errors';
 import { Encoded } from '../utils/encoder';
@@ -78,7 +79,7 @@ export default class Channel {
 
   _fsmId?: Encoded.Bytearray;
 
-  _messageQueue: object[] = [];
+  _messageQueue: ChannelMessage[] = [];
 
   _isMessageQueueLocked = false;
 

--- a/src/channel/Contract.ts
+++ b/src/channel/Contract.ts
@@ -160,11 +160,9 @@ export default class ChannelContract extends ChannelSpend {
                   ? 'initiatorId' : 'responderId';
                 const owner = this._options[addressKey];
                 changeState(this, message2.params.data.state);
-                state2.resolve({
-                  accepted: true,
-                  address: encodeContractAddress(owner, params.round),
-                  signedTx: message2.params.data.state,
-                });
+                const address = encodeContractAddress(owner, params.round);
+                emit(this, 'newContract', address);
+                state2.resolve({ accepted: true, address, signedTx: message2.params.data.state });
                 return { handler: channelOpen };
               })
             ),


### PR DESCRIPTION
closes #1619 

This PR adds a stateless support for created contracts on channel.
Peers can listen on `onNewContract` events and also access created contract addresses through `channel.contracts()`.

Due to the fact that the node API does not provide way to fetch deployed contract addresses, the implementation is stateless which means that for example in (browser) cases, where users refresh their window and reconnects, they will lose access to given array of contract addresses. Given this, `channel.contracts()` might be a good discussion point whether if it should be kept or removed