### PR TITLE
fix(node): don't retry 500 code responses

### DIFF
--- a/src/utils/autorest.ts
+++ b/src/utils/autorest.ts
@@ -119,7 +119,7 @@ export const genRetryOnFailurePolicy = (
   policy: {
     name: 'retry-on-failure',
     async sendRequest(request, next) {
-      const statusesToNotRetry = [200, 400, 403];
+      const statusesToNotRetry = [200, 400, 403, 500];
 
       const intervals = new Array(retryCount).fill(0)
         .map((_, idx) => ((idx + 1) / retryCount) ** 2);


### PR DESCRIPTION
In general node shouldn't return 500 code. And I don't know cases when it should be retried.

Also, it looks like our API gateway has a kind of protection of doing frequent requests that fail with 500 code: there is an exponentially growing delay in receiving a response.

For example, I was retrying https://testnet.aeternity.io/v3/dry-run

requested at 2023-08-27T16:23:08.129Z 
responded at 2023-08-27T16:23:13.594Z with 500 code in 5 seconds

requested at 2023-08-27T16:23:13.652Z
responded at 2023-08-27T16:23:28.214Z with 500 code in 15 seconds

requested at 2023-08-27T16:23:28.444Z
responded at 2023-08-27T16:24:16.582Z with 500 code in 48 seconds

requested at 2023-08-27T16:24:17.096Z
responded at 2023-08-27T16:26:04.847Z with 500 code in 107 seconds

So, in this case, request retrying making the overall process extremely long, I'm proposing to disable it.

This PR is supported by the Æternity Crypto Foundation