### PR TITLE
chore: build and test compatibility with Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:types": "tsc && node tooling/downlevel/run.mjs",
     "build:es": "babel src --config-file ./babel.esm.config.js --out-dir es --extensions .js,.ts --out-file-extension .mjs --source-maps true",
     "build:api": "node tooling/autorest/compiler-prepare.mjs && autorest tooling/autorest/compiler.yaml && autorest tooling/autorest/node.yaml",
-    "build:generate": "tooling/generate-schema.ts",
+    "build:generate": "ts-node --transpileOnly tooling/generate-schema.ts",
     "build": "npm run build:api && npm run build:generate && webpack && npm run build:types && npm run build:es && npm run build:assets",
     "docs:examples": "node tooling/docs/examples-to-md.js examples/node/*.mjs",
     "docs:api": "typedoc",

--- a/test/integration/compiler.ts
+++ b/test/integration/compiler.ts
@@ -51,7 +51,7 @@ function testCompiler(compiler: CompilerBase): void {
     )).to.be.rejectedWith(
       CompilerError,
       compiler instanceof CompilerCli
-        ? /Command failed: escript [\w-/]+\/bin\/aesophia_cli( --create_json_aci)? [\w-/]+\.aes\nType error( in '[\w-/]+\.aes')? at line 3, col 3:\nDuplicate definitions of `getArg` at\n {2}- line 2, column 3\n {2}- line 3, column 3\n\n/m
+        ? /Command failed: escript .+[\\/]bin[\\/]aesophia_cli( --create_json_aci)? .+\.aes\nType error( in '.+\.aes')? at line 3, col 3:\nDuplicate definitions of `getArg` at\n {2}- line 2, column 3\n {2}- line 3, column 3\n\n/m
         : 'compile error:\n'
         + 'type_error:3:3: Duplicate definitions of `getArg` at\n'
         + '  - line 2, column 3\n'

--- a/tooling/generate-schema.ts
+++ b/tooling/generate-schema.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S ts-node --transpile-only
+#!/usr/bin/env -S ts-node --transpileOnly
 import ts, { factory, IntersectionTypeNode, TypeNode } from 'typescript';
 import { writeFileSync } from 'fs';
 import { basename } from 'path';


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation

```
> @aeternity/aepp-sdk@13.0.0-beta.0 build:generate
> tooling/generate-schema.ts
'tooling' is not recognized as an internal or external command,
operable program or batch file.
```