### PR TITLE
refactor(channel): strongly type events

### DIFF
--- a/src/channel/Base.ts
+++ b/src/channel/Base.ts
@@ -34,6 +34,7 @@ import {
   ChannelStatus,
   ChannelFsm,
   ChannelMessage,
+  ChannelEvents,
 } from './internal';
 import { ChannelError } from '../utils/errors';
 import { Encoded } from '../utils/encoder';
@@ -44,8 +45,6 @@ function snakeToPascalObjKeys<Type>(obj: object): Type {
     [snakeToPascal(key)]: val,
   }), {}) as Type;
 }
-
-type EventCallback = (...args: any[]) => void;
 
 /**
  * Channel
@@ -169,19 +168,23 @@ export default class Channel {
    * Possible events:
    *
    *   - "error"
+   *   - "stateChanged"
+   *   - "statusChanged"
+   *   - "message"
+   *   - "peerDisconnected"
    *   - "onChainTx"
    *   - "ownWithdrawLocked"
    *   - "withdrawLocked"
    *   - "ownDepositLocked"
    *   - "depositLocked"
+   *   - "channelReestablished"
+   *   - "newContract"
    *
-   * TODO: the event list looks outdated
    *
    * @param eventName - Event name
    * @param callback - Callback function
    */
-  // TODO define specific callback type depending on the event name
-  on(eventName: string, callback: EventCallback): void {
+  on<E extends keyof ChannelEvents>(eventName: E, callback: ChannelEvents[E]): void {
     this._eventEmitter.on(eventName, callback);
   }
 
@@ -190,7 +193,7 @@ export default class Channel {
    * @param eventName - Event name
    * @param callback - Callback function
    */
-  off(eventName: string, callback: EventCallback): void {
+  off<E extends keyof ChannelEvents>(eventName: E, callback: ChannelEvents[E]): void {
     this._eventEmitter.removeListener(eventName, callback);
   }
 

--- a/src/channel/handlers.ts
+++ b/src/channel/handlers.ts
@@ -28,6 +28,7 @@ import {
   ChannelFsm,
   SignTx,
   ChannelStatus,
+  ChannelEvents,
 } from './internal';
 import { unpackTx, buildTx } from '../tx/builder';
 import { decode, Encoded } from '../utils/encoder';
@@ -40,6 +41,7 @@ import {
 } from '../utils/errors';
 import type Channel from './Base';
 import { Tag } from '../tx/builder/constants';
+import { snakeToPascal } from '../utils/string';
 
 export async function appendSignature(
   tx: Encoded.Transaction,
@@ -270,7 +272,7 @@ export async function channelOpen(
           //
           //       We should enter intermediate state where offchain transactions
           //       are blocked until channel is reestablished.
-          emit(channel, message.params.data.event);
+          emit(channel, snakeToPascal(message.params.data.event) as keyof ChannelEvents);
           return { handler: channelOpen };
         case 'fsm_up':
           channel._fsmId = message.params.data.fsm_id;

--- a/src/channel/internal.ts
+++ b/src/channel/internal.ts
@@ -32,6 +32,21 @@ import {
 } from '../utils/errors';
 import { encodeContractAddress } from '../utils/crypto';
 
+export interface ChannelEvents {
+  statusChanged: (status: ChannelStatus) => void;
+  stateChanged: (tx: Encoded.Transaction) => void;
+  depositLocked: () => void;
+  ownDepositLocked: () => void;
+  withdrawLocked: () => void;
+  ownWithdrawLocked: () => void;
+  peerDisconnected: () => void;
+  channelReestablished: () => void;
+  error: (error: Error) => void;
+  onChainTx: (tx: Encoded.Transaction, details: { info: string; type: string }) => void;
+  message: (message: string | Object) => void;
+  newContract: (contractAddress: Encoded.ContractAddress) => void;
+}
+
 export interface ChannelAction {
   guard: (channel: Channel, state?: ChannelFsm) => boolean;
   action: (channel: Channel, state?: ChannelFsm) => ChannelFsm;
@@ -140,7 +155,10 @@ const PING_TIMEOUT_MS = 10000;
 // Close connection if pong message is not received within 15 seconds
 const PONG_TIMEOUT_MS = 15000;
 
-export function emit(channel: Channel, ...args: any[]): void {
+export function emit<E extends keyof ChannelEvents>(
+  channel: Channel,
+  ...args: [E, ...Parameters<ChannelEvents[E]>]
+): void {
   const [eventName, ...rest] = args;
   channel._eventEmitter.emit(eventName, ...rest);
 }


### PR DESCRIPTION
closes #1710 

Fixes snake formats to camelCase for some unhandled events such as `peerDisconnected`
Provides strongly typed events, see screenshots of use cases:
![image](https://user-images.githubusercontent.com/45261205/203364091-ba59fce7-a524-48dd-babc-cda63885a0f2.png)
![image](https://user-images.githubusercontent.com/45261205/203364031-c3c2dec4-e8b2-4f0d-8f2a-425bebdf19b9.png)
![image](https://user-images.githubusercontent.com/45261205/203364211-3a79eab4-5553-43b6-80cf-dd7aa3eff00f.png)
