### PR TITLE
fix(contract): use fallback account if `onAccount` not provided

### DIFF
--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -324,6 +324,7 @@ class Contract<M extends ContractMethodsBase> {
       const useFallbackAccount = callStatic === true && (
         (error instanceof TypeError && error.message === 'Account should be an address (ak-prefixed string), or instance of AccountBase, got undefined instead')
         || (error instanceof NoWalletConnectedError)
+        || (error instanceof InternalError && error.message === 'Use fallback account')
       );
       if (!useFallbackAccount) throw error;
       callerId = DRY_RUN_ACCOUNT.pub;

--- a/test/integration/Middleware.ts
+++ b/test/integration/Middleware.ts
@@ -17,7 +17,7 @@ describe('MiddlewareSubscriber', () => {
       },
       mdwGensPerMinute: res.mdwGensPerMinute,
       mdwHeight: res.mdwHeight,
-      mdwLastMigration: 20230519120000,
+      mdwLastMigration: res.mdwLastMigration,
       mdwRevision: res.mdwRevision,
       mdwSynced: true,
       mdwSyncing: true,

--- a/test/integration/contract-aci.ts
+++ b/test/integration/contract-aci.ts
@@ -269,6 +269,14 @@ describe('Contract instance', () => {
     expect(res.tx.fee).to.be.equal('182000000000000');
   });
 
+  it('calls with fallback account if onAccount is not provided', async () => {
+    const account = testContract.$options.onAccount;
+    delete testContract.$options.onAccount;
+    const res = await testContract.intFn(2);
+    expect(res.decodedResult).to.be.equal(2n);
+    testContract.$options.onAccount = account;
+  });
+
   it('calls on chain', async () => {
     const res = await testContract.intFn(2, { callStatic: false });
     expect(res.decodedResult).to.be.equal(2n);


### PR DESCRIPTION
closes https://github.com/aeternity/aepp-sdk-js/issues/1844

This PR is supported by the Æternity Crypto Foundation