### PR TITLE
Return unpackTx's type in sendTransaction

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -81,7 +81,6 @@ BaseError
 │   ├── EncodeError
 │   ├── PayloadLengthError
 │   ├── DryRunError
-│   ├── IllegalBidFeeError
 │   ├── InvalidSignatureError
 │   ├── InvalidTxError
 │   ├── PrefixNotFoundError

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -47,16 +47,13 @@ const senderAccount = new MemoryAccount('<SENDER_SECRET_KEY>');
   })
 
   // spend one AE
-  await aeSdk.spend(1, '<RECIPIENT_PUBLIC_KEY>', {
-    // replace <RECIPIENT_PUBLIC_KEY>, Ideally you use public key from Superhero Wallet you have created before
-    denomination: AE_AMOUNT_FORMATS.AE
-  })
+  // replace <RECIPIENT_PUBLIC_KEY>, Ideally you use public key from Superhero Wallet you have created before
+  await aeSdk.spend(1e18, '<RECIPIENT_PUBLIC_KEY>')
 })()
 ```
 
 Note:
 
 - You may remove code from Step 2 as this serves only for one-time creation
-- By default the `spend` function expects the amount to be spent in `aettos` (the smallest possible unit)
-- Following the example snippet you would specify `AE` as denomination
+- The `spend` function expects the amount to be spent in `aettos` (the smallest possible unit)
 - See [Testnet Explorer](https://explorer.testnet.aeternity.io/) and track your transactions

--- a/docs/transaction-options.md
+++ b/docs/transaction-options.md
@@ -6,9 +6,9 @@ The `options` object can be optionally passed to the respective function behind 
 ```js
 const sender = 'ak_...'
 const recipient = 'ak_...'
-const options = { onAccount: sender, denomination: 'ae' } // optional options object
+const options = { onAccount: sender } // optional options object
 // aeSdk is an instance of the AeSdk class
-await aeSdk.spend(1, recipient, options) // amount, recipient and (optional) options
+await aeSdk.spend(1e18, recipient, options) // amount, recipient and (optional) options
 ```
 
 Note:
@@ -48,9 +48,7 @@ The following options are sepcific for each tx-type.
 
 ### ContractCreateTx & ContractCallTx
 - `amount` (default: `0`)
-  - To be used for providing `aettos` (or `AE` with respective denomination) to a contract related transaction.
-- `denomination` (default: `aettos`)
-  - You can specify the denomination of the `amount` that will be provided to the contract related transaction.
+  - To be used for providing `aettos` to a contract related transaction.
 - `gasLimit`
   - Maximum amount of gas to be consumed by the transaction. Learn more on [How to estimate gas?](#how-to-estimate-gas)
 - `gasPrice` (default: `1e9`)
@@ -90,10 +88,6 @@ The following options are sepcific for each tx-type.
 - `responseTtlType` (default `ORACLE_TTL_TYPES.delta`)
   - `ORACLE_TTL_TYPES.delta`: TTL value treated relative to a current block height
   - `ORACLE_TTL_TYPES.block`: TTL value treated as absolute block height
-
-### SpendTx
-- `denomination` (default: `aettos`)
-  - You can specify the denomination of the `amount` that will be provided to the contract related transaction.
 
 ## How to estimate gas?
 - As æpp developer, it is reasonable to estimate the gas consumption for a contract call using the dry-run feature of the node **once** and provide a specific offset (e.g. multiplied by 1.5 or 2) as default in the æpp to ensure that contract calls are mined. Depending on the logic of the contract the gas consumption of a specific contract call can vary and therefore you should monitor the gas consumption and increase the default for the respective contract call accordingly over time.

--- a/src/aens.ts
+++ b/src/aens.ts
@@ -6,11 +6,10 @@
  * repository.
  */
 
-import BigNumber from 'bignumber.js';
 import { genSalt } from './utils/crypto';
 import { commitmentHash, isAuctionName } from './tx/builder/helpers';
 import {
-  CLIENT_TTL, NAME_TTL, Tag, AensName,
+  CLIENT_TTL, NAME_TTL, Tag, AensName, Int,
 } from './tx/builder/constants';
 import { ArgumentError } from './utils/errors';
 import { Encoded } from './utils/encoder';
@@ -386,7 +385,7 @@ interface AensPreclaimOptions extends
  */
 export async function aensBid(
   name: AensName,
-  nameFee: number | string | BigNumber,
+  nameFee: Int,
   options: Omit<Parameters<typeof aensClaim>[2], 'nameFee'>,
 ): ReturnType<typeof aensClaim> {
   return aensClaim(name, 0, { ...options, nameFee });

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -118,7 +118,7 @@ export async function awaitHeight(
  * @category chain
  * @param txHash - Transaction hash
  * @param options - Options
- * @param options.confirm - Number of micro blocks to wait for transaction confirmation
+ * @param options.confirm - Number of key blocks to wait for transaction confirmation
  * @param options.onNode - Node to use
  * @returns Current Height
  */
@@ -149,7 +149,7 @@ export async function waitForTxConfirm(
  * @param options.onAccount - Account to use
  * @param options.verify - Verify transaction before broadcast, throw error if not
  * @param options.waitMined - Ensure that transaction get into block
- * @param options.confirm - Number of micro blocks that should be mined after tx get included
+ * @param options.confirm - Number of key blocks that should be mined after tx get included
  * @returns Transaction details
  */
 export async function sendTransaction(
@@ -199,10 +199,7 @@ export async function sendTransaction(
       // wait for transaction confirmation
       if (confirm != null && (confirm === true || confirm > 0)) {
         const c = typeof confirm === 'boolean' ? undefined : confirm;
-        return {
-          ...txData,
-          confirmationHeight: await waitForTxConfirm(txHash, { onNode, confirm: c, ...options }),
-        };
+        await waitForTxConfirm(txHash, { onNode, confirm: c, ...options });
       }
       return txData;
     }
@@ -227,7 +224,6 @@ export interface SendTransactionOptions extends SendTransactionOptionsType {}
 interface SendTransactionReturnType extends Partial<TransformNodeType<SignedTx>> {
   hash: Encoded.TxHash;
   rawTx: Encoded.Transaction;
-  confirmationHeight?: number;
 }
 
 /**

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -1,4 +1,3 @@
-import { AE_AMOUNT_FORMATS, formatAmount } from './utils/amount-formatter';
 import verifyTransaction, { ValidatorResult } from './tx/validator';
 import { isAccountNotFoundError, pause } from './utils/other';
 import { isNameValid, produceNameId } from './tx/builder/helpers';
@@ -257,9 +256,8 @@ export async function getAccount(
  */
 export async function getBalance(
   address: Encoded.AccountAddress | Encoded.ContractAddress | Encoded.OracleAddress,
-  { format = AE_AMOUNT_FORMATS.AETTOS, ...options }:
-  { format?: AE_AMOUNT_FORMATS } & Parameters<typeof getAccount>[1],
-): Promise<string> {
+  options: Parameters<typeof getAccount>[1],
+): Promise<bigint> {
   const addr = address.startsWith('ok_')
     ? encode(decode(address), Encoding.AccountAddress)
     : address as Encoded.AccountAddress | Encoded.ContractAddress;
@@ -269,7 +267,7 @@ export async function getBalance(
     return { balance: 0n };
   });
 
-  return formatAmount(balance, { targetDenomination: format });
+  return balance;
 }
 
 /**

--- a/src/channel/Contract.ts
+++ b/src/channel/Contract.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { snakeToPascal } from '../utils/string';
 import {
-  MIN_GAS_PRICE, Tag, AbiVersion, VmVersion,
+  MIN_GAS_PRICE, Tag, AbiVersion, VmVersion, Int,
 } from '../tx/builder/constants';
 import {
   signAndNotify,
@@ -275,14 +275,15 @@ export default class ChannelContract extends ChannelSpend {
    */
   async forceProgress(
     {
-      amount, callData, contract, abiVersion, gasLimit = 1000000, gasPrice = MIN_GAS_PRICE,
+      amount, callData, contract, abiVersion, gasLimit = 1000000,
+      gasPrice = MIN_GAS_PRICE.toString(),
     }: {
-      amount: number;
+      amount: Int;
       callData: Encoded.ContractBytearray;
       contract: Encoded.ContractAddress;
       abiVersion: AbiVersion;
       gasLimit?: number;
-      gasPrice?: number;
+      gasPrice?: Int;
     },
     sign: SignTx,
     { onOnChainTx }: Pick<ChannelState, 'onOnChainTx'> = {},

--- a/src/channel/Spend.ts
+++ b/src/channel/Spend.ts
@@ -150,13 +150,13 @@ export default class ChannelSpend extends Channel {
    */
   async balances(
     accounts: Encoded.AccountAddress[],
-  ): Promise<{ [key: Encoded.AccountAddress]: string }> {
+  ): Promise<{ [key: Encoded.AccountAddress]: bigint }> {
     return Object.fromEntries(
       (await call(this, 'channels.get.balances', { accounts }))
         .map((item: {
           account: Encoded.AccountAddress;
           balance: string;
-        }) => [item.account, item.balance]),
+        }) => [item.account, BigInt(item.balance)]),
     );
   }
 

--- a/src/spend.ts
+++ b/src/spend.ts
@@ -5,7 +5,7 @@ import {
 import { buildTxAsync, BuildTxOptions, unpackTx } from './tx/builder';
 import { ArgumentError } from './utils/errors';
 import { Encoded, Encoding } from './utils/encoder';
-import { Tag, AensName } from './tx/builder/constants';
+import { Tag, AensName, Int } from './tx/builder/constants';
 import AccountBase from './account/Base';
 
 /**
@@ -17,7 +17,7 @@ import AccountBase from './account/Base';
  * @returns Transaction
  */
 export async function spend(
-  amount: number | string,
+  amount: Int,
   recipientIdOrName: Encoded.AccountAddress | AensName,
   options: SpendOptions,
 ): ReturnType<typeof sendTransaction> {

--- a/src/spend.ts
+++ b/src/spend.ts
@@ -60,7 +60,7 @@ interface SpendOptions extends SpendOptionsType {}
  * ```
  */
 export async function transferFunds(
-  fraction: number | string,
+  fraction: number,
   recipientIdOrName: AensName | Encoded.AccountAddress,
   options: TransferFundsOptions,
 ): ReturnType<typeof sendTransaction> {

--- a/src/tx/builder/constants.ts
+++ b/src/tx/builder/constants.ts
@@ -12,9 +12,9 @@ export const NAME_TTL = 180000;
 export const NAME_MAX_TTL = 36000;
 export const NAME_MAX_CLIENT_TTL = 84600;
 export const CLIENT_TTL = NAME_MAX_CLIENT_TTL;
-export const MIN_GAS_PRICE = 1e9;
+export const MIN_GAS_PRICE = BigInt(1e9);
 // # see https://github.com/aeternity/aeternity/blob/72e440b8731422e335f879a31ecbbee7ac23a1cf/apps/aecore/src/aec_governance.erl#L67
-export const NAME_FEE_MULTIPLIER = 1e14; // 100000000000000
+export const NAME_FEE_MULTIPLIER = BigInt(1e14); // 100000000000000
 export const NAME_FEE_BID_INCREMENT = 0.05; // # the increment is in percentage
 // # see https://github.com/aeternity/aeternity/blob/72e440b8731422e335f879a31ecbbee7ac23a1cf/apps/aecore/src/aec_governance.erl#L272
 export const NAME_BID_TIMEOUT_BLOCKS = 480; // # ~1 day
@@ -56,7 +56,7 @@ export const NAME_BID_RANGES = mapObject({
   3: 2178309,
   2: 3524578,
   1: 5702887,
-}, ([key, value]) => [key, new BigNumber(value).times(NAME_FEE_MULTIPLIER)]);
+}, ([key, value]) => [key, BigInt(value) * NAME_FEE_MULTIPLIER]);
 
 export enum ConsensusProtocolVersion {
   Iris = 5,

--- a/src/tx/builder/field-types/coin-amount.ts
+++ b/src/tx/builder/field-types/coin-amount.ts
@@ -1,6 +1,5 @@
 import uInt from './u-int';
 import { Int } from '../constants';
-import { AE_AMOUNT_FORMATS, formatAmount } from '../../../utils/amount-formatter';
 
 export default {
   ...uInt,
@@ -12,13 +11,9 @@ export default {
   serialize(
     value: Int | undefined,
     params: {},
-    { denomination = AE_AMOUNT_FORMATS.AETTOS }: { denomination?: AE_AMOUNT_FORMATS },
   ): Buffer {
     return uInt.serialize(
-      this.serializeAettos(
-        value != null ? formatAmount(value, { denomination }) : value,
-        params,
-      ),
+      this.serializeAettos(value, params),
     );
   },
 };

--- a/src/tx/builder/field-types/coin-amount.ts
+++ b/src/tx/builder/field-types/coin-amount.ts
@@ -1,19 +1,11 @@
 import uInt from './u-int';
 import { Int } from '../constants';
 
+// TODO: serialize and deserialize a wrapper around bigint
 export default {
   ...uInt,
 
-  serializeAettos(value: string | undefined): string {
-    return value ?? '0';
-  },
-
-  serialize(
-    value: Int | undefined,
-    params: {},
-  ): Buffer {
-    return uInt.serialize(
-      this.serializeAettos(value, params),
-    );
+  serialize(value: Int | undefined): Buffer {
+    return uInt.serialize(value ?? 0);
   },
 };

--- a/src/tx/builder/field-types/deposit.ts
+++ b/src/tx/builder/field-types/deposit.ts
@@ -8,16 +8,14 @@ export default {
   /**
    * @param value - Deposit value in string format. Should be equal to '0'.
    * @param options - Options
-   * @param parameters - Parameters
    * @returns Deposit value Buffer.
    */
   serialize(
     value: Int | undefined,
     options: Parameters<typeof coinAmount['serialize']>[1],
-    parameters: Parameters<typeof coinAmount['serialize']>[2],
   ): Buffer {
     value ??= 0;
     if (+value !== 0) throw new IllegalArgumentError(`Contract deposit is not refundable, so it should be equal 0, got ${value.toString()} instead`);
-    return coinAmount.serialize(value, options, parameters);
+    return coinAmount.serialize(value, options);
   },
 };

--- a/src/tx/builder/field-types/deposit.ts
+++ b/src/tx/builder/field-types/deposit.ts
@@ -7,15 +7,13 @@ export default {
 
   /**
    * @param value - Deposit value in string format. Should be equal to '0'.
-   * @param options - Options
    * @returns Deposit value Buffer.
    */
-  serialize(
-    value: Int | undefined,
-    options: Parameters<typeof coinAmount['serialize']>[1],
-  ): Buffer {
+  serialize(value: Int | undefined): Buffer {
     value ??= 0;
-    if (+value !== 0) throw new IllegalArgumentError(`Contract deposit is not refundable, so it should be equal 0, got ${value.toString()} instead`);
-    return coinAmount.serialize(value, options);
+    if (+value !== 0) {
+      throw new IllegalArgumentError(`Contract deposit is not refundable, so it should be equal 0, got ${value.toString()} instead`);
+    }
+    return coinAmount.serialize(value);
   },
 };

--- a/src/tx/builder/field-types/fee.ts
+++ b/src/tx/builder/field-types/fee.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { IllegalArgumentError } from '../../../utils/errors';
-import { MIN_GAS_PRICE, Tag } from '../constants';
+import { Int, MIN_GAS_PRICE, Tag } from '../constants';
 import coinAmount from './coin-amount';
 import { isKeyOfObject } from '../../../utils/other';
 import { decode, Encoded } from '../../../utils/encoder';
@@ -135,8 +135,8 @@ function calculateMinFee(
 export default {
   ...coinAmount,
 
-  serializeAettos(
-    _value: string | undefined,
+  serialize(
+    _value: Int | undefined,
     {
       rebuildTx, unpackTx, buildTx, _computingMinFee, _pickBiggerFee,
     }: {
@@ -146,8 +146,8 @@ export default {
       _computingMinFee?: BigNumber;
       _pickBiggerFee?: boolean;
     },
-  ): string {
-    if (_computingMinFee != null) return _computingMinFee.toFixed();
+  ): Buffer {
+    if (_computingMinFee != null) return coinAmount.serialize(_computingMinFee);
     const minFee = calculateMinFee(
       (fee) => rebuildTx({ _computingMinFee: fee }),
       unpackTx,
@@ -155,9 +155,9 @@ export default {
     );
     const value = new BigNumber(_value ?? minFee);
     if (minFee.gt(value)) {
-      if (_pickBiggerFee === true) return minFee.toFixed();
+      if (_pickBiggerFee === true) return coinAmount.serialize(minFee);
       throw new IllegalArgumentError(`Fee ${value.toString()} must be bigger then ${minFee}`);
     }
-    return value.toFixed();
+    return coinAmount.serialize(value);
   },
 };

--- a/src/tx/builder/field-types/fee.ts
+++ b/src/tx/builder/field-types/fee.ts
@@ -17,10 +17,10 @@ const KEY_BLOCK_INTERVAL = 3;
  * @returns The base fee
  * @example
  * ```js
- * TX_FEE_BASE('channelForceProgress') => new BigNumber(30 * 15000)
+ * TX_FEE_BASE_GAS(Tag.ChannelForceProgressTx) => 30 * 15000
  * ```
  */
-const TX_FEE_BASE_GAS = (txType: Tag): BigNumber => {
+const TX_FEE_BASE_GAS = (txType: Tag): number => {
   const feeFactors = {
     [Tag.ChannelForceProgressTx]: 30,
     [Tag.ChannelOffChainTx]: 0,
@@ -36,7 +36,7 @@ const TX_FEE_BASE_GAS = (txType: Tag): BigNumber => {
     [Tag.PayingForTx]: 1 / 5,
   } as const;
   const factor = feeFactors[txType as keyof typeof feeFactors] ?? 1;
-  return new BigNumber(factor * BASE_GAS);
+  return factor * BASE_GAS;
 };
 
 /**
@@ -50,30 +50,27 @@ const TX_FEE_BASE_GAS = (txType: Tag): BigNumber => {
  * @returns The Other fee
  * @example
  * ```js
- * TX_FEE_OTHER_GAS('oracleResponse',10, { relativeTtl: 10, innerTxSize: 10 })
- *  => new BigNumber(10).times(20).plus(Math.ceil(32000 * 10 / Math.floor(60 * 24 * 365 / 2)))
+ * TX_FEE_OTHER_GAS(Tag.OracleResponseTx, 10, { relativeTtl: 10, innerTxSize: 10 })
+ *  => 10 * 20 + Math.ceil(32000 * 10 / Math.floor(60 * 24 * 365 / 2))
  * ```
  */
 const TX_FEE_OTHER_GAS = (
   txType: Tag,
   txSize: number,
   { relativeTtl, innerTxSize }: { relativeTtl: number; innerTxSize: number },
-): BigNumber => {
+): number => {
   switch (txType) {
     case Tag.OracleRegisterTx:
     case Tag.OracleExtendTx:
     case Tag.OracleQueryTx:
     case Tag.OracleResponseTx:
-      return new BigNumber(txSize)
-        .times(GAS_PER_BYTE)
-        .plus(
-          Math.ceil((32000 * relativeTtl) / Math.floor((60 * 24 * 365) / KEY_BLOCK_INTERVAL)),
-        );
+      return txSize * GAS_PER_BYTE
+        + Math.ceil((32000 * relativeTtl) / Math.floor((60 * 24 * 365) / KEY_BLOCK_INTERVAL));
     case Tag.GaMetaTx:
     case Tag.PayingForTx:
-      return new BigNumber(txSize).minus(innerTxSize).times(GAS_PER_BYTE);
+      return (txSize - innerTxSize) * GAS_PER_BYTE;
     default:
-      return new BigNumber(txSize).times(GAS_PER_BYTE);
+      return txSize * GAS_PER_BYTE;
   }
 };
 
@@ -97,7 +94,7 @@ export function buildFee(
   builtTx: Encoded.Transaction,
   unpackTx: typeof unpackTxType,
   buildTx: typeof buildTxType,
-): BigNumber {
+): bigint {
   const { length } = decode(builtTx);
   const txObject = unpackTx(builtTx);
 
@@ -106,11 +103,10 @@ export function buildFee(
     innerTxSize = decode(buildTx(txObject.tx.encodedTx)).length;
   }
 
-  return TX_FEE_BASE_GAS(txObject.tag)
-    .plus(TX_FEE_OTHER_GAS(txObject.tag, length, {
-      relativeTtl: getOracleRelativeTtl(txObject), innerTxSize,
-    }))
-    .times(MIN_GAS_PRICE);
+  const gas = TX_FEE_BASE_GAS(txObject.tag) + TX_FEE_OTHER_GAS(txObject.tag, length, {
+    relativeTtl: getOracleRelativeTtl(txObject), innerTxSize,
+  });
+  return BigInt(gas) * MIN_GAS_PRICE;
 }
 
 /**
@@ -119,16 +115,16 @@ export function buildFee(
  * @param rebuildTx - Callback to get built transaction with specific fee
  */
 function calculateMinFee(
-  rebuildTx: (value: BigNumber) => Encoded.Transaction,
+  rebuildTx: (value: bigint) => Encoded.Transaction,
   unpackTx: typeof unpackTxType,
   buildTx: typeof buildTxType,
-): BigNumber {
-  let fee = new BigNumber(0);
+): bigint {
+  let fee = 0n;
   let previousFee;
   do {
     previousFee = fee;
     fee = buildFee(rebuildTx(fee), unpackTx, buildTx);
-  } while (!fee.eq(previousFee));
+  } while (fee !== previousFee);
   return fee;
 }
 
@@ -143,16 +139,16 @@ export default {
       rebuildTx: (params: any) => Encoded.Transaction;
       unpackTx: typeof unpackTxType;
       buildTx: typeof buildTxType;
-      _computingMinFee?: BigNumber;
+      _computingMinFee?: bigint;
       _pickBiggerFee?: boolean;
     },
   ): Buffer {
-    if (_computingMinFee != null) return coinAmount.serialize(_computingMinFee);
-    const minFee = calculateMinFee(
+    if (_computingMinFee != null) return coinAmount.serialize(_computingMinFee.toString());
+    const minFee = new BigNumber(calculateMinFee(
       (fee) => rebuildTx({ _computingMinFee: fee }),
       unpackTx,
       buildTx,
-    );
+    ).toString());
     const value = new BigNumber(_value ?? minFee);
     if (minFee.gt(value)) {
       if (_pickBiggerFee === true) return coinAmount.serialize(minFee);

--- a/src/tx/builder/field-types/gas-limit.ts
+++ b/src/tx/builder/field-types/gas-limit.ts
@@ -10,7 +10,7 @@ function calculateGasLimitMax(
   unpackTx: typeof unpackTxType,
   buildTx: typeof buildTxType,
 ): number {
-  return gasMax - +buildFee(rebuildTx(gasMax), unpackTx, buildTx).dividedBy(MIN_GAS_PRICE);
+  return gasMax - Number(buildFee(rebuildTx(gasMax), unpackTx, buildTx) / MIN_GAS_PRICE);
 }
 
 export default {

--- a/src/tx/builder/field-types/gas-price.ts
+++ b/src/tx/builder/field-types/gas-price.ts
@@ -5,7 +5,7 @@ import { Int, MIN_GAS_PRICE } from '../constants';
 export default {
   ...coinAmount,
 
-  serialize(value: Int = MIN_GAS_PRICE): Buffer {
+  serialize(value: Int = MIN_GAS_PRICE.toString()): Buffer {
     if (+value < MIN_GAS_PRICE) {
       throw new IllegalArgumentError(`Gas price ${value.toString()} must be bigger then ${MIN_GAS_PRICE}`);
     }

--- a/src/tx/builder/field-types/gas-price.ts
+++ b/src/tx/builder/field-types/gas-price.ts
@@ -1,14 +1,14 @@
 import coinAmount from './coin-amount';
 import { IllegalArgumentError } from '../../../utils/errors';
-import { MIN_GAS_PRICE } from '../constants';
+import { Int, MIN_GAS_PRICE } from '../constants';
 
 export default {
   ...coinAmount,
 
-  serializeAettos(value: string | undefined = MIN_GAS_PRICE.toString()): string {
+  serialize(value: Int = MIN_GAS_PRICE): Buffer {
     if (+value < MIN_GAS_PRICE) {
       throw new IllegalArgumentError(`Gas price ${value.toString()} must be bigger then ${MIN_GAS_PRICE}`);
     }
-    return value;
+    return coinAmount.serialize(value);
   },
 };

--- a/src/tx/builder/field-types/name-fee.ts
+++ b/src/tx/builder/field-types/name-fee.ts
@@ -7,25 +7,15 @@ import { AensName, Int } from '../constants';
 export default {
   ...coinAmount,
 
-  serializeAettos(
-    _value: string | undefined,
-    txFields: { name: AensName },
-  ): string {
-    const minNameFee = getMinimumNameFee(txFields.name);
-    const value = new BigNumber(_value ?? minNameFee);
-    if (minNameFee.gt(value)) throw new InsufficientNameFeeError(value, minNameFee);
-    return value.toFixed();
-  },
-
   /**
-   * @param value - AENS name fee Buffer
+   * @param value - AENS name fee
    * @param txFields - Transaction fields
    * @param txFields.name - AENS Name in transaction
    */
-  serialize(
-    value: Int | undefined,
-    txFields: { name: AensName } & Parameters<typeof coinAmount['serialize']>[1],
-  ): Buffer {
-    return coinAmount.serialize.call(this, value, txFields);
+  serialize(value: Int | undefined, txFields: { name: AensName }): Buffer {
+    const minNameFee = getMinimumNameFee(txFields.name);
+    const val = new BigNumber(value ?? minNameFee);
+    if (minNameFee.gt(val)) throw new InsufficientNameFeeError(val, minNameFee);
+    return coinAmount.serialize(val);
   },
 };

--- a/src/tx/builder/field-types/name-fee.ts
+++ b/src/tx/builder/field-types/name-fee.ts
@@ -25,8 +25,7 @@ export default {
   serialize(
     value: Int | undefined,
     txFields: { name: AensName } & Parameters<typeof coinAmount['serialize']>[1],
-    parameters: Parameters<typeof coinAmount['serialize']>[2],
   ): Buffer {
-    return coinAmount.serialize.call(this, value, txFields, parameters);
+    return coinAmount.serialize.call(this, value, txFields);
   },
 };

--- a/src/tx/builder/field-types/name-fee.ts
+++ b/src/tx/builder/field-types/name-fee.ts
@@ -13,7 +13,7 @@ export default {
    * @param txFields.name - AENS Name in transaction
    */
   serialize(value: Int | undefined, txFields: { name: AensName }): Buffer {
-    const minNameFee = getMinimumNameFee(txFields.name);
+    const minNameFee = new BigNumber(getMinimumNameFee(txFields.name).toString());
     const val = new BigNumber(value ?? minNameFee);
     if (minNameFee.gt(val)) throw new InsufficientNameFeeError(val, minNameFee);
     return coinAmount.serialize(val);

--- a/src/tx/builder/helpers.ts
+++ b/src/tx/builder/helpers.ts
@@ -13,8 +13,7 @@ import {
   NAME_FEE_BID_INCREMENT,
   NAME_MAX_LENGTH_FEE,
 } from './constants';
-import { ceil } from '../../utils/bignumber';
-import { ArgumentError, IllegalBidFeeError } from '../../utils/errors';
+import { ArgumentError } from '../../utils/errors';
 
 /**
  * JavaScript-based Transaction builder helper function's
@@ -161,16 +160,13 @@ export function getMinimumNameFee(name: AensName): BigNumber {
  */
 export function computeBidFee(
   name: AensName,
-  { startFee, increment = NAME_FEE_BID_INCREMENT }:
+  { startFee = getMinimumNameFee(name), increment = NAME_FEE_BID_INCREMENT }:
   { startFee?: Int; increment?: number } = {},
 ): BigNumber {
-  if (!(Number(increment) === increment && increment % 1 !== 0)) throw new IllegalBidFeeError(`Increment must be float. Current increment ${increment}`);
-  if (increment < NAME_FEE_BID_INCREMENT) throw new IllegalBidFeeError(`minimum increment percentage is ${NAME_FEE_BID_INCREMENT}`);
-  // FIXME: increment should be used somehow here
-  return ceil(
-    new BigNumber(startFee ?? getMinimumNameFee(name))
-      .times(new BigNumber(NAME_FEE_BID_INCREMENT).plus(1)),
-  );
+  if (increment < NAME_FEE_BID_INCREMENT) {
+    throw new ArgumentError('increment', `not less than ${NAME_FEE_BID_INCREMENT}`, increment);
+  }
+  return new BigNumber(startFee).times(increment + 1).integerValue(BigNumber.ROUND_CEIL);
 }
 
 /**

--- a/src/tx/builder/helpers.ts
+++ b/src/tx/builder/helpers.ts
@@ -144,7 +144,7 @@ export function getDefaultPointerKey(
  * @param name - the AENS name to get the fee for
  * @returns the minimum fee for the AENS name auction
  */
-export function getMinimumNameFee(name: AensName): BigNumber {
+export function getMinimumNameFee(name: AensName): bigint {
   const nameLength = name.length - AENS_SUFFIX.length;
   return NAME_BID_RANGES[Math.min(nameLength, NAME_MAX_LENGTH_FEE)];
 }
@@ -161,12 +161,12 @@ export function getMinimumNameFee(name: AensName): BigNumber {
 export function computeBidFee(
   name: AensName,
   { startFee = getMinimumNameFee(name), increment = NAME_FEE_BID_INCREMENT }:
-  { startFee?: Int; increment?: number } = {},
-): BigNumber {
+  { startFee?: Int | bigint; increment?: number } = {},
+): bigint {
   if (increment < NAME_FEE_BID_INCREMENT) {
     throw new ArgumentError('increment', `not less than ${NAME_FEE_BID_INCREMENT}`, increment);
   }
-  return new BigNumber(startFee).times(increment + 1).integerValue(BigNumber.ROUND_CEIL);
+  return BigInt(Math.ceil(Number(startFee) * (increment + 1)));
 }
 
 /**

--- a/src/tx/builder/helpers.ts
+++ b/src/tx/builder/helpers.ts
@@ -7,6 +7,7 @@ import { toBytes } from '../../utils/bytes';
 import { concatBuffers } from '../../utils/other';
 import {
   AensName,
+  Int,
   NAME_BID_RANGES,
   NAME_BID_TIMEOUT_BLOCKS,
   NAME_FEE_BID_INCREMENT,
@@ -161,7 +162,7 @@ export function getMinimumNameFee(name: AensName): BigNumber {
 export function computeBidFee(
   name: AensName,
   { startFee, increment = NAME_FEE_BID_INCREMENT }:
-  { startFee?: number | string | BigNumber; increment?: number } = {},
+  { startFee?: Int; increment?: number } = {},
 ): BigNumber {
   if (!(Number(increment) === increment && increment % 1 !== 0)) throw new IllegalBidFeeError(`Increment must be float. Current increment ${increment}`);
   if (increment < NAME_FEE_BID_INCREMENT) throw new IllegalBidFeeError(`minimum increment percentage is ${NAME_FEE_BID_INCREMENT}`);

--- a/src/tx/builder/helpers.ts
+++ b/src/tx/builder/helpers.ts
@@ -28,7 +28,7 @@ import { ArgumentError, IllegalBidFeeError } from '../../utils/errors';
  */
 export function buildContractId(
   ownerId: Encoded.AccountAddress,
-  nonce: number | BigNumber,
+  nonce: number,
 ): Encoded.ContractAddress {
   const ownerIdAndNonce = Buffer.from([...decode(ownerId), ...toBytes(nonce)]);
   const b2bHash = hash(ownerIdAndNonce);
@@ -45,10 +45,10 @@ export function buildContractId(
  */
 export function oracleQueryId(
   senderId: Encoded.AccountAddress,
-  nonce: number | BigNumber | string,
+  nonce: number,
   oracleId: Encoded.OracleAddress,
 ): Encoded.OracleQueryId {
-  function _int32(val: number | string | BigNumber): Buffer {
+  function _int32(val: number): Buffer {
     const nonceBE = toBytes(val, true);
     return concatBuffers([Buffer.alloc(32 - nonceBE.length), nonceBE]);
   }

--- a/src/utils/bignumber.ts
+++ b/src/utils/bignumber.ts
@@ -7,15 +7,10 @@ import BigNumber from 'bignumber.js';
  * Check if value is BigNumber, Number, BigInt or number string representation
  * @param number - number to check
  */
+// eslint-disable-next-line import/prefer-default-export
 export const isBigNumber = (number: string | number | bigint | BigNumber): boolean => {
   if (typeof number === 'bigint') return true;
   return ['number', 'object', 'string'].includes(typeof number)
     // eslint-disable-next-line no-restricted-globals
     && (!isNaN(number as number) || Number.isInteger(number) || BigNumber.isBigNumber(number));
 };
-
-/**
- * BigNumber ceil operation
- */
-export const ceil = (bigNumber: BigNumber): BigNumber => bigNumber
-  .integerValue(BigNumber.ROUND_CEIL);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -679,16 +679,6 @@ export class DryRunError extends TransactionError {
 /**
  * @category exception
  */
-export class IllegalBidFeeError extends TransactionError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'IllegalBidFeeError';
-  }
-}
-
-/**
- * @category exception
- */
 export class InvalidSignatureError extends TransactionError {
   constructor(message: string) {
     super(message);

--- a/test/integration/accounts.ts
+++ b/test/integration/accounts.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import { getSdk } from '.';
 import {
   AeSdk, MemoryAccount,
-  generateKeyPair, AE_AMOUNT_FORMATS,
+  generateKeyPair,
   UnavailableAccountError, TypeError, ArgumentError, UnexpectedTsError,
 } from '../../src';
 import { Encoded } from '../../src/utils/encoder';
@@ -103,7 +103,7 @@ describe('Accounts', () => {
   });
 
   it('spends coins in AE format', async () => {
-    const ret = await aeSdk.spend(1, receiver.address, { denomination: AE_AMOUNT_FORMATS.AE });
+    const ret = await aeSdk.spend(1e18, receiver.address);
     ret.should.have.property('tx');
     if (ret.tx == null) throw new UnexpectedTsError();
     ret.tx.should.include({ amount: 10n ** 18n, recipientId: receiver.address });

--- a/test/integration/accounts.ts
+++ b/test/integration/accounts.ts
@@ -30,7 +30,7 @@ describe('Accounts', () => {
   });
 
   it('determining the balance with 0 balance', async () => {
-    await aeSdkNoCoins.getBalance(aeSdkNoCoins.address).should.eventually.be.equal('0');
+    expect(await aeSdkNoCoins.getBalance(aeSdkNoCoins.address)).to.be.equal(0n);
   });
 
   it('spending coins with 0 balance', async () => {
@@ -41,7 +41,7 @@ describe('Accounts', () => {
     .to.be.rejectedWith(ArgumentError, 'value should be greater or equal to 0, got -1 instead'));
 
   it('determines the balance using `balance`', async () => {
-    await aeSdk.getBalance(aeSdk.address).should.eventually.be.a('string');
+    expect(await aeSdk.getBalance(aeSdk.address)).to.be.a('bigint');
   });
 
   describe('transferFunds', () => {
@@ -51,9 +51,9 @@ describe('Accounts', () => {
       amount: BigNumber;
       fee: BigNumber;
     }> => {
-      const balanceBefore = new BigNumber(await aeSdk.getBalance(aeSdk.address));
+      const balanceBefore = new BigNumber((await aeSdk.getBalance(aeSdk.address)).toString());
       const { tx } = await aeSdk.transferFunds(fraction, receiver.address);
-      const balanceAfter = new BigNumber(await aeSdk.getBalance(aeSdk.address));
+      const balanceAfter = new BigNumber((await aeSdk.getBalance(aeSdk.address)).toString());
       if (tx == null || tx.amount == null) throw new UnexpectedTsError();
       return {
         balanceBefore,
@@ -91,7 +91,7 @@ describe('Accounts', () => {
 
     it('accepts onAccount option', async () => {
       await aeSdk.transferFunds(1, aeSdk.address, { onAccount: receiver });
-      new BigNumber(await aeSdk.getBalance(receiver.address)).isZero().should.be.equal(true);
+      expect(await aeSdk.getBalance(receiver.address)).to.be.equal(0n);
     });
   });
 
@@ -115,7 +115,7 @@ describe('Accounts', () => {
     const ret = await aeSdk.spend(bigAmount.toString(), publicKey);
 
     const balanceAfter = await aeSdk.getBalance(publicKey);
-    balanceAfter.should.be.equal(bigAmount.toString());
+    balanceAfter.should.be.equal(bigAmount);
     ret.should.have.property('tx');
     if (ret.tx == null) throw new UnexpectedTsError();
     ret.tx.should.include({ amount: bigAmount, recipientId: publicKey });

--- a/test/integration/aens.ts
+++ b/test/integration/aens.ts
@@ -163,7 +163,7 @@ describe('Aens', () => {
       const claim = await preclaim.claim();
       claim.should.be.an('object');
 
-      const bidFee = computeBidFee(nameShort);
+      const bidFee = computeBidFee(nameShort).toString();
       const bid: Awaited<ReturnType<typeof aeSdk.aensClaim>> = await aeSdk
         .aensBid(nameShort, bidFee, { onAccount });
       bid.should.be.an('object');

--- a/test/integration/channel.ts
+++ b/test/integration/channel.ts
@@ -710,8 +710,8 @@ describe('Channel', () => {
       tag: Tag.ChannelSettleTx,
       channelId: await initiatorCh.id(),
       fromId: initiatorAddr,
-      initiatorAmountFinal: balances[initiatorAddr],
-      responderAmountFinal: balances[responderAddr],
+      initiatorAmountFinal: balances[initiatorAddr].toString(),
+      responderAmountFinal: balances[responderAddr].toString(),
     });
     const settleTxFee = unpackTx(settleTx, Tag.ChannelSettleTx).fee;
     await aeSdkInitiatior.sendTransaction(settleTx);
@@ -721,11 +721,11 @@ describe('Channel', () => {
       .minus(initiatorBalanceBeforeClose.toString())
       .plus(closeSoloTxFee)
       .plus(settleTxFee)
-      .isEqualTo(balances[initiatorAddr])
+      .isEqualTo(balances[initiatorAddr].toString())
       .should.be.equal(true);
     new BigNumber(responderBalanceAfterClose.toString())
       .minus(responderBalanceBeforeClose.toString())
-      .isEqualTo(balances[responderAddr])
+      .isEqualTo(balances[responderAddr].toString())
       .should.be.equal(true);
   });
 
@@ -784,8 +784,8 @@ describe('Channel', () => {
       tag: Tag.ChannelSettleTx,
       channelId: responderCh.id(),
       fromId: responderAddr,
-      initiatorAmountFinal: recentBalances[initiatorAddr],
-      responderAmountFinal: recentBalances[responderAddr],
+      initiatorAmountFinal: recentBalances[initiatorAddr].toString(),
+      responderAmountFinal: recentBalances[responderAddr].toString(),
     });
     const settleTxFee = unpackTx(settleTx, Tag.ChannelSettleTx).fee;
     await aeSdkResponder.sendTransaction(settleTx);
@@ -794,13 +794,13 @@ describe('Channel', () => {
     new BigNumber(initiatorBalanceAfterClose.toString())
       .minus(initiatorBalanceBeforeClose.toString())
       .plus(closeSoloTxFee)
-      .isEqualTo(recentBalances[initiatorAddr])
+      .isEqualTo(recentBalances[initiatorAddr].toString())
       .should.be.equal(true);
     new BigNumber(responderBalanceAfterClose.toString())
       .minus(responderBalanceBeforeClose.toString())
       .plus(slashTxFee)
       .plus(settleTxFee)
-      .isEqualTo(recentBalances[responderAddr])
+      .isEqualTo(recentBalances[responderAddr].toString())
       .should.be.equal(true);
   });
 
@@ -933,10 +933,9 @@ describe('Channel', () => {
     const contractAddr = encode(decode(contractAddress), Encoding.AccountAddress);
     const addresses = [aeSdkInitiatior.address, aeSdkResponder.address, contractAddr];
     const balances = await initiatorCh.balances(addresses);
-    balances.should.be.an('object');
-    balances[aeSdkInitiatior.address].should.be.a('string');
-    balances[aeSdkResponder.address].should.be.a('string');
-    balances[contractAddr].should.be.equal(1000);
+    expect(balances[aeSdkInitiatior.address]).to.be.a('bigint');
+    expect(balances[aeSdkResponder.address]).to.be.a('bigint');
+    expect(balances[contractAddr]).to.be.equal(1000n);
     expect(balances).to.eql(await responderCh.balances(addresses));
   });
 

--- a/test/integration/channel.ts
+++ b/test/integration/channel.ts
@@ -717,14 +717,14 @@ describe('Channel', () => {
     await aeSdkInitiatior.sendTransaction(settleTx);
     const initiatorBalanceAfterClose = await aeSdkInitiatior.getBalance(initiatorAddr);
     const responderBalanceAfterClose = await aeSdkResponder.getBalance(responderAddr);
-    new BigNumber(initiatorBalanceAfterClose)
-      .minus(initiatorBalanceBeforeClose)
+    new BigNumber(initiatorBalanceAfterClose.toString())
+      .minus(initiatorBalanceBeforeClose.toString())
       .plus(closeSoloTxFee)
       .plus(settleTxFee)
       .isEqualTo(balances[initiatorAddr])
       .should.be.equal(true);
-    new BigNumber(responderBalanceAfterClose)
-      .minus(responderBalanceBeforeClose)
+    new BigNumber(responderBalanceAfterClose.toString())
+      .minus(responderBalanceBeforeClose.toString())
       .isEqualTo(balances[responderAddr])
       .should.be.equal(true);
   });
@@ -791,13 +791,13 @@ describe('Channel', () => {
     await aeSdkResponder.sendTransaction(settleTx);
     const initiatorBalanceAfterClose = await aeSdkInitiatior.getBalance(initiatorAddr);
     const responderBalanceAfterClose = await aeSdkResponder.getBalance(responderAddr);
-    new BigNumber(initiatorBalanceAfterClose)
-      .minus(initiatorBalanceBeforeClose)
+    new BigNumber(initiatorBalanceAfterClose.toString())
+      .minus(initiatorBalanceBeforeClose.toString())
       .plus(closeSoloTxFee)
       .isEqualTo(recentBalances[initiatorAddr])
       .should.be.equal(true);
-    new BigNumber(responderBalanceAfterClose)
-      .minus(responderBalanceBeforeClose)
+    new BigNumber(responderBalanceAfterClose.toString())
+      .minus(responderBalanceBeforeClose.toString())
       .plus(slashTxFee)
       .plus(settleTxFee)
       .isEqualTo(recentBalances[responderAddr])

--- a/test/integration/contract-aci.ts
+++ b/test/integration/contract-aci.ts
@@ -14,7 +14,6 @@ import {
   IllegalArgumentError,
   Contract,
   hash,
-  AE_AMOUNT_FORMATS,
 } from '../../src';
 import { getSdk } from '.';
 import { Encoded } from '../../src/utils/encoder';
@@ -209,7 +208,6 @@ describe('Contract instance', () => {
   it('deploys', async () => {
     const deployInfo = await testContract.$deploy(['test', 1, 'hahahaha'], {
       amount: 42,
-      denomination: AE_AMOUNT_FORMATS.AETTOS,
       gasLimit: 16000,
       deposit: 0,
       ttl: 0,

--- a/test/integration/contract-aci.ts
+++ b/test/integration/contract-aci.ts
@@ -375,7 +375,7 @@ describe('Contract instance', () => {
     const contractBalance = await aeSdk.getBalance(testContract.$options.address);
     await testContract.stringFn('test', { amount: 100, callStatic: false });
     const balanceAfter = await aeSdk.getBalance(testContract.$options.address);
-    balanceAfter.should.be.equal(`${+contractBalance + 100}`);
+    balanceAfter.should.be.equal(contractBalance + 100n);
   });
 
   it('calls on specific account', async () => {

--- a/test/integration/ga.ts
+++ b/test/integration/ga.ts
@@ -68,8 +68,7 @@ describe('Generalized Account', () => {
     const callData = authContract._calldata.encode('BlindAuth', 'authorize', [genSalt()]);
     await aeSdk.spend(10000, publicKey, { authData: { callData } });
     await aeSdk.spend(10000, publicKey, { authData: { sourceCode, args: [genSalt()] } });
-    const balanceAfter = await aeSdk.getBalance(publicKey);
-    balanceAfter.should.be.equal('20000');
+    expect(await aeSdk.getBalance(publicKey)).to.be.equal(20000n);
   });
 
   it('throws error if gasLimit exceeds the maximum value', async () => {

--- a/test/integration/paying-for.ts
+++ b/test/integration/paying-for.ts
@@ -1,6 +1,5 @@
 import { describe, it, before } from 'mocha';
 import { expect } from 'chai';
-import BigNumber from 'bignumber.js';
 import { getSdk } from '.';
 import {
   AeSdk, Contract, MemoryAccount, Tag, UnexpectedTsError,
@@ -33,12 +32,10 @@ describe('Paying for transaction of another account', () => {
     const outerFee = tx?.fee;
     const innerFee = tx?.tx?.tx.fee;
     if (outerFee == null || innerFee == null) throw new UnexpectedTsError();
-    expect(await aeSdk.getBalance(aeSdk.address)).to.equal(
-      new BigNumber(payerBalanceBefore)
-        .minus(outerFee.toString()).minus(innerFee.toString()).toFixed(),
-    );
-    expect(await aeSdk.getBalance(sender.address)).to.equal('0');
-    expect(await aeSdk.getBalance(receiver.address)).to.equal('10000');
+    expect(await aeSdk.getBalance(aeSdk.address)).to
+      .equal(payerBalanceBefore - outerFee - innerFee);
+    expect(await aeSdk.getBalance(sender.address)).to.equal(0n);
+    expect(await aeSdk.getBalance(receiver.address)).to.equal(10000n);
   });
 
   const sourceCode = `

--- a/test/integration/transaction.ts
+++ b/test/integration/transaction.ts
@@ -4,7 +4,7 @@ import { getSdk } from './index';
 import {
   AeSdk,
   commitmentHash, oracleQueryId, decode, encode,
-  ORACLE_TTL_TYPES, Tag, AE_AMOUNT_FORMATS, buildTx, unpackTx,
+  ORACLE_TTL_TYPES, Tag, buildTx, unpackTx,
 } from '../../src';
 import { Encoded, Encoding } from '../../src/utils/encoder';
 
@@ -52,17 +52,6 @@ describe('Transaction', () => {
     contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
   });
 
-  it('build spend tx using denomination amount', async () => {
-    const params = {
-      senderId, recipientId, nonce, payload,
-    };
-    const spendAe = await aeSdk.buildTx({
-      ...params, tag: Tag.SpendTx, amount: 1, denomination: AE_AMOUNT_FORMATS.AE,
-    });
-    const spendAettos = await aeSdk.buildTx({ ...params, tag: Tag.SpendTx, amount: 1e18 });
-    spendAe.should.be.equal(spendAettos);
-  });
-
   const contractId = 'ct_TCQVoset7Y4qEyV5tgEAJAqa2Foz8J1EXqoGpq3fB6dWH5roe';
   const transactions: Array<[string, Encoded.Transaction, () => Promise<Encoded.Transaction>]> = [[
     'spend',
@@ -73,8 +62,7 @@ describe('Transaction', () => {
       recipientId,
       nonce,
       payload,
-      amount: 2,
-      denomination: AE_AMOUNT_FORMATS.AE,
+      amount: 2e18,
     }),
   ], [
     'name pre-claim',


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation

- [ ] check denomination usage and drop it
- [ ] unpack tx as bigint instead of string (don't use strings in tx builder as numbers)
- [ ] rename txPayload and txSigned