### PR TITLE
fix(wallet): provide origin on webext side instead of empty string

### DIFF
--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -76,20 +76,27 @@ export default {
   },
   mounted() {
     const aeppInfo = {};
-    const genConfirmCallback = (actionName) => (aeppId) => {
-      if (!confirm(`Client ${aeppInfo[aeppId].name} with id ${aeppId} want to ${actionName}`)) {
+    const genConfirmCallback = (actionName) => (aeppId, parameters, origin) => {
+      if (!confirm([
+        `Client ${aeppInfo[aeppId].name} with id ${aeppId} at ${origin} want to ${actionName}`,
+        JSON.stringify(parameters, null, 2),
+      ].join('\n'))) {
         throw new RpcRejectedByUserError();
       }
     };
 
     class AccountMemoryProtected extends MemoryAccount {
-      async signTransaction(tx, { aeppRpcClientId: id, ...options } = {}) {
-        if (id != null) genConfirmCallback(`sign transaction ${tx}`)(id);
+      async signTransaction(tx, { aeppRpcClientId: id, aeppOrigin, ...options } = {}) {
+        if (id != null) {
+          genConfirmCallback(`sign transaction ${tx}`)(id, options, aeppOrigin);
+        }
         return super.signTransaction(tx, options);
       }
 
-      async signMessage(message, { aeppRpcClientId: id, ...options } = {}) {
-        if (id != null) genConfirmCallback(`sign message ${message}`)(id);
+      async signMessage(message, { aeppRpcClientId: id, aeppOrigin, ...options } = {}) {
+        if (id != null) {
+          genConfirmCallback(`sign message ${message}`)(id, options, aeppOrigin);
+        }
         return super.signMessage(message, options);
       }
 
@@ -113,8 +120,8 @@ export default {
       ],
       onCompiler: new CompilerHttp('https://v7.compiler.aepps.com'),
       name: 'Wallet Iframe',
-      onConnection: (aeppId, params) => {
-        if (!confirm(`Client ${params.name} with id ${aeppId} want to connect`)) {
+      onConnection: (aeppId, params, origin) => {
+        if (!confirm(`Client ${params.name} with id ${aeppId} at ${origin} want to connect`)) {
           throw new RpcConnectionDenyError();
         }
         aeppInfo[aeppId] = params;

--- a/src/aepp-wallet-communication/connection/BrowserRuntime.ts
+++ b/src/aepp-wallet-communication/connection/BrowserRuntime.ts
@@ -43,7 +43,8 @@ export default class BrowserRuntimeConnection extends BrowserConnection {
     super.connect(onMessage, onDisconnect);
     this.port.onMessage.addListener((message, port) => {
       this.receiveMessage(message);
-      onMessage(message, port.name, port);
+      // TODO: make `origin` optional because sender url is not available on aepp side
+      onMessage(message, port.sender?.url ?? '', port);
     });
     this.port.onDisconnect.addListener(onDisconnect);
   }


### PR DESCRIPTION
After this sdk won't pass an empty string to wallet based on web extension

This PR is supported by the Æternity Crypto Foundation