### PR TITLE
refactor(wallet,aepp): inline sendTransaction return type

### DIFF
--- a/src/aepp-wallet-communication/rpc/types.ts
+++ b/src/aepp-wallet-communication/rpc/types.ts
@@ -1,6 +1,7 @@
-import { sendTransaction } from '../../chain';
 import { Encoded } from '../../utils/encoder';
 import { METHODS, SUBSCRIPTION_TYPES, WALLET_TYPE } from '../schema';
+import { TransformNodeType } from '../../Node';
+import { SignedTx } from '../../apis/node';
 
 export interface WalletInfo {
   id: string;
@@ -59,7 +60,10 @@ export interface WalletApi {
      * @deprecated this is not a hash at all, will be removed later at the same time
      * as dropping ability to broadcast transaction by wallet
      */
-    transactionHash?: Awaited<ReturnType<typeof sendTransaction>>;
+    transactionHash?: Partial<TransformNodeType<SignedTx>> & {
+      hash: Encoded.TxHash;
+      rawTx: Encoded.Transaction;
+    };
     signedTransaction?: Encoded.Transaction;
   }>);
 


### PR DESCRIPTION
To ensure that no breaking changes in protocol.

This PR is supported by the Æternity Crypto Foundation