### PR TITLE
feat(account): accept async function in `authData` of AccountGeneralized

### DIFF
--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -18,6 +18,13 @@ import { Encoded } from '../utils/encoder';
 import Node from '../Node';
 import CompilerBase from '../contract/compiler/Base';
 
+interface AuthData {
+  gasLimit?: number;
+  callData?: Encoded.ContractBytearray;
+  sourceCode?: string;
+  args?: any[];
+}
+
 /**
  * Account is one of the three basic building blocks of an
  * {@link AeSdk} and provides access to a signing key pair.
@@ -36,12 +43,7 @@ export default abstract class AccountBase {
     options: {
       innerTx?: boolean;
       networkId?: string;
-      authData?: {
-        gasLimit?: number;
-        callData?: Encoded.ContractBytearray;
-        sourceCode?: string;
-        args?: any[];
-      };
+      authData?: AuthData | ((tx: Encoded.Transaction) => Promise<AuthData>);
       onNode?: Node;
       onCompiler?: CompilerBase;
       aeppOrigin?: string;

--- a/src/account/Generalized.ts
+++ b/src/account/Generalized.ts
@@ -63,7 +63,7 @@ export default class AccountGeneralized extends AccountBase {
     }
     const {
       callData, sourceCode, args, gasLimit,
-    } = authData;
+    } = typeof authData === 'function' ? await authData(tx) : authData;
 
     const authCallData = callData ?? await (async () => {
       if (this.#authFun == null) {

--- a/test/integration/ga.ts
+++ b/test/integration/ga.ts
@@ -31,6 +31,7 @@ import {
 } from '../../src';
 import { Encoded } from '../../src/utils/encoder';
 import { ContractMethodsBase } from '../../src/contract/Contract';
+import { ensureEqual } from '../utils';
 
 const sourceCode = `contract BlindAuth =
   record state = { txHash: option(hash) }
@@ -104,6 +105,20 @@ describe('Generalized Account', () => {
     const spendTx = buildTx(gaMetaTxParams.tx.encodedTx);
     expect(await aeSdk.buildAuthTxHash(spendTx)).to.be
       .eql((await authContract.getTxHash()).decodedResult);
+  });
+
+  it('accepts a function in authData', async () => {
+    let spendTx;
+    const { rawTx } = await aeSdk.spend(10000, publicKey, {
+      authData: async (tx) => {
+        spendTx = tx;
+        return { sourceCode, args: [genSalt()] };
+      },
+    });
+    const txParams = unpackTx(rawTx, Tag.SignedTx);
+    ensureEqual<Tag.GaMetaTx>(txParams.encodedTx.tag, Tag.GaMetaTx);
+    ensureEqual<Tag.SignedTx>(txParams.encodedTx.tx.tag, Tag.SignedTx);
+    expect(buildTx(txParams.encodedTx.tx.encodedTx)).to.be.equal(spendTx);
   });
 
   it('fails trying to send SignedTx using generalized account', async () => {


### PR DESCRIPTION
would simplify `authData` generation significantly in cases like https://github.com/aeternity/aepp-ga-ui/pull/2/files
cc: @loxs 

This PR is supported by the Æternity Crypto Foundation