### PR TITLE
fix(tx-builder): drop nonce validator to avoid false positive

### DIFF
--- a/src/tx/builder/field-types/nonce.ts
+++ b/src/tx/builder/field-types/nonce.ts
@@ -2,6 +2,7 @@ import { isAccountNotFoundError } from '../../../utils/other';
 import shortUInt from './short-u-int';
 import Node from '../../../Node';
 import { ArgumentError } from '../../../utils/errors';
+import { NextNonceStrategy } from '../../../apis/node';
 
 export default function genNonceField<SenderKey extends string>(senderKey: SenderKey): {
   serialize: (value: number) => Buffer;
@@ -10,7 +11,7 @@ export default function genNonceField<SenderKey extends string>(senderKey: Sende
     value: number | undefined,
     params: {},
     // TODO: replace `string` with AddressEncodings
-    options: { [key in SenderKey]: string } & { strategy?: 'continuity' | 'max'; onNode?: Node },
+    options: { [key in SenderKey]: string } & { strategy?: NextNonceStrategy; onNode?: Node },
   ) => Promise<number>;
   deserialize: (value: Buffer) => number;
   senderKey: string;

--- a/src/tx/validator.ts
+++ b/src/tx/validator.ts
@@ -142,23 +142,7 @@ validators.push(
     if (message == null) return [];
     return [{ message, key: 'InvalidAccountType', checkedKeys: ['tag'] }];
   },
-  (tx, { account, parentTxTypes }) => {
-    if (!('nonce' in tx) || parentTxTypes.includes(Tag.GaMetaTx)) return [];
-    const validNonce = account.nonce + 1;
-    if (tx.nonce === validNonce) return [];
-    return [{
-      ...tx.nonce < validNonce
-        ? {
-          message: `Nonce ${tx.nonce} is already used, valid nonce is ${validNonce}`,
-          key: 'NonceAlreadyUsed',
-        }
-        : {
-          message: `Nonce ${tx.nonce} is too high, valid nonce is ${validNonce}`,
-          key: 'NonceHigh',
-        },
-      checkedKeys: ['nonce'],
-    }];
-  },
+  // TODO: revert nonce check
   (tx, { consensusProtocolVersion }) => {
     const oracleCall = Tag.Oracle === tx.tag || Tag.OracleRegisterTx === tx.tag;
     const contractCreate = Tag.ContractCreateTx === tx.tag || Tag.GaAttachTx === tx.tag;

--- a/test/environment/name-claim-unmined.mjs
+++ b/test/environment/name-claim-unmined.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// eslint-disable-next-line import/extensions
+import { Node, AeSdk, MemoryAccount } from '../../es/index.mjs';
+
+const aeSdk = new AeSdk({
+  nodes: [{ name: 'testnet', instance: new Node('https://testnet.aeternity.io') }],
+  accounts: [MemoryAccount.generate()],
+});
+
+const { address } = aeSdk;
+const { status } = await fetch(`https://faucet.aepps.com/account/${address}`, { method: 'POST' });
+console.assert(status === 200, 'Invalid faucet response code', status);
+
+const pauseUntilLoadBalancerGetSynced = () => new Promise((resolve) => {
+  setTimeout(resolve, 500);
+});
+const name = `test-${Math.random().toString(16).slice(2)}.chain`;
+const options = { waitMined: false };
+const txHashes = [];
+
+const preclaim = await aeSdk.aensPreclaim(name, options);
+txHashes.push(preclaim.hash);
+
+await pauseUntilLoadBalancerGetSynced();
+const claim = await aeSdk.aensClaim(name, preclaim.salt, options);
+txHashes.push(claim.hash);
+
+let res;
+
+await pauseUntilLoadBalancerGetSynced();
+res = await aeSdk.spend(0.5e18, 'ak_21A27UVVt3hDkBE5J7rhhqnH5YNb4Y1dqo4PnSybrH85pnWo7E', options);
+txHashes.push(res.hash);
+
+await pauseUntilLoadBalancerGetSynced();
+res = await aeSdk.spend(0.5e18, 'ak_21A27UVVt3hDkBE5J7rhhqnH5YNb4Y1dqo4PnSybrH85pnWo7E', options);
+txHashes.push(res.hash);
+
+await pauseUntilLoadBalancerGetSynced();
+res = await aeSdk.spend(0.5e18, 'ak_21A27UVVt3hDkBE5J7rhhqnH5YNb4Y1dqo4PnSybrH85pnWo7E', options);
+txHashes.push(res.hash);
+
+console.log('All transactions submitted');
+
+await Promise.all(txHashes.map((hash) => aeSdk.poll(hash)));
+console.log('All transactions mined');

--- a/test/examples.sh
+++ b/test/examples.sh
@@ -9,6 +9,8 @@ echo Run environment/node.ts
 ./test/environment/node.ts
 echo Run environment/node-unhandled-exception.mjs
 ./test/environment/node-unhandled-exception.mjs
+echo Run environment/name-claim-unmined.mjs
+./test/environment/name-claim-unmined.mjs
 
 echo Check typescript
 cd ./test/environment/typescript/

--- a/test/integration/txVerification.ts
+++ b/test/integration/txVerification.ts
@@ -34,12 +34,10 @@ describe('Verify Transaction', () => {
     });
     const signedTx = await aeSdk.signTransaction(spendTx, { onAccount: MemoryAccount.generate() });
     const errors = await verifyTransaction(signedTx, node);
-    expect(errors.map(({ key }) => key)).to.be.eql([
-      'InvalidSignature', 'ExpiredTTL', 'NonceAlreadyUsed',
-    ]);
+    expect(errors.map(({ key }) => key)).to.be.eql(['InvalidSignature', 'ExpiredTTL']);
   });
 
-  it('returns NonceHigh error', async () => {
+  it.skip('returns NonceHigh error', async () => {
     const spendTx = await aeSdk.buildTx({
       tag: Tag.SpendTx,
       senderId: aeSdk.address,
@@ -75,7 +73,7 @@ describe('Verify Transaction', () => {
   it('verifies channel create tx', async () => {
     const channelCreate = 'tx_+IgyAqEBA36iFX3O+BMXMZJbffeT423KLpEuFsISUTsGu8Sb10eJBWvHXi1jEAAAoQGTnVZ1Jow5NGyBOg3NAf+ie3mV8qDj/wBwyKBHFNdhT4kFa8deLWMQAAAAAQCGECcSfcAAwMCgGAbROhx5lfoSkXsM5MQLw+EAWei3pcUGj/zWSO8RGkAKfIRASg==';
     const errors = await verifyTransaction(channelCreate, node);
-    expect(errors).to.have.lengthOf(2);
+    expect(errors).to.have.lengthOf(1);
   });
 
   it('verifies nameFee for nameClaim transaction', async () => {


### PR DESCRIPTION
Sometime before we implemented support for `getAccountNextNonce` node's endpoint, this endpoint had a `strategy` option that may result in a different nonce. While so, the generated nonce is still validated the old way, to validate it correctly, the transaction validator should know the chosen strategy. Instead of complicating validator API, I would integrate it into the transaction builder https://github.com/aeternity/aepp-sdk-js/issues/1763. Let's omit the nonce validation until it is implemented.

This PR is supported by the Æternity Crypto Foundation