### PR TITLE
Don't expose internal errors in broadcast, throw reason of internal errors on wallet side

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -96,7 +96,6 @@ BaseError
 │
 ├── RpcError
 │   ├── RpcInvalidTransactionError
-│   ├── RpcBroadcastError
 │   ├── RpcRejectedByUserError
 │   ├── RpcUnsupportedProtocolError
 │   ├── RpcConnectionDenyError

--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -4,7 +4,7 @@ import verifyTransaction from './tx/validator';
 import RpcClient from './aepp-wallet-communication/rpc/RpcClient';
 import {
   METHODS, RPC_STATUS, SUBSCRIPTION_TYPES, WALLET_TYPE,
-  RpcBroadcastError, RpcInvalidTransactionError,
+  RpcInvalidTransactionError,
   RpcNotAuthorizeError, RpcPermissionDenyError, RpcUnsupportedProtocolError,
 } from './aepp-wallet-communication/schema';
 import { InternalError, UnknownRpcClientError } from './utils/errors';
@@ -20,7 +20,6 @@ import {
 } from './aepp-wallet-communication/rpc/types';
 import { Encoded } from './utils/encoder';
 import jsonBig from './utils/json-big';
-import { ensureError } from './utils/other';
 
 type RpcClientWallet = RpcClient<AeppApi, WalletApi>;
 
@@ -260,8 +259,7 @@ export default class AeSdkWallet extends AeSdk {
             } catch (error) {
               const validation = await verifyTransaction(tx, this.api);
               if (validation.length > 0) throw new RpcInvalidTransactionError(validation);
-              ensureError(error);
-              throw new RpcBroadcastError(error.message);
+              throw error;
             }
           },
           [METHODS.signMessage]: async ({ message, onAccount = this.address }, origin) => {

--- a/src/aepp-wallet-communication/schema.ts
+++ b/src/aepp-wallet-communication/schema.ts
@@ -102,22 +102,6 @@ rpcErrors.push(RpcInvalidTransactionError);
 /**
  * @category exception
  */
-export class RpcBroadcastError extends RpcError {
-  static override code = 3;
-
-  override code = 3;
-
-  constructor(data?: any) {
-    super('Broadcast failed');
-    this.data = data;
-    this.name = 'RpcBroadcastError';
-  }
-}
-rpcErrors.push(RpcBroadcastError);
-
-/**
- * @category exception
- */
 export class RpcRejectedByUserError extends RpcError {
   static override code = 4;
 

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -1,0 +1,18 @@
+import { RpcError } from './aepp-wallet-communication/schema';
+
+/**
+ * @category exception
+ * @deprecated this exception is not thrown anymore
+ */
+// eslint-disable-next-line import/prefer-default-export
+export class RpcBroadcastError extends RpcError {
+  static override code = 3;
+
+  override code = 3;
+
+  constructor(data?: any) {
+    super('Broadcast failed');
+    this.data = data;
+    this.name = 'RpcBroadcastError';
+  }
+}

--- a/src/index-browser.ts
+++ b/src/index-browser.ts
@@ -50,3 +50,4 @@ export { default as walletDetector } from './aepp-wallet-communication/wallet-de
 export { default as BrowserRuntimeConnection } from './aepp-wallet-communication/connection/BrowserRuntime';
 export { default as BrowserWindowMessageConnection } from './aepp-wallet-communication/connection/BrowserWindowMessage';
 export * from './utils/errors';
+export * from './deprecated';


### PR DESCRIPTION
The idea is that we need a strict set of defined errors between aepp and wallet, other errors should be communicated as internal errors and be handled on the emitter side.

related to #1826 

This PR is supported by the Æternity Crypto Foundation