### PR TITLE
Delegation signature over aepp-wallet connection

### DIFF
--- a/examples/browser/aepp/src/App.vue
+++ b/examples/browser/aepp/src/App.vue
@@ -32,6 +32,13 @@
     >
       Typed data
     </a>
+    <a
+      href="#"
+      :class="{ active: view === 'DelegationSignature' }"
+      @click="view = 'DelegationSignature'"
+    >
+      Delegation signature
+    </a>
   </div>
 
   <Component
@@ -47,10 +54,11 @@ import Basic from './Basic.vue';
 import Contracts from './Contracts.vue';
 import PayForTx from './PayForTx.vue';
 import TypedData from './TypedData.vue';
+import DelegationSignature from './DelegationSignature.vue';
 
 export default {
   components: {
-    Connect, Basic, Contracts, PayForTx, TypedData,
+    Connect, Basic, Contracts, PayForTx, TypedData, DelegationSignature,
   },
   data: () => ({ view: '' }),
   computed: mapState(['aeSdk']),

--- a/examples/browser/aepp/src/DelegationSignature.vue
+++ b/examples/browser/aepp/src/DelegationSignature.vue
@@ -1,0 +1,68 @@
+<template>
+  <h2>Sign delegation to contract</h2>
+  <div class="group">
+    <div>
+      <div>Contract address</div>
+      <div><input v-model="contractAddress"></div>
+    </div>
+    <div>
+      <label>
+        <input v-model="type" type="radio" value="general">
+        AENS and oracle
+      </label>
+    </div>
+    <div>
+      <label>
+        <input v-model="type" type="radio" value="name">
+        AENS name
+      </label>
+      <div><input v-model="name"></div>
+    </div>
+    <div>
+      <label>
+        <input v-model="type" type="radio" value="oracle-query">
+        Oracle query
+      </label>
+      <div><input v-model="oracleQueryId"></div>
+    </div>
+    <button @click="signPromise = sign()">
+      Sign
+    </button>
+    <div v-if="signPromise">
+      <div>Signature</div>
+      <Value :value="signPromise" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import Value from './components/Value.vue';
+
+export default {
+  components: { Value },
+  data: () => ({
+    type: 'general',
+    contractAddress: 'ct_6y3N9KqQb74QsvR9NrESyhWeLNiA9aJgJ7ua8CvsTuGot6uzh',
+    name: 'test.chain',
+    oracleQueryId: 'oq_6y3N9KqQb74QsvR9NrESyhWeLNiA9aJgJ7ua8CvsTuGot6uzh',
+    signPromise: null,
+  }),
+  computed: mapState(['aeSdk']),
+  methods: {
+    sign() {
+      switch (this.type) {
+        case 'general':
+          return this.aeSdk.signDelegationToContract(this.contractAddress);
+        case 'name':
+          return this.aeSdk.signNameDelegationToContract(this.contractAddress, this.name);
+        case 'oracle-query':
+          return this.aeSdk
+            .signOracleQueryDelegationToContract(this.contractAddress, this.oracleQueryId);
+        default:
+          throw new Error(`Unknown delegation signature type: ${this.type}`)
+      }
+    },
+  },
+};
+</script>

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -112,42 +112,37 @@ export default {
 
       async signDelegationToContract(
         contractAddress,
-        networkId,
         { aeppRpcClientId: id, aeppOrigin, ...options },
       ) {
         if (id != null) {
-          const opt = { ...options, contractAddress, networkId };
+          const opt = { ...options, contractAddress };
           genConfirmCallback('sign delegation to contract')(id, opt, aeppOrigin);
         }
-        return super.signDelegationToContract(contractAddress, networkId, options);
+        return super.signDelegationToContract(contractAddress, options);
       }
 
       async signNameDelegationToContract(
         contractAddress,
         name,
-        networkId,
         { aeppRpcClientId: id, aeppOrigin, ...options },
       ) {
         if (id != null) {
-          const opt = { ...options, contractAddress, name, networkId };
+          const opt = { ...options, contractAddress, name };
           genConfirmCallback('sign delegation of name to contract')(id, opt, aeppOrigin);
         }
-        return super.signNameDelegationToContract(contractAddress, name, networkId, options);
+        return super.signNameDelegationToContract(contractAddress, name, options);
       }
 
       async signOracleQueryDelegationToContract(
         contractAddress,
         oracleQueryId,
-        networkId,
         { aeppRpcClientId: id, aeppOrigin, ...options },
       ) {
         if (id != null) {
-          const opt = { ...options, contractAddress, oracleQueryId, networkId };
+          const opt = { ...options, contractAddress, oracleQueryId };
           genConfirmCallback('sign delegation of oracle query to contract')(id, opt, aeppOrigin);
         }
-        return super.signOracleQueryDelegationToContract(
-          contractAddress, oracleQueryId, networkId, options,
-        );
+        return super.signOracleQueryDelegationToContract(contractAddress, oracleQueryId, options);
       }
 
       static generate() {

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -110,6 +110,46 @@ export default {
         return super.signTypedData(data, aci, options);
       }
 
+      async signDelegationToContract(
+        contractAddress,
+        networkId,
+        { aeppRpcClientId: id, aeppOrigin, ...options },
+      ) {
+        if (id != null) {
+          const opt = { ...options, contractAddress, networkId };
+          genConfirmCallback('sign delegation to contract')(id, opt, aeppOrigin);
+        }
+        return super.signDelegationToContract(contractAddress, networkId, options);
+      }
+
+      async signNameDelegationToContract(
+        contractAddress,
+        name,
+        networkId,
+        { aeppRpcClientId: id, aeppOrigin, ...options },
+      ) {
+        if (id != null) {
+          const opt = { ...options, contractAddress, name, networkId };
+          genConfirmCallback('sign delegation of name to contract')(id, opt, aeppOrigin);
+        }
+        return super.signNameDelegationToContract(contractAddress, name, networkId, options);
+      }
+
+      async signOracleQueryDelegationToContract(
+        contractAddress,
+        oracleQueryId,
+        networkId,
+        { aeppRpcClientId: id, aeppOrigin, ...options },
+      ) {
+        if (id != null) {
+          const opt = { ...options, contractAddress, oracleQueryId, networkId };
+          genConfirmCallback('sign delegation of oracle query to contract')(id, opt, aeppOrigin);
+        }
+        return super.signOracleQueryDelegationToContract(
+          contractAddress, oracleQueryId, networkId, options,
+        );
+      }
+
       static generate() {
         // TODO: can inherit parent method after implementing https://github.com/aeternity/aepp-sdk-js/issues/1672
         return new AccountMemoryProtected(generateKeyPair().secretKey);

--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -77,42 +77,37 @@ class AccountMemoryProtected extends MemoryAccount {
 
   async signDelegationToContract(
     contractAddress,
-    networkId,
     { aeppRpcClientId: id, aeppOrigin, ...options },
   ) {
     if (id != null) {
-      const opt = { ...options, contractAddress, networkId };
+      const opt = { ...options, contractAddress };
       await genConfirmCallback('sign delegation to contract')(id, opt, aeppOrigin);
     }
-    return super.signDelegationToContract(contractAddress, networkId, options);
+    return super.signDelegationToContract(contractAddress, options);
   }
 
   async signNameDelegationToContract(
     contractAddress,
     name,
-    networkId,
     { aeppRpcClientId: id, aeppOrigin, ...options },
   ) {
     if (id != null) {
-      const opt = { ...options, contractAddress, name, networkId };
+      const opt = { ...options, contractAddress, name };
       await genConfirmCallback('sign delegation of name to contract')(id, opt, aeppOrigin);
     }
-    return super.signNameDelegationToContract(contractAddress, name, networkId, options);
+    return super.signNameDelegationToContract(contractAddress, name, options);
   }
 
   async signOracleQueryDelegationToContract(
     contractAddress,
     oracleQueryId,
-    networkId,
     { aeppRpcClientId: id, aeppOrigin, ...options },
   ) {
     if (id != null) {
-      const opt = { ...options, contractAddress, oracleQueryId, networkId };
+      const opt = { ...options, contractAddress, oracleQueryId };
       await genConfirmCallback('sign delegation of oracle query to contract')(id, opt, aeppOrigin);
     }
-    return super.signOracleQueryDelegationToContract(
-      contractAddress, oracleQueryId, networkId, options,
-    );
+    return super.signOracleQueryDelegationToContract(contractAddress, oracleQueryId, options);
   }
 
   static generate() {

--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -75,6 +75,46 @@ class AccountMemoryProtected extends MemoryAccount {
     return super.signTypedData(data, aci, options);
   }
 
+  async signDelegationToContract(
+    contractAddress,
+    networkId,
+    { aeppRpcClientId: id, aeppOrigin, ...options },
+  ) {
+    if (id != null) {
+      const opt = { ...options, contractAddress, networkId };
+      await genConfirmCallback('sign delegation to contract')(id, opt, aeppOrigin);
+    }
+    return super.signDelegationToContract(contractAddress, networkId, options);
+  }
+
+  async signNameDelegationToContract(
+    contractAddress,
+    name,
+    networkId,
+    { aeppRpcClientId: id, aeppOrigin, ...options },
+  ) {
+    if (id != null) {
+      const opt = { ...options, contractAddress, name, networkId };
+      await genConfirmCallback('sign delegation of name to contract')(id, opt, aeppOrigin);
+    }
+    return super.signNameDelegationToContract(contractAddress, name, networkId, options);
+  }
+
+  async signOracleQueryDelegationToContract(
+    contractAddress,
+    oracleQueryId,
+    networkId,
+    { aeppRpcClientId: id, aeppOrigin, ...options },
+  ) {
+    if (id != null) {
+      const opt = { ...options, contractAddress, oracleQueryId, networkId };
+      await genConfirmCallback('sign delegation of oracle query to contract')(id, opt, aeppOrigin);
+    }
+    return super.signOracleQueryDelegationToContract(
+      contractAddress, oracleQueryId, networkId, options,
+    );
+  }
+
   static generate() {
     // TODO: can inherit parent method after implementing https://github.com/aeternity/aepp-sdk-js/issues/1672
     return new AccountMemoryProtected(generateKeyPair().secretKey);

--- a/src/AeSdkBase.ts
+++ b/src/AeSdkBase.ts
@@ -1,11 +1,13 @@
 import Node from './Node';
 import AccountBase from './account/Base';
 import {
+  ArgumentError,
   CompilerError, DuplicateNodeError, NodeNotFoundError, NotImplementedError, TypeError,
 } from './utils/errors';
 import { Encoded } from './utils/encoder';
 import CompilerBase from './contract/compiler/Base';
 import AeSdkMethods, { OnAccount, getValueOrErrorProxy, AeSdkMethodsOptions } from './AeSdkMethods';
+import { AensName } from './tx/builder/constants';
 
 type NodeInfo = Awaited<ReturnType<Node['getNodeInfo']>> & { name: string };
 
@@ -174,6 +176,44 @@ export default class AeSdkBase extends AeSdkMethods {
     { onAccount, ...options }: { onAccount?: OnAccount } & Parameters<AccountBase['signTypedData']>[2] = {},
   ): Promise<Encoded.Signature> {
     return this._resolveAccount(onAccount).signTypedData(data, aci, options);
+  }
+
+  async signDelegationToContract(
+    contractAddress: Encoded.ContractAddress,
+    { onAccount, ...options }: { onAccount?: OnAccount; networkId?: string }
+    & Parameters<AccountBase['signDelegationToContract']>[2] = {},
+  ): Promise<Encoded.Signature> {
+    const networkId = options?.networkId
+      ?? (this.selectedNodeName !== null ? await this.api.getNetworkId() : undefined);
+    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
+    return this._resolveAccount(onAccount)
+      .signDelegationToContract(contractAddress, networkId, options);
+  }
+
+  async signNameDelegationToContract(
+    contractAddress: Encoded.ContractAddress,
+    name: AensName,
+    { onAccount, ...options }: { onAccount?: OnAccount; networkId?: string }
+    & Parameters<AccountBase['signNameDelegationToContract']>[3] = {},
+  ): Promise<Encoded.Signature> {
+    const networkId = options?.networkId
+      ?? (this.selectedNodeName !== null ? await this.api.getNetworkId() : undefined);
+    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
+    return this._resolveAccount(onAccount)
+      .signNameDelegationToContract(contractAddress, name, networkId, options);
+  }
+
+  async signOracleQueryDelegationToContract(
+    contractAddress: Encoded.ContractAddress,
+    oracleQueryId: Encoded.OracleQueryId,
+    { onAccount, ...options }: { onAccount?: OnAccount; networkId?: string }
+    & Parameters<AccountBase['signOracleQueryDelegationToContract']>[3] = {},
+  ): Promise<Encoded.Signature> {
+    const networkId = options?.networkId
+      ?? (this.selectedNodeName !== null ? await this.api.getNetworkId() : undefined);
+    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
+    return this._resolveAccount(onAccount)
+      .signOracleQueryDelegationToContract(contractAddress, oracleQueryId, networkId, options);
   }
 
   override _getOptions(callOptions: AeSdkMethodsOptions = {}): {

--- a/src/AeSdkBase.ts
+++ b/src/AeSdkBase.ts
@@ -1,7 +1,6 @@
 import Node from './Node';
 import AccountBase from './account/Base';
 import {
-  ArgumentError,
   CompilerError, DuplicateNodeError, NodeNotFoundError, NotImplementedError, TypeError,
 } from './utils/errors';
 import { Encoded } from './utils/encoder';
@@ -180,40 +179,37 @@ export default class AeSdkBase extends AeSdkMethods {
 
   async signDelegationToContract(
     contractAddress: Encoded.ContractAddress,
-    { onAccount, ...options }: { onAccount?: OnAccount; networkId?: string }
-    & Parameters<AccountBase['signDelegationToContract']>[2] = {},
+    { onAccount, ...options }: { onAccount?: OnAccount }
+    & Parameters<AccountBase['signDelegationToContract']>[1] = {},
   ): Promise<Encoded.Signature> {
-    const networkId = options?.networkId
-      ?? (this.selectedNodeName !== null ? await this.api.getNetworkId() : undefined);
-    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
+    options.networkId ??= this.selectedNodeName !== null
+      ? await this.api.getNetworkId() : undefined;
     return this._resolveAccount(onAccount)
-      .signDelegationToContract(contractAddress, networkId, options);
+      .signDelegationToContract(contractAddress, options);
   }
 
   async signNameDelegationToContract(
     contractAddress: Encoded.ContractAddress,
     name: AensName,
-    { onAccount, ...options }: { onAccount?: OnAccount; networkId?: string }
-    & Parameters<AccountBase['signNameDelegationToContract']>[3] = {},
+    { onAccount, ...options }: { onAccount?: OnAccount }
+    & Parameters<AccountBase['signNameDelegationToContract']>[2] = {},
   ): Promise<Encoded.Signature> {
-    const networkId = options?.networkId
-      ?? (this.selectedNodeName !== null ? await this.api.getNetworkId() : undefined);
-    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
+    options.networkId ??= this.selectedNodeName !== null
+      ? await this.api.getNetworkId() : undefined;
     return this._resolveAccount(onAccount)
-      .signNameDelegationToContract(contractAddress, name, networkId, options);
+      .signNameDelegationToContract(contractAddress, name, options);
   }
 
   async signOracleQueryDelegationToContract(
     contractAddress: Encoded.ContractAddress,
     oracleQueryId: Encoded.OracleQueryId,
-    { onAccount, ...options }: { onAccount?: OnAccount; networkId?: string }
-    & Parameters<AccountBase['signOracleQueryDelegationToContract']>[3] = {},
+    { onAccount, ...options }: { onAccount?: OnAccount }
+    & Parameters<AccountBase['signOracleQueryDelegationToContract']>[2] = {},
   ): Promise<Encoded.Signature> {
-    const networkId = options?.networkId
-      ?? (this.selectedNodeName !== null ? await this.api.getNetworkId() : undefined);
-    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
+    options.networkId ??= this.selectedNodeName !== null
+      ? await this.api.getNetworkId() : undefined;
     return this._resolveAccount(onAccount)
-      .signOracleQueryDelegationToContract(contractAddress, oracleQueryId, networkId, options);
+      .signOracleQueryDelegationToContract(contractAddress, oracleQueryId, options);
   }
 
   override _getOptions(callOptions: AeSdkMethodsOptions = {}): {

--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -295,6 +295,24 @@ export default class AeSdkWallet extends AeSdk {
               signature: await this.signTypedData(data, aci, parameters),
             };
           },
+          [METHODS.signDelegationToContract]: async ({
+            contractAddress, name, oracleQueryId, onAccount = this.address,
+          }, origin) => {
+            if (!this._isRpcClientConnected(id)) throw new RpcNotAuthorizeError();
+            if (!this.addresses().includes(onAccount)) {
+              throw new RpcPermissionDenyError(onAccount);
+            }
+
+            const parameters = { onAccount, aeppOrigin: origin, aeppRpcClientId: id };
+            const signature = await (
+              (name == null ? null : this
+                .signNameDelegationToContract(contractAddress, name, parameters))
+              ?? (oracleQueryId == null ? null : this
+                .signOracleQueryDelegationToContract(contractAddress, oracleQueryId, parameters))
+              ?? this.signDelegationToContract(contractAddress, parameters)
+            );
+            return { signature };
+          },
         },
       ),
     };

--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -87,8 +87,8 @@ export default abstract class AccountBase {
   async signDelegationToContract(
     /* eslint-disable @typescript-eslint/no-unused-vars */
     contractAddress: Encoded.ContractAddress,
-    networkId: string,
     options?: {
+      networkId?: string;
       aeppOrigin?: string;
       aeppRpcClientId?: string;
     },
@@ -110,8 +110,8 @@ export default abstract class AccountBase {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     contractAddress: Encoded.ContractAddress,
     name: AensName,
-    networkId: string,
     options?: {
+      networkId?: string;
       aeppOrigin?: string;
       aeppRpcClientId?: string;
     },
@@ -140,8 +140,8 @@ export default abstract class AccountBase {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     contractAddress: Encoded.ContractAddress,
     oracleQueryId: Encoded.OracleQueryId,
-    networkId: string,
     options?: {
+      networkId?: string;
       aeppOrigin?: string;
       aeppRpcClientId?: string;
     },

--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -3,6 +3,7 @@ import Node from '../Node';
 import CompilerBase from '../contract/compiler/Base';
 import { Int } from '../tx/builder/constants';
 import { AciValue, Domain } from '../utils/typed-data';
+import { NotImplementedError } from '../utils/errors';
 
 interface AuthData {
   fee?: Int;
@@ -60,14 +61,20 @@ export default abstract class AccountBase {
    * @param options - Options
    * @returns Signature
    */
-  abstract signTypedData(
+  // TODO: make abstract in the next major release
+  // eslint-disable-next-line class-methods-use-this
+  async signTypedData(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     data: Encoded.ContractBytearray,
     aci: AciValue,
     options?: Domain & {
       aeppOrigin?: string;
       aeppRpcClientId?: string;
     },
-  ): Promise<Encoded.Signature>;
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signTypedData method');
+  }
 
   /**
    * Sign data blob

--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -1,7 +1,7 @@
 import { Encoded } from '../utils/encoder';
 import Node from '../Node';
 import CompilerBase from '../contract/compiler/Base';
-import { Int } from '../tx/builder/constants';
+import { AensName, Int } from '../tx/builder/constants';
 import { AciValue, Domain } from '../utils/typed-data';
 import { NotImplementedError } from '../utils/errors';
 
@@ -74,6 +74,80 @@ export default abstract class AccountBase {
     /* eslint-enable @typescript-eslint/no-unused-vars */
   ): Promise<Encoded.Signature> {
     throw new NotImplementedError('signTypedData method');
+  }
+
+  /**
+   * Sign delegation of AENS, oracle operations to a contract
+   * @param contractAddress - Address of a contract to delegate permissions to
+   * @param options - Options
+   * @returns Signature
+   */
+  // TODO: make abstract in the next major release
+  // eslint-disable-next-line class-methods-use-this
+  async signDelegationToContract(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    contractAddress: Encoded.ContractAddress,
+    networkId: string,
+    options?: {
+      aeppOrigin?: string;
+      aeppRpcClientId?: string;
+    },
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signDelegationToContract method');
+  }
+
+  /**
+   * Sign delegation of an AENS name to a contract
+   * @param contractAddress - Address of a contract to delegate permissions to
+   * @param name - AENS name to manage by a contract
+   * @param options - Options
+   * @returns Signature
+   */
+  // TODO: make abstract in the next major release
+  // eslint-disable-next-line class-methods-use-this
+  async signNameDelegationToContract(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    contractAddress: Encoded.ContractAddress,
+    name: AensName,
+    networkId: string,
+    options?: {
+      aeppOrigin?: string;
+      aeppRpcClientId?: string;
+    },
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signNameDelegationToContract method');
+  }
+
+  /**
+   * Sign delegation of oracle query to a contract
+   *
+   * Warning! Implementations needs to ensure that decoded oracle query id is not equal to decoded
+   * current account address unless https://github.com/aeternity/aesophia/issues/475 is fixed.
+   *
+   * Warning! Implementations needs to ensure that oracle query and contract exists unless
+   * https://github.com/aeternity/aesophia/issues/474 is fixed.
+   *
+   * @param contractAddress - Address of a contract to delegate permissions to
+   * @param oracleQueryId - Oracle query ID to reply by a contract
+   * @param options - Options
+   * @returns Signature
+   */
+  // TODO: make abstract in the next major release
+  // eslint-disable-next-line class-methods-use-this
+  async signOracleQueryDelegationToContract(
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    contractAddress: Encoded.ContractAddress,
+    oracleQueryId: Encoded.OracleQueryId,
+    networkId: string,
+    options?: {
+      aeppOrigin?: string;
+      aeppRpcClientId?: string;
+    },
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  ): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signOracleQueryDelegationToContract method');
   }
 
   /**

--- a/src/account/Generalized.ts
+++ b/src/account/Generalized.ts
@@ -43,6 +43,21 @@ export default class AccountGeneralized extends AccountBase {
     throw new NotImplementedError('Can\'t sign using generalized account');
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  override async signDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using generalized account');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signNameDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using generalized account');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signOracleQueryDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using generalized account');
+  }
+
   override async signTransaction(
     tx: Encoded.Transaction,
     { authData, onCompiler, onNode }: Parameters<AccountBase['signTransaction']>[1],

--- a/src/account/Ledger.ts
+++ b/src/account/Ledger.ts
@@ -45,6 +45,21 @@ export default class AccountLedger extends AccountBase {
     throw new NotImplementedError('Typed data signing using Ledger HW');
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  override async signDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using Ledger HW');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signNameDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using Ledger HW');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signOracleQueryDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using Ledger HW');
+  }
+
   override async signTransaction(
     tx: Encoded.Transaction,
     { innerTx, networkId }: { innerTx?: boolean; networkId?: string } = {},

--- a/src/account/Memory.ts
+++ b/src/account/Memory.ts
@@ -93,8 +93,9 @@ export default class AccountMemory extends AccountBase {
 
   override async signDelegationToContract(
     contractAddress: Encoded.ContractAddress,
-    networkId: string,
+    { networkId }: { networkId?: string } = {},
   ): Promise<Encoded.Signature> {
+    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
     const payload = concatBuffers([
       Buffer.from(networkId),
       decode(this.address),
@@ -107,8 +108,9 @@ export default class AccountMemory extends AccountBase {
   override async signNameDelegationToContract(
     contractAddress: Encoded.ContractAddress,
     name: AensName,
-    networkId: string,
+    { networkId }: { networkId?: string } = {},
   ): Promise<Encoded.Signature> {
+    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
     const payload = concatBuffers([
       Buffer.from(networkId),
       decode(this.address),
@@ -122,7 +124,7 @@ export default class AccountMemory extends AccountBase {
   override async signOracleQueryDelegationToContract(
     contractAddress: Encoded.ContractAddress,
     oracleQueryId: Encoded.OracleQueryId,
-    networkId: string,
+    { networkId }: { networkId?: string } = {},
   ): Promise<Encoded.Signature> {
     const oracleQueryIdDecoded = decode(oracleQueryId);
     const addressDecoded = decode(this.address);
@@ -130,6 +132,7 @@ export default class AccountMemory extends AccountBase {
     if (oracleQueryIdDecoded.compare(addressDecoded) === 0) {
       throw new ArgumentError('oracleQueryId', 'not equal to account address', oracleQueryId);
     }
+    if (networkId == null) throw new ArgumentError('networkId', 'provided', networkId);
     const payload = concatBuffers([
       Buffer.from(networkId),
       oracleQueryIdDecoded,

--- a/src/account/Rpc.ts
+++ b/src/account/Rpc.ts
@@ -4,6 +4,7 @@ import { ArgumentError, NotImplementedError, UnsupportedProtocolError } from '..
 import { Encoded } from '../utils/encoder';
 import RpcClient from '../aepp-wallet-communication/rpc/RpcClient';
 import { AeppApi, WalletApi } from '../aepp-wallet-communication/rpc/types';
+import { AensName } from '../tx/builder/constants';
 
 /**
  * Account provided by wallet
@@ -70,18 +71,37 @@ export default class AccountRpc extends AccountBase {
     return signature;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  override async signDelegationToContract(): Promise<Encoded.Signature> {
-    throw new NotImplementedError('signing delegation to contract using wallet');
+  override async signDelegationToContract(
+    contractAddress: Encoded.ContractAddress,
+  ): Promise<Encoded.Signature> {
+    const { signature } = await this._rpcClient.request(METHODS.signDelegationToContract, {
+      onAccount: this.address,
+      contractAddress,
+    });
+    return signature;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  override async signNameDelegationToContract(): Promise<Encoded.Signature> {
-    throw new NotImplementedError('signing delegation to contract using wallet');
+  override async signNameDelegationToContract(
+    contractAddress: Encoded.ContractAddress,
+    name: AensName,
+  ): Promise<Encoded.Signature> {
+    const { signature } = await this._rpcClient.request(METHODS.signDelegationToContract, {
+      onAccount: this.address,
+      contractAddress,
+      name,
+    });
+    return signature;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  override async signOracleQueryDelegationToContract(): Promise<Encoded.Signature> {
-    throw new NotImplementedError('signing delegation to contract using wallet');
+  override async signOracleQueryDelegationToContract(
+    contractAddress: Encoded.ContractAddress,
+    oracleQueryId: Encoded.OracleQueryId,
+  ): Promise<Encoded.Signature> {
+    const { signature } = await this._rpcClient.request(METHODS.signDelegationToContract, {
+      onAccount: this.address,
+      contractAddress,
+      oracleQueryId,
+    });
+    return signature;
   }
 }

--- a/src/account/Rpc.ts
+++ b/src/account/Rpc.ts
@@ -69,4 +69,19 @@ export default class AccountRpc extends AccountBase {
     });
     return signature;
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using wallet');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signNameDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using wallet');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  override async signOracleQueryDelegationToContract(): Promise<Encoded.Signature> {
+    throw new NotImplementedError('signing delegation to contract using wallet');
+  }
 }

--- a/src/aepp-wallet-communication/rpc/types.ts
+++ b/src/aepp-wallet-communication/rpc/types.ts
@@ -3,6 +3,7 @@ import { Domain, AciValue } from '../../utils/typed-data';
 import { METHODS, SUBSCRIPTION_TYPES, WALLET_TYPE } from '../schema';
 import { TransformNodeType } from '../../Node';
 import { SignedTx } from '../../apis/node';
+import { AensName } from '../../tx/builder/constants';
 
 export interface WalletInfo {
   id: string;
@@ -79,6 +80,15 @@ export interface WalletApi {
       domain: Domain;
       aci: AciValue;
       data: Encoded.ContractBytearray;
+      onAccount: Encoded.AccountAddress;
+    },
+  ) => Promise<{ signature: Encoded.Signature }>;
+
+  [METHODS.signDelegationToContract]: (
+    p: {
+      contractAddress: Encoded.ContractAddress;
+      name?: AensName;
+      oracleQueryId?: Encoded.OracleQueryId;
       onAccount: Encoded.AccountAddress;
     },
   ) => Promise<{ signature: Encoded.Signature }>;

--- a/src/aepp-wallet-communication/schema.ts
+++ b/src/aepp-wallet-communication/schema.ts
@@ -37,6 +37,7 @@ export const enum METHODS {
   sign = 'transaction.sign',
   signMessage = 'message.sign',
   signTypedData = 'typedData.sign',
+  signDelegationToContract = 'delegationToContract.sign',
   subscribeAddress = 'address.subscribe',
   updateNetwork = 'networkId.update',
   closeConnection = 'connection.close',

--- a/src/contract/delegation-signature.ts
+++ b/src/contract/delegation-signature.ts
@@ -59,7 +59,7 @@ export default async function createDelegationSignature(
     if (omitAddress === true) {
       throw new ArgumentError('omitAddress', 'equal false', omitAddress);
     }
-    return decode(await onAccount.signDelegationToContract(contractAddress, networkId));
+    return decode(await onAccount.signDelegationToContract(contractAddress, { networkId }));
   }
 
   const [payload] = ids;
@@ -68,7 +68,7 @@ export default async function createDelegationSignature(
       throw new ArgumentError('omitAddress', 'equal false', omitAddress);
     }
     return decode(
-      await onAccount.signNameDelegationToContract(contractAddress, payload, networkId),
+      await onAccount.signNameDelegationToContract(contractAddress, payload, { networkId }),
     );
   }
 
@@ -77,6 +77,6 @@ export default async function createDelegationSignature(
     throw new ArgumentError('omitAddress', 'equal true', omitAddress);
   }
   return decode(
-    await onAccount.signOracleQueryDelegationToContract(contractAddress, payload, networkId),
+    await onAccount.signOracleQueryDelegationToContract(contractAddress, payload, { networkId }),
   );
 }

--- a/test/integration/contract.ts
+++ b/test/integration/contract.ts
@@ -504,5 +504,12 @@ describe('Contract', () => {
       const queryObject2 = await aeSdk.getQueryObject(oracle.id, queryId);
       queryObject2.decodedResponse.should.be.equal(r);
     });
+
+    it('fails trying to create general delegation as oracle query', async () => {
+      const fakeQueryId = encode(decode(aeSdk.address), Encoding.OracleQueryId);
+      await expect(
+        aeSdk.createDelegationSignature(contractAddress, [fakeQueryId], { omitAddress: true }),
+      ).to.be.rejectedWith('not equal to account address');
+    });
   });
 });

--- a/test/integration/rpc.ts
+++ b/test/integration/rpc.ts
@@ -296,7 +296,7 @@ describe('Aepp<->Wallet', function aeppWallet() {
         recipientId: keypair.publicKey,
         amount: 0,
       });
-      await expect(aepp.signTransaction(tx, { onAccount: account.address }))
+      await expect(aepp.signTransaction(tx))
         .to.be.rejectedWith('The peer failed to execute your request due to unknown error');
     });
 
@@ -380,7 +380,7 @@ describe('Aepp<->Wallet', function aeppWallet() {
         wallet._resolveAccount().signMessage = () => {
           throw new Error('test');
         };
-        await expect(aepp.signMessage('test', { onAccount: account.address }))
+        await expect(aepp.signMessage('test'))
           .to.be.rejectedWith('The peer failed to execute your request due to unknown error');
       });
 
@@ -424,7 +424,7 @@ describe('Aepp<->Wallet', function aeppWallet() {
         wallet._resolveAccount().signTypedData = () => {
           throw new Error('test');
         };
-        await expect(aepp.signTypedData(recordData, recordAci, { onAccount: account.address }))
+        await expect(aepp.signTypedData(recordData, recordAci))
           .to.be.rejectedWith('The peer failed to execute your request due to unknown error');
       });
 
@@ -433,6 +433,42 @@ describe('Aepp<->Wallet', function aeppWallet() {
         const messageSig = await aepp.signTypedData(recordData, recordAci, { onAccount });
         const hash = hashTypedData(recordData, recordAci, {});
         expect(verify(hash, decode(messageSig), onAccount)).to.be.equal(true);
+      });
+    });
+
+    describe('Sign delegation to contract', () => {
+      const contractAddress = 'ct_6y3N9KqQb74QsvR9NrESyhWeLNiA9aJgJ7ua8CvsTuGot6uzh';
+
+      it('rejected by wallet', async () => {
+        let origin;
+        wallet._resolveAccount().signDelegationToContract = (ct, netId, { aeppOrigin } = {}) => {
+          origin = aeppOrigin;
+          throw new RpcRejectedByUserError();
+        };
+        await expect(aepp.signDelegationToContract(contractAddress)).to.be.eventually
+          .rejectedWith('Operation rejected by user').with.property('code', 4);
+        expect(origin).to.be.equal('http://origin.test');
+      });
+
+      it('works', async () => {
+        // @ts-expect-error removes object property to restore the original behavior
+        delete wallet._resolveAccount().signDelegationToContract;
+        const signature = await aepp.signDelegationToContract(contractAddress);
+        expect(signature).to.satisfy((s: string) => s.startsWith('sg_'));
+      });
+
+      it('fails with unknown error', async () => {
+        wallet._resolveAccount().signDelegationToContract = () => {
+          throw new Error('test');
+        };
+        await expect(aepp.signDelegationToContract(contractAddress))
+          .to.be.rejectedWith('The peer failed to execute your request due to unknown error');
+      });
+
+      it('signs using specific account', async () => {
+        const onAccount = wallet.addresses()[1];
+        const signature = await aepp.signDelegationToContract(contractAddress, { onAccount });
+        expect(signature).to.satisfy((s: string) => s.startsWith('sg_'));
       });
     });
 

--- a/test/integration/rpc.ts
+++ b/test/integration/rpc.ts
@@ -441,7 +441,7 @@ describe('Aepp<->Wallet', function aeppWallet() {
 
       it('rejected by wallet', async () => {
         let origin;
-        wallet._resolveAccount().signDelegationToContract = (ct, netId, { aeppOrigin } = {}) => {
+        wallet._resolveAccount().signDelegationToContract = (contractAddr, { aeppOrigin } = {}) => {
           origin = aeppOrigin;
           throw new RpcRejectedByUserError();
         };


### PR DESCRIPTION
closes #1758

This PR is supported by the Æternity Crypto Foundation

Test UI added to aepp example

<img width="825" alt="Screenshot 2023-07-25 at 13 22 22" src="https://github.com/aeternity/aepp-sdk-js/assets/9007851/0011e242-1134-42b3-9af6-39e6c411b09e">

The last time I try to move `createDelegationSignature` to Contract, now I'm moving it to AccountBase 🙃 This is need to be in accordance with the current aepp-wallet permission model.