### PR TITLE
refactor(oracle): pass queries one by one in pollForQueries

### DIFF
--- a/docs/guides/oracles.md
+++ b/docs/guides/oracles.md
@@ -86,11 +86,11 @@ console.log(decodedResponse)
 ## 3. Oracle: poll for queries and respond
 
 ### Poll for queries
-Typically the oracle itself polls for its own queries and responds as soon as possible:
+Typically, the oracle itself polls for its own queries and responds as soon as possible:
 
 ```js
-const stopPolling = await oracle.pollQueries((queries) => {
-   console.log(queries) // log all new queries
+const stopPolling = await oracle.pollQueries((query) => {
+  console.log(query) // log a new query
 }, { interval: 1000 }) // polling interval in milliseconds
 
 stopPolling() // stop polling

--- a/src/oracle.ts
+++ b/src/oracle.ts
@@ -41,7 +41,7 @@ type OracleQueries = Awaited<ReturnType<Node['getOracleQueriesByPubkey']>>['orac
  */
 export function pollForQueries(
   oracleId: Encoded.OracleAddress,
-  onQuery: (queries: OracleQueries) => void,
+  onQuery: (query: OracleQueries[number]) => void,
   { interval, onNode, ...options }: { interval?: number; onNode: Node }
   & Parameters<typeof _getPollInterval>[1],
 ): () => void {
@@ -50,8 +50,10 @@ export function pollForQueries(
   const checkNewQueries = async (): Promise<void> => {
     const queries = ((await onNode.getOracleQueriesByPubkey(oracleId)).oracleQueries ?? [])
       .filter(({ id }) => !knownQueryIds.has(id));
-    queries.forEach(({ id }) => knownQueryIds.add(id));
-    if (queries.length > 0) onQuery(queries);
+    queries.forEach((query) => {
+      knownQueryIds.add(query.id);
+      onQuery(query);
+    });
   };
 
   let stopped = false;

--- a/test/integration/oracle.ts
+++ b/test/integration/oracle.ts
@@ -45,8 +45,8 @@ describe('Oracle', () => {
 
   it('Pool for queries', (done) => {
     let count = 0;
-    const stopPolling = oracle.pollQueries((queries) => {
-      count += queries.length;
+    const stopPolling = oracle.pollQueries(() => {
+      count += 1;
       expect(count).to.be.lessThanOrEqual(4);
       if (count !== 4) return;
       stopPolling();


### PR DESCRIPTION
BREAKING CHANGE: `onQuery` callback of `pollForQueries`, `oracle.pollQueries` accepts a single query
It was accepting an array before. Apply a patch:
```diff
-aeSdk.pollForQueries(oracleId, (queries) => queries.forEach(handleQuery));
+aeSdk.pollForQueries(oracleId, handleQuery);
```

closes #1383 

This PR is supported by the Æternity Crypto Foundation