### PR TITLE
refactor(channel)!: return unpacked entries in `state` method

### DIFF
--- a/src/channel/handlers.ts
+++ b/src/channel/handlers.ts
@@ -167,7 +167,8 @@ export async function awaitingReconnection(
   if (message.method === 'channels.info') {
     if (message.params.data.event === 'fsm_up') {
       channel._fsmId = message.params.data.fsm_id;
-      changeState(channel, (await channel.state()).signedTx);
+      const { signedTx } = await channel.state();
+      changeState(channel, signedTx == null ? '' : buildTx(signedTx));
       return { handler: channelOpen };
     }
   }

--- a/src/channel/internal.ts
+++ b/src/channel/internal.ts
@@ -31,10 +31,11 @@ import {
   ChannelError,
 } from '../utils/errors';
 import { encodeContractAddress } from '../utils/crypto';
+import { buildTx } from '../tx/builder';
 
 export interface ChannelEvents {
   statusChanged: (status: ChannelStatus) => void;
-  stateChanged: (tx: Encoded.Transaction) => void;
+  stateChanged: (tx: Encoded.Transaction | '') => void;
   depositLocked: () => void;
   ownDepositLocked: () => void;
   withdrawLocked: () => void;
@@ -185,7 +186,7 @@ export function changeStatus(channel: Channel, newStatus: ChannelStatus): void {
   emit(channel, 'statusChanged', newStatus);
 }
 
-export function changeState(channel: Channel, newState: Encoded.Transaction): void {
+export function changeState(channel: Channel, newState: Encoded.Transaction | ''): void {
   channel._state = newState;
   emit(channel, 'stateChanged', newState);
 }
@@ -349,7 +350,10 @@ export async function initialize(
         if (channelOptions.reconnectTx != null) {
           enterState(channel, { handler: openHandler });
           const { signedTx } = await channel.state();
-          changeState(channel, signedTx);
+          if (signedTx == null) {
+            throw new ChannelError('`signedTx` missed in state while reconnection');
+          }
+          changeState(channel, buildTx(signedTx));
         }
         ping(channel);
       },


### PR DESCRIPTION
BREAKING CHANGE: Channel:state returns unpacked entries Use `buildTx` to pack them back if needed.