### PR TITLE
fix(chain): reduce /2 number of blocks to wait before throwing timeout

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -76,7 +76,7 @@ export async function getHeight({ onNode }: { onNode: Node }): Promise<number> {
 export async function poll(
   th: Encoded.TxHash,
   {
-    blocks = 10, interval, onNode, ...options
+    blocks = 5, interval, onNode, ...options
   }:
   { blocks?: number; interval?: number; onNode: Node } & Parameters<typeof _getPollInterval>[1],
 ): Promise<TransformNodeType<SignedTx>> {


### PR DESCRIPTION
Currently if transaction can't be mined but present in mempool, sdk by default would wait for 10 blocks before sdk would fail. Considering it takes 3 minutes to mine a generation, this would fail after 30 minutes, that is extremely long time to wait. I propose to reduce this 2 times (to 15 minutes). Thought it can be even smaller, 2 blocks?

This PR is supported by the Æternity Crypto Foundation