### PR TITLE
fix(aepp): don't call `onDetected` with empty wallet array

### DIFF
--- a/src/aepp-wallet-communication/wallet-detector.ts
+++ b/src/aepp-wallet-communication/wallet-detector.ts
@@ -22,7 +22,7 @@ interface Wallets { [key: string]: Wallet }
  */
 export default (
   connection: BrowserConnection,
-  onDetected: ({ wallets, newWallet }: { wallets: Wallets; newWallet?: Wallet }) => void,
+  onDetected: ({ wallets, newWallet }: { wallets: Wallets; newWallet: Wallet }) => void,
 ): () => void => {
   if (window == null) throw new UnsupportedPlatformError('Window object not found, you can run wallet detector only in browser');
   const wallets: Wallets = {};
@@ -49,7 +49,6 @@ export default (
     wallets[wallet.info.id] = wallet;
     onDetected({ wallets, newWallet: wallet });
   }, () => {});
-  if (Object.keys(wallets).length > 0) onDetected({ wallets });
 
   return () => connection.disconnect();
 };


### PR DESCRIPTION
This happened for historical reasons, before the `wallets` object was the same for multiple calls of `walletDetector`.

This PR is supported by the Æternity Crypto Foundation