### PR TITLE
ci: update GH actions and conda.yml

### DIFF
--- a/.github/workflows/docs-develop.yml
+++ b/.github/workflows/docs-develop.yml
@@ -1,23 +1,22 @@
+# TODO: combine with docs-release using if
 name: Publish develop docs
 on:
   push:
     branches: ['develop']
-      
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-      - uses: actions/cache@v2
+          python-version: 3.11
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip3
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
       - run: pip3 install -r docs/requirements.txt
-      - run: git config --global user.email "github-action@users.noreply.github.com"
-      - run: git config --global user.name "GitHub Action"
       - run: mike deploy --push develop

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -2,23 +2,21 @@ name: Publish release docs
 on:
   release:
     types: [released]
-      
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-      - uses: actions/cache@v2
+          python-version: 3.11
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip3
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
       - run: pip3 install -r docs/requirements.txt
-      - run: git config --global user.email "github-action@users.noreply.github.com"
-      - run: git config --global user.name "GitHub Action"
       - run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
       - run: mike deploy --push --update-aliases $RELEASE_VERSION latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ jobs:
       - run: |
           wget -q https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_25.0.4-1~ubuntu~jammy_amd64.deb
           sudo apt install --allow-downgrades ./esl-erlang_25.0.4-1~ubuntu~jammy_amd64.deb
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 100
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 18.x
       - uses: actions/cache@v3

--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -1,6 +1,6 @@
 dependencies:
-  - python=3.8.*
-  - nodejs=10.*
+  - python=3.11.*
+  - nodejs=18.*
   - pip
   - pip:
     - -r file:requirements.txt


### PR DESCRIPTION
Fixes warning

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2, actions/cache@v2

This PR is supported by the Æternity Crypto Foundation