### PR TITLE
fix(contract): don't mark contract as deployed if tx failed

### DIFF
--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -252,12 +252,12 @@ class Contract<M extends ContractMethodsBase> {
       code: this.$options.bytecode,
       ownerId,
     });
-    this.$options.address = buildContractIdByContractTx(tx);
     const { hash, ...other } = await this.#sendAndProcess(
       tx,
       'init',
       { ...opt, onAccount: opt.onAccount },
     );
+    this.$options.address = buildContractIdByContractTx(tx);
     return {
       ...other,
       ...other.result?.log != null && {


### PR DESCRIPTION
To avoid DuplicateContractError if signing was rejected or so.

This PR is supported by the Æternity Crypto Foundation