### PR TITLE
docs: warn about incompatibility with `strictFunctionTypes`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,8 @@ This may be done in `tsconfig.json`:
 ```
 SDK uses modern features available since typescript@4.7. Though SDK is still compatible with typescript@4.1 and above using types generated separately, but these types are less accurate.
 
+Ensure that you have `strictFunctionTypes` option not enabled (as it is in VS code and `ts-node` by default), otherwise some of SDK types won't work correctly (see [#1793](https://github.com/aeternity/aepp-sdk-js/issues/1793)).
+
 ### Vue CLI@4
 SDK checks are not working correctly because CLI picks both ESM and CJS versions of `autorest`
 dependencies. To fix this, you need to specify aliases in `vue.config.js`.

--- a/test/integration/accounts.ts
+++ b/test/integration/accounts.ts
@@ -6,8 +6,8 @@ import {
   AeSdk, MemoryAccount,
   generateKeyPair, AE_AMOUNT_FORMATS,
   UnavailableAccountError, TypeError, ArgumentError, UnexpectedTsError,
+  encode, Encoding, Encoded,
 } from '../../src';
-import { Encoded } from '../../src/utils/encoder';
 
 describe('Accounts', () => {
   let aeSdk: AeSdk;
@@ -119,6 +119,12 @@ describe('Accounts', () => {
     ret.should.have.property('tx');
     if (ret.tx == null) throw new UnexpectedTsError();
     ret.tx.should.include({ amount: bigAmount, recipientId: publicKey });
+  });
+
+  it('spends with a payload', async () => {
+    const payload = encode(Buffer.from([1, 2, 3, 4]), Encoding.Bytearray);
+    const { tx } = await aeSdk.spend(1, receiver.address, { payload });
+    expect(tx?.payload).to.be.equal('ba_AQIDBI3kcuI=');
   });
 
   it('Get Account by block height/hash', async () => {


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation
related to #1791 