### PR TITLE
provide types in exports field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,17 @@
     "<4.5": {
       "es/index.d.ts": [
         "./types-legacy/ts4.2/index.d.ts"
+      ],
+      "es/index-browser.d.ts": [
+        "./types-legacy/ts4.2/index-browser.d.ts"
       ]
     },
     "<4.7": {
       "es/index.d.ts": [
         "./types-legacy/ts4.5/index.d.ts"
+      ],
+      "es/index-browser.d.ts": [
+        "./types-legacy/ts4.5/index-browser.d.ts"
       ]
     }
   },
@@ -23,9 +29,11 @@
   },
   "exports": {
     "node": {
+      "types": "./es/index.d.ts",
       "import": "./es/index.mjs",
       "default": "./dist/aepp-sdk.js"
     },
+    "types": "./es/index-browser.d.ts",
     "import": "./es/index-browser.mjs",
     "default": "./dist/aepp-sdk.browser.js"
   },

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -103,7 +103,7 @@ type NodeTransformedApi = new (...args: ConstructorParameters<typeof NodeApi>) =
     ? NodeApi[Name] : TransformNodeType<NodeApi[Name]>
 };
 
-export interface NodeInfo {
+interface NodeInfo {
   url: string;
   nodeNetworkId: string;
   version: string;


### PR DESCRIPTION
Fixes compatibility with @vue/tsconfig

https://github.com/vuejs/tsconfig#migrating-from-typescript--50
https://nodejs.org/api/packages.html#community-conditions-definitions

This PR is supported by the Æternity Crypto Foundation