### PR TITLE
feat(tx-builder): get actual gas price from node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   node:
-    image: aeternity/aeternity:master@sha256:824d40d60fcf4a07d805bba6b6880e182331a971bb8e4793d45d66eaa5e568fa
+    image: aeternity/aeternity:master@sha256:4ab3f2e33f02b0b96a0cb1b16544cd62498d0b4b983ba74e12b2564f2b908834
     hostname: node
     ports: ["3013:3013", "3113:3113", "3014:3014", "3114:3114"]
     volumes:

--- a/docs/guides/batch-requests.md
+++ b/docs/guides/batch-requests.md
@@ -25,6 +25,8 @@ await Promise.all(spends.map(({ amount, address }, idx) =>
 ```
 This way, SDK would make a single request to get info about the sender account and a transaction post request per each item in the `spends` array.
 
+Additionally, you may want to set `gasPrice` and `fee` to have predictable expenses. By default, SDK sets them based on the current network demand.
+
 ## Multiple contract static calls
 Basically, the dry-run endpoint of the node is used to run them. Doing requests one by one, like
 ```js

--- a/docs/transaction-options.md
+++ b/docs/transaction-options.md
@@ -32,7 +32,7 @@ These options are common and can be provided to every tx-type:
     If the strategy is set to `continuity`, then transactions in the mempool are checked if there are gaps - missing nonces that prevent transactions with greater nonces to get included
 - `ttl` (default: `0`)
   - Should be set if you want the transaction to be only valid until a certain block height is reached.
-- `fee` (default: calculated for each tx-type)
+- `fee` (default: calculated for each tx-type, based on network demand)
   - The minimum fee is dependent on the tx-type.
   - You can provide a higher fee to additionally reward the miners.
 - `innerTx` (default: `false`)
@@ -53,7 +53,7 @@ The following options are sepcific for each tx-type.
   - You can specify the denomination of the `amount` that will be provided to the contract related transaction.
 - `gasLimit`
   - Maximum amount of gas to be consumed by the transaction. Learn more on [How to estimate gas?](#how-to-estimate-gas)
-- `gasPrice` (default: `1e9`)
+- `gasPrice` (default: based on network demand, minimum: `1e9`)
   - To increase chances to get your transaction included quickly you can use a higher gasPrice.
 
 ### NameClaimTx

--- a/src/AeSdkMethods.ts
+++ b/src/AeSdkMethods.ts
@@ -89,6 +89,7 @@ class AeSdkMethods {
     };
   }
 
+  // TODO: omit onNode from options, because it is already in context
   async buildTx(options: TxParamsAsync): Promise<Encoded.Transaction> {
     return buildTxAsync({ ...this.getContext(), ...options });
   }

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -53,7 +53,7 @@ export async function getHeight(
   const onNode = unwrapProxy(options.onNode);
   if (cached) {
     const cache = heightCache.get(onNode);
-    if (cache?.time != null && cache.time > Date.now() - _getPollInterval('block', options)) {
+    if (cache != null && cache.time > Date.now() - _getPollInterval('block', options)) {
       return cache.height;
     }
   }

--- a/src/tx/builder/constants.ts
+++ b/src/tx/builder/constants.ts
@@ -9,7 +9,7 @@ export const DRY_RUN_ACCOUNT = {
 export const MAX_AUTH_FUN_GAS = 50000;
 export type Int = number | string | BigNumber;
 export type AensName = `${string}.chain`;
-export const MIN_GAS_PRICE = 1e9;
+export const MIN_GAS_PRICE = 1e9; // TODO: don't use number for ae
 // # see https://github.com/aeternity/aeternity/blob/72e440b8731422e335f879a31ecbbee7ac23a1cf/apps/aecore/src/aec_governance.erl#L67
 export const NAME_FEE_MULTIPLIER = 1e14; // 100000000000000
 export const NAME_FEE_BID_INCREMENT = 0.05; // # the increment is in percentage

--- a/src/tx/builder/field-types/fee.ts
+++ b/src/tx/builder/field-types/fee.ts
@@ -1,26 +1,29 @@
 import BigNumber from 'bignumber.js';
-import { IllegalArgumentError } from '../../../utils/errors';
-import { MIN_GAS_PRICE, Tag } from '../constants';
+import { ArgumentError, IllegalArgumentError } from '../../../utils/errors';
+import { Int, MIN_GAS_PRICE, Tag } from '../constants';
+import uInt from './u-int';
 import coinAmount from './coin-amount';
+import { getCachedIncreasedGasPrice } from './gas-price';
 import { isKeyOfObject } from '../../../utils/other';
 import { decode, Encoded } from '../../../utils/encoder';
 import type { unpackTx as unpackTxType, buildTx as buildTxType } from '../index';
+import Node from '../../../Node';
 
 const BASE_GAS = 15000;
 const GAS_PER_BYTE = 20;
 const KEY_BLOCK_INTERVAL = 3;
 
 /**
- * Calculate the Base fee gas
+ * Calculate the base gas
  * @see {@link https://github.com/aeternity/protocol/blob/master/consensus/README.md#gas}
  * @param txType - The transaction type
- * @returns The base fee
+ * @returns The base gas
  * @example
  * ```js
- * TX_FEE_BASE('channelForceProgress') => new BigNumber(30 * 15000)
+ * TX_BASE_GAS(Tag.ChannelForceProgressTx) => 30 * 15000
  * ```
  */
-const TX_FEE_BASE_GAS = (txType: Tag): BigNumber => {
+const TX_BASE_GAS = (txType: Tag): number => {
   const feeFactors = {
     [Tag.ChannelForceProgressTx]: 30,
     [Tag.ChannelOffChainTx]: 0,
@@ -36,44 +39,41 @@ const TX_FEE_BASE_GAS = (txType: Tag): BigNumber => {
     [Tag.PayingForTx]: 1 / 5,
   } as const;
   const factor = feeFactors[txType as keyof typeof feeFactors] ?? 1;
-  return new BigNumber(factor * BASE_GAS);
+  return factor * BASE_GAS;
 };
 
 /**
- * Calculate fee for Other types of transactions
+ * Calculate gas for other types of transactions
  * @see {@link https://github.com/aeternity/protocol/blob/master/consensus/README.md#gas}
  * @param txType - The transaction type
  * @param txSize - The transaction size
  * @returns parameters - The transaction parameters
  * @returns parameters.relativeTtl - The relative ttl
  * @returns parameters.innerTxSize - The size of the inner transaction
- * @returns The Other fee
+ * @returns The other gas
  * @example
  * ```js
- * TX_FEE_OTHER_GAS('oracleResponse',10, { relativeTtl: 10, innerTxSize: 10 })
- *  => new BigNumber(10).times(20).plus(Math.ceil(32000 * 10 / Math.floor(60 * 24 * 365 / 2)))
+ * TX_OTHER_GAS(Tag.OracleResponseTx, 10, { relativeTtl: 12, innerTxSize: 0 })
+ *  => 10 * 20 + Math.ceil(32000 * 12 / Math.floor(60 * 24 * 365 / 3))
  * ```
  */
-const TX_FEE_OTHER_GAS = (
+const TX_OTHER_GAS = (
   txType: Tag,
   txSize: number,
   { relativeTtl, innerTxSize }: { relativeTtl: number; innerTxSize: number },
-): BigNumber => {
+): number => {
   switch (txType) {
     case Tag.OracleRegisterTx:
     case Tag.OracleExtendTx:
     case Tag.OracleQueryTx:
     case Tag.OracleResponseTx:
-      return new BigNumber(txSize)
-        .times(GAS_PER_BYTE)
-        .plus(
-          Math.ceil((32000 * relativeTtl) / Math.floor((60 * 24 * 365) / KEY_BLOCK_INTERVAL)),
-        );
+      return txSize * GAS_PER_BYTE
+        + Math.ceil((32000 * relativeTtl) / Math.floor((60 * 24 * 365) / KEY_BLOCK_INTERVAL));
     case Tag.GaMetaTx:
     case Tag.PayingForTx:
-      return new BigNumber(txSize).minus(innerTxSize).times(GAS_PER_BYTE);
+      return (txSize - innerTxSize) * GAS_PER_BYTE;
     default:
-      return new BigNumber(txSize).times(GAS_PER_BYTE);
+      return txSize * GAS_PER_BYTE;
   }
 };
 
@@ -91,13 +91,13 @@ function getOracleRelativeTtl(params: any): number {
 }
 
 /**
- * Calculate fee based on tx type and params
+ * Calculate gas based on tx type and params
  */
-export function buildFee(
+export function buildGas(
   builtTx: Encoded.Transaction,
   unpackTx: typeof unpackTxType,
   buildTx: typeof buildTxType,
-): BigNumber {
+): number {
   const { length } = decode(builtTx);
   const txObject = unpackTx(builtTx);
 
@@ -106,11 +106,10 @@ export function buildFee(
     innerTxSize = decode(buildTx(txObject.tx.encodedTx)).length;
   }
 
-  return TX_FEE_BASE_GAS(txObject.tag)
-    .plus(TX_FEE_OTHER_GAS(txObject.tag, length, {
+  return TX_BASE_GAS(txObject.tag)
+    + TX_OTHER_GAS(txObject.tag, length, {
       relativeTtl: getOracleRelativeTtl(txObject), innerTxSize,
-    }))
-    .times(MIN_GAS_PRICE);
+    });
 }
 
 /**
@@ -127,24 +126,45 @@ function calculateMinFee(
   let previousFee;
   do {
     previousFee = fee;
-    fee = buildFee(rebuildTx(fee), unpackTx, buildTx);
+    fee = new BigNumber(MIN_GAS_PRICE).times(buildGas(rebuildTx(fee), unpackTx, buildTx));
   } while (!fee.eq(previousFee));
   return fee;
+}
+
+// TODO: Get rid of this workaround. Transaction builder can't accept/return gas price instead of
+// fee because it may get a decimal gas price. So, it should accept the optional `gasPrice` even
+// if it is not a contract-related transaction. And use this `gasPrice` to calculate `fee`.
+const gasPricePrefix = '_gas-price:';
+
+export interface SerializeAettosParams {
+  rebuildTx: (params: any) => Encoded.Transaction;
+  unpackTx: typeof unpackTxType;
+  buildTx: typeof buildTxType;
+  _computingMinFee?: BigNumber;
 }
 
 export default {
   ...coinAmount,
 
+  async prepare(
+    value: Int | undefined,
+    params: {},
+    { onNode }: { onNode?: Node },
+  ): Promise<Int | undefined> {
+    if (value != null) return value;
+    if (onNode == null) {
+      throw new ArgumentError('onNode', 'provided (or provide `fee` instead)', onNode);
+    }
+    const gasPrice = await getCachedIncreasedGasPrice(onNode);
+    if (gasPrice === 0n) return undefined;
+    return gasPricePrefix + gasPrice;
+  },
+
   serializeAettos(
     _value: string | undefined,
     {
       rebuildTx, unpackTx, buildTx, _computingMinFee,
-    }: {
-      rebuildTx: (params: any) => Encoded.Transaction;
-      unpackTx: typeof unpackTxType;
-      buildTx: typeof buildTxType;
-      _computingMinFee?: BigNumber;
-    },
+    }: SerializeAettosParams,
     { _canIncreaseFee }: { _canIncreaseFee?: boolean },
   ): string {
     if (_computingMinFee != null) return _computingMinFee.toFixed();
@@ -153,7 +173,9 @@ export default {
       unpackTx,
       buildTx,
     );
-    const value = new BigNumber(_value ?? minFee);
+    const value = _value?.startsWith(gasPricePrefix) === true
+      ? minFee.dividedBy(MIN_GAS_PRICE).times(_value.replace(gasPricePrefix, ''))
+      : new BigNumber(_value ?? minFee);
     if (minFee.gt(value)) {
       if (_canIncreaseFee === true) return minFee.toFixed();
       throw new IllegalArgumentError(`Fee ${value.toString()} must be bigger than ${minFee}`);
@@ -163,9 +185,12 @@ export default {
 
   serialize(
     value: Parameters<typeof coinAmount.serialize>[0],
-    params: Parameters<typeof coinAmount.serialize>[1],
+    params: Parameters<typeof coinAmount.serialize>[1] & SerializeAettosParams,
     options: { _canIncreaseFee?: boolean } & Parameters<typeof coinAmount.serialize>[2],
   ): Buffer {
+    if (typeof value === 'string' && value.startsWith(gasPricePrefix)) {
+      return uInt.serialize(this.serializeAettos(value, params, options));
+    }
     return coinAmount.serialize.call(this, value, params, options);
   },
 };

--- a/src/tx/builder/field-types/gas-limit.ts
+++ b/src/tx/builder/field-types/gas-limit.ts
@@ -1,7 +1,7 @@
 import { IllegalArgumentError } from '../../../utils/errors';
-import { MIN_GAS_PRICE, Tag, MAX_AUTH_FUN_GAS } from '../constants';
+import { Tag, MAX_AUTH_FUN_GAS } from '../constants';
 import shortUInt from './short-u-int';
-import { buildFee } from './fee';
+import { buildGas } from './fee';
 import type { unpackTx as unpackTxType, buildTx as buildTxType } from '../index';
 
 function calculateGasLimitMax(
@@ -10,7 +10,7 @@ function calculateGasLimitMax(
   unpackTx: typeof unpackTxType,
   buildTx: typeof buildTxType,
 ): number {
-  return gasMax - +buildFee(rebuildTx(gasMax), unpackTx, buildTx).dividedBy(MIN_GAS_PRICE);
+  return gasMax - +buildGas(rebuildTx(gasMax), unpackTx, buildTx);
 }
 
 export default {

--- a/src/tx/builder/field-types/gas-price.ts
+++ b/src/tx/builder/field-types/gas-price.ts
@@ -1,10 +1,65 @@
+import BigNumber from 'bignumber.js';
 import coinAmount from './coin-amount';
-import { IllegalArgumentError } from '../../../utils/errors';
-import { MIN_GAS_PRICE } from '../constants';
+import { ArgumentError, IllegalArgumentError } from '../../../utils/errors';
+import { Int, MIN_GAS_PRICE } from '../constants';
+import Node from '../../../Node';
+import { AE_AMOUNT_FORMATS, formatAmount } from '../../../utils/amount-formatter';
+import semverSatisfies from '../../../utils/semver-satisfies';
+
+const gasPriceCache: WeakMap<Node, { time: number; gasPrice: bigint }> = new WeakMap();
+
+export async function getCachedIncreasedGasPrice(node: Node): Promise<bigint> {
+  const cache = gasPriceCache.get(node);
+  if (cache != null && cache.time > Date.now() - 20 * 1000) {
+    return cache.gasPrice;
+  }
+
+  // TODO: remove after requiring node@6.13.0
+  const { nodeVersion } = await node._getCachedStatus();
+  // TODO: remove remove '6.12.0+' check after releasing 6.13.0
+  if (!nodeVersion.startsWith('6.12.0+') && !semverSatisfies(nodeVersion, '6.13.0', '7.0.0')) {
+    return 0n;
+  }
+
+  const { minGasPrice, utilization } = (await node.getRecentGasPrices())[0];
+  let gasPrice = utilization < 70 ? 0n : BigInt(
+    new BigNumber(minGasPrice.toString()).times(1.01).integerValue().toFixed(),
+  );
+
+  const maxSafeGasPrice = BigInt(MIN_GAS_PRICE) * 100000n; // max microblock fee is 600ae or 35usd
+  if (gasPrice > maxSafeGasPrice) {
+    console.warn([
+      `Estimated gas price ${gasPrice} exceeds the maximum safe value for unknown reason.`,
+      `It will be limited to ${maxSafeGasPrice}.`,
+      'To overcome this restriction provide `gasPrice`/`fee` in options.',
+    ].join(' '));
+    gasPrice = maxSafeGasPrice;
+  }
+
+  gasPriceCache.set(node, { gasPrice, time: Date.now() });
+  return gasPrice;
+}
 
 // TODO: use withFormatting after using a single type for coins representation
 export default {
   ...coinAmount,
+
+  async prepare(
+    value: Int | undefined,
+    params: {},
+    { onNode, denomination }: {
+      onNode?: Node;
+      denomination?: AE_AMOUNT_FORMATS;
+    },
+  ): Promise<Int | undefined> {
+    if (value != null) return value;
+    if (onNode == null) {
+      throw new ArgumentError('onNode', 'provided (or provide `gasPrice` instead)', onNode);
+    }
+    const gasPrice = await getCachedIncreasedGasPrice(onNode);
+    if (gasPrice === 0n) return undefined;
+    return formatAmount(gasPrice, { targetDenomination: denomination });
+  },
 
   serializeAettos(value: string | undefined = MIN_GAS_PRICE.toString()): string {
     if (+value < MIN_GAS_PRICE) {

--- a/src/tx/builder/index.ts
+++ b/src/tx/builder/index.ts
@@ -54,6 +54,7 @@ export function buildTx(
 export type BuildTxOptions <TxType extends Tag, OmitFields extends string> =
   Omit<TxParamsAsync & { tag: TxType }, 'tag' | OmitFields>;
 
+// TODO: require onNode because it is the only reason this builder is async [breaking change]
 /**
  * Build transaction async (may request node for additional data)
  * @category transaction builder

--- a/test/dynamic-gas-price.html
+++ b/test/dynamic-gas-price.html
@@ -1,0 +1,258 @@
+<html>
+<head>
+  <title>Run several clients and render stats</title>
+</head>
+<body>
+
+<table class="charts">
+  <tr>
+    <td>
+      <strong>Gas price</strong>
+      <canvas id="chart-gas-price"></canvas>
+    </td>
+    <td>
+      <strong>Utilization</strong>
+      <canvas id="chart-utilization"></canvas>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <strong>Overall gas</strong>
+      <canvas id="chart-overall-gas"></canvas>
+    </td>
+    <td>
+      <strong>Operation count</strong>
+      <canvas id="chart-operation-count"></canvas>
+    </td>
+  </tr>
+</table>
+
+<button id="add-client-fixed">Add client with fixed gas price</button>
+<button id="add-client-dynamic">Add client with dynamic gas price</button>
+<div id="clients"></div>
+
+<style>
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 4px 0;
+  }
+
+  table td {
+    border: 1px solid black;
+    padding: 4px;
+  }
+
+  table.charts td {
+    width: 50%;
+  }
+</style>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="../../dist/aepp-sdk.browser-script.js"></script>
+<script type="text/javascript">
+const commonOptions = {
+  type: 'line',
+  plugins: {
+    colors: {
+      forceOverride: true
+    }
+  },
+};
+
+const [chartGasPrice, chartUtilization, chartOverallGas, chartOperationCount] = [
+  'chart-gas-price', 'chart-utilization', 'chart-overall-gas', 'chart-operation-count',
+].map((id) => new Chart(document.getElementById(id), {
+  type: 'line',
+  data: {
+    labels: [],
+    datasets: [],
+  }
+}));
+
+chartOverallGas.data.datasets[0] = {
+  label: 'Overall used gas',
+  data: [],
+};
+
+const { Node, AeSdk, MemoryAccount, CompilerHttp, MIN_GAS_PRICE } = Aeternity;
+
+const nodeUrl = 'http://localhost:3013';
+const node = new Node(nodeUrl);
+const genesis = new MemoryAccount('9ebd7beda0c79af72a42ece3821a56eff16359b6df376cf049aee995565f022f840c974b97164776454ba119d84edc4d6058a8dec92b6edc578ab2d30b4c4200');
+const minGasPriceToShow = 1e9 - 10;
+
+async function newFrame() {
+  (await node.getRecentGasPrices()).forEach(({ minGasPrice, minutes, utilization }) => {
+    chartGasPrice.data.datasets
+      .find(({ label }) => label === `node ${minutes} min`)
+      .data.push(minGasPrice === 0n ? minGasPriceToShow : Number(minGasPrice));
+    chartUtilization.data.datasets
+      .find(({ label }) => label === `node ${minutes} min`)
+      .data.push(utilization);
+  });
+  chartGasPrice.data.labels.push(new Date().toLocaleTimeString());
+  chartUtilization.data.labels.push(new Date().toLocaleTimeString());
+  chartGasPrice.data.datasets
+    .filter(({ label }) => label.includes('client'))
+    .forEach(({ data }) => data.push(minGasPriceToShow));
+  chartGasPrice.update();
+  chartUtilization.update();
+
+  chartOverallGas.data.labels.push(new Date().toLocaleTimeString());
+  chartOverallGas.data.datasets[0].data.push(0);
+  chartOverallGas.update();
+
+  chartOperationCount.data.labels.push(new Date().toLocaleTimeString());
+  chartOperationCount.data.datasets.forEach(({ data }) => data.push(0));
+  chartOperationCount.update();
+}
+
+let clientCounter = 0;
+const activeClients = {};
+
+function renderClients() {
+  document.getElementById('clients').innerHTML = `
+  <table>
+    <thead>
+      <tr><td>Client idx</td><td>Is fixed gas</td><td>Last message</td><td></td></tr>
+    </thead>
+    ${Object.entries(activeClients).map(([idx, { fixedGasPrice, message }]) => `
+      <tr>
+        <td>client ${idx}</td>
+        <td>${fixedGasPrice}</td>
+        <td>${message}</td>
+        <td><button data-idx="${idx}">Remove</button></td>
+      </tr>
+    `).join('')}
+  </table>
+  `;
+}
+
+async function updateClient(idx, data) {
+  if (activeClients[idx] == null) return;
+  Object.assign(activeClients[idx], data);
+  renderClients();
+};
+
+const contractSourceCode = `
+contract Test =
+  entrypoint factorial(n : int) =
+    if (n == 0) 1
+    else n * factorial(n - 1)
+`;
+
+async function addClient(fixedGasPrice) {
+  const aeSdk = new AeSdk({
+    nodes: [{ name: 'testnet', instance: new Node(nodeUrl) }],
+    accounts: [MemoryAccount.generate()],
+    onCompiler: new CompilerHttp('https://v7.compiler.aepps.com'),
+    _expectedMineRate: 60000,
+    _microBlockCycle: 3000,
+  });
+
+  let stop = false;
+  const idx = clientCounter++;
+  activeClients[idx] = {};
+  updateClient(idx, {
+    stop() {
+      stop = true;
+    },
+    fixedGasPrice: !!fixedGasPrice,
+    message: '',
+  });
+
+  const components = [0, 0, 0].map(() => Math.floor(Math.random() * 200));
+  const toColor = (components) => '#' + components.map((c) => c.toString(16).padStart(2, '0')).join('');
+  const colorDark = toColor(components.map((c) => c + 25));
+  const colorLight = toColor(components.map((c) => c + 50));
+
+  chartGasPrice.data.datasets.push({
+    label: `client ${idx}`,
+    borderColor: colorDark,
+    data: new Array(chartGasPrice.data.labels.length).fill(minGasPriceToShow),
+  });
+  chartOperationCount.data.datasets.push({
+    label: `client ${idx} mined`,
+    borderColor: colorDark,
+    data: new Array(chartOperationCount.data.labels.length).fill(-1),
+  }, {
+    label: `client ${idx} failed`,
+    borderColor: colorLight,
+    data: new Array(chartOperationCount.data.labels.length).fill(-1),
+  });
+  chartOperationCount.update();
+
+  try {
+    await aeSdk.transferFunds(0.01, aeSdk.address, { onAccount: genesis });
+    const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+    const deployInfo = await contract.$deploy([]);
+    updateClient(idx, { message: `Contract deployed at ${deployInfo.address}` });
+    while (!stop) {
+      try {
+        const { result: { gasUsed, gasPrice } } = await contract.factorial(1000, {
+          callStatic: false,
+          gasLimit: 2040000,
+          blocks: 15,
+          ttl: await aeSdk.getHeight({ cached: true }) + 5,
+          verify: false,
+          ...fixedGasPrice && { gasPrice: MIN_GAS_PRICE, fee: `_gas-price:${MIN_GAS_PRICE}` },
+        });
+
+        let data;
+        ({ data } = chartOverallGas.data.datasets[0]);
+        data[data.length - 1] += gasUsed;
+        chartOverallGas.update();
+
+        ({ data } = chartGasPrice.data.datasets.find(({ label }) => label === `client ${idx}`));
+        data[data.length - 1] = Number(gasPrice);
+        chartGasPrice.update();
+
+        ({ data } = chartOperationCount.data.datasets
+          .find(({ label }) => label === `client ${idx} mined`));
+        data[data.length - 1] += 1;
+      } catch (error) {
+        const { data } = chartOperationCount.data.datasets
+          .find(({ label }) => label === `client ${idx} failed`);
+        data[data.length - 1] += 1;
+        updateClient(idx, { message: error.message });
+      }
+      chartOperationCount.update();
+    }
+  } catch (error) {
+    updateClient(idx, { message: error.message });
+  }
+}
+
+function removeClient(idx) {
+  activeClients[idx].stop();
+  delete activeClients[idx];
+  renderClients();
+}
+
+document.getElementById('clients').addEventListener('click', (event) => {
+  if (event.target.tagName !== 'BUTTON') return;
+  removeClient(event.target.dataset.idx);
+});
+document.getElementById('add-client-fixed').addEventListener('click', () => addClient(true));
+document.getElementById('add-client-dynamic').addEventListener('click', () => addClient(false));
+renderClients();
+
+(async () => {
+  (await node.getRecentGasPrices()).forEach(({ minGasPrice, minutes, utilization }) => {
+    chartGasPrice.data.datasets.push({
+      label: `node ${minutes} min`,
+      data: [],
+    });
+    chartUtilization.data.datasets.push({
+      label: `node ${minutes} min`,
+      data: [],
+    });
+  });
+
+  await newFrame();
+  setInterval(newFrame, 10000);
+})();
+</script>
+</body>
+</html>

--- a/test/integration/chain.ts
+++ b/test/integration/chain.ts
@@ -152,6 +152,9 @@ describe('Node Chain', () => {
   });
 
   it('multiple spends from different accounts', async () => {
+    await aeSdkWithoutAccount.spend(0, aeSdk.address, {
+      onAccount: Object.values(aeSdk.accounts)[0],
+    });
     const getCount = bindRequestCounter(aeSdkWithoutAccount.api);
     const spends = await Promise.all(
       accounts.map(async (onAccount) => aeSdkWithoutAccount.spend(1e14, aeSdk.address, {

--- a/test/integration/node.ts
+++ b/test/integration/node.ts
@@ -89,6 +89,19 @@ describe('Node client', () => {
       .to.be.rejectedWith(RestError, 'v3/transactions error: Invalid tx (nonce_too_high)');
   });
 
+  it('returns recent gas prices', async () => {
+    const example: Awaited<ReturnType<typeof node.getRecentGasPrices>> = [
+      { minGasPrice: 0n, minutes: 5, utilization: 0 },
+    ];
+    expect(example);
+
+    const actual = await node.getRecentGasPrices();
+    expect(actual).to.be.eql([1, 5, 15, 60].map((minutes, idx) => {
+      const { minGasPrice, utilization } = actual[idx];
+      return { minGasPrice, minutes, utilization };
+    }));
+  });
+
   describe('Node Pool', () => {
     it('Throw error on using API without node', () => {
       const nodes = new AeSdkBase({});

--- a/tooling/autorest/node.yaml
+++ b/tooling/autorest/node.yaml
@@ -7,6 +7,11 @@ directive:
         if (!$[key].oneOf) return;
         $[key] = $[key].oneOf.find(({ type }) => type === 'string');
       });
+      const { utilization } = $.GasPrices.items.properties;
+      Object.assign(utilization, {
+        oneOf: undefined,
+        ...(utilization.oneOf ?? []).find(({ type }) => type === 'string'),
+      });
     reason:
       fix parsing of big numbers
       remove after fixing https://github.com/aeternity/aeternity/issues/3891
@@ -154,7 +159,7 @@ version: ^3.7.1
 use-extension:
   '@autorest/typescript': ^6.0.15
   '@autorest/modelerfour': ^4.27.0
-input-file: https://raw.githubusercontent.com/aeternity/aeternity/abc961d398e422c5d72f698a87ec471ffe8ff3ec/apps/aehttp/priv/oas3.yaml
+input-file: https://raw.githubusercontent.com/aeternity/aeternity/51b236f8a04b349e080644c76ad8844b8b71151b/apps/aehttp/priv/oas3.yaml
 output-folder: ../../src/apis/node
 source-code-folder-path: .
 generator: typescript


### PR DESCRIPTION
closes https://github.com/aeternity/aepp-sdk-js/issues/1786

This PR is supported by the Æternity Foundation

To protect from funds loss in case of a bug/misusage, I propose to add an upper limit for the gas price substituted by default. Known issues:

### A single active client would compete with himself

If somebody posts transactions from a single client with high blockchain utilization, the gas price will increase for no reason. This is a special use case, I'm adding a note to `batch-requests.md`.

### Overall solution doesn't protect from mining time fluctuation

With a low utilization, it is expected to get a transaction mined within 3 seconds. Currently, it is cheap to increase utilization at any moment. The current solution would reflect utilization change in a minute. So, a user may experience arbitrary changes of mining time.

<img width="1546" alt="Screenshot 2024-03-12 at 14 57 57" src="https://github.com/aeternity/aepp-sdk-js/assets/9007851/2aab40f8-26e6-4448-96f4-d2c04d85af37">

I've wrote a script to create several clients pushing transactions one by one and to visualize that gathered data. On the screenshot, I've added about 5 dynamic price clients and removed all of them with an interval from the middle to the end. It looks +/- as expected.
