### PR TITLE
fix: compatibility with @vue/cli@4

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,8 +2,13 @@ module.exports = {
   presets: [
     ['@babel/preset-env', {
       include: [
+        // compatibility with create-react-app@4
         '@babel/plugin-proposal-nullish-coalescing-operator',
+        // compatibility with vue-cli-plugin-browser-extension@0.25
         '@babel/plugin-proposal-logical-assignment-operators',
+        // compatibility with @vue/cli@4
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-private-methods',
       ],
     }],
     '@babel/preset-typescript',


### PR DESCRIPTION
based on https://github.com/subhod-i/aepp-sdk-js/commit/a7d816822c045cedbecb4204e38bc06d4b109986
I don't think that SDK needs `@babel/plugin-proposal-private-property-in-object` plugin because it doesn't uses `#property in object` (https://babeljs.io/docs/en/babel-plugin-proposal-private-property-in-object)