### PR TITLE
feat(node): exponential retry of requests on failure

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { OperationArguments, OperationSpec } from '@azure/core-client';
 import {
   genRequestQueuesPolicy, genCombineGetRequestsPolicy, genErrorFormatterPolicy,
-  genVersionCheckPolicy,
+  genVersionCheckPolicy, genRetryOnFailurePolicy,
 } from './utils/autorest';
 import { Node as NodeApi, NodeOptionalParams, ErrorModel } from './apis/node';
 import { mapObject } from './utils/other';
@@ -128,6 +128,7 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
       additionalPolicies: [
         genRequestQueuesPolicy(),
         genCombineGetRequestsPolicy(),
+        genRetryOnFailurePolicy(),
         genErrorFormatterPolicy((body: ErrorModel) => ` ${body.reason}`),
       ],
       ...options,

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -117,10 +117,18 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
    * @param url - Url for node API
    * @param options - Options
    * @param options.ignoreVersion - Don't check node version
+   * @param options.retryCount - Amount of extra requests to do in case of failure
+   * @param options.retryOverallDelay - Time in ms to wait between all retries
    */
   constructor(
     url: string,
-    { ignoreVersion = false, ...options }: NodeOptionalParams & { ignoreVersion?: boolean } = {},
+    {
+      ignoreVersion = false, retryCount = 3, retryOverallDelay = 800, ...options
+    }: NodeOptionalParams & {
+      ignoreVersion?: boolean;
+      retryCount?: number;
+      retryOverallDelay?: number;
+    } = {},
   ) {
     // eslint-disable-next-line constructor-super
     super(url, {
@@ -128,7 +136,7 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
       additionalPolicies: [
         genRequestQueuesPolicy(),
         genCombineGetRequestsPolicy(),
-        genRetryOnFailurePolicy(),
+        genRetryOnFailurePolicy(retryCount, retryOverallDelay),
         genErrorFormatterPolicy((body: ErrorModel) => ` ${body.reason}`),
       ],
       ...options,


### PR DESCRIPTION
closes #1630 
found issues https://github.com/aeternity/aeternity/pull/4084

Attempt | Intermediate | Delay
-- | -- | --
0 | 0 | 0
1 | 0.33 | 55.55
2 | 0.66 | 222.22
3 | 1 | 500
  | Delay sum | 777.77

This is a bit different than Dincho suggested, I would reduce the amount of retries and make it truly exponential 🙂

This PR is supported by the Æternity Crypto Foundation