### PR TITLE
fix(node): uncatchable exception if request failed in queue

### DIFF
--- a/src/utils/autorest.ts
+++ b/src/utils/autorest.ts
@@ -15,10 +15,10 @@ export const genRequestQueuesPolicy = (): AdditionalPolicyConfig => {
         request.headers.delete('__queue');
         const getResponse = async (): Promise<PipelineResponse> => next(request);
         if (key == null) return getResponse();
-        const req = (requestQueues.get(key) ?? Promise.resolve()).then(getResponse, getResponse);
-        // TODO: remove after fixing https://github.com/aeternity/aeternity/issues/3803
+        const req = (requestQueues.get(key) ?? Promise.resolve()).then(getResponse);
+        // TODO: remove pause after fixing https://github.com/aeternity/aeternity/issues/3803
         // gap to ensure that node won't reject the nonce
-        requestQueues.set(key, req.then(async () => pause(750)));
+        requestQueues.set(key, req.then(async () => pause(750), () => {}));
         return req;
       },
     },


### PR DESCRIPTION
I was making a lot of transactions one by one and because of the occasionally wrong nonce, some tx was rejected. The whole process was crushing since these exceptions weren't possible to handle.

This PR is supported by the Æternity Crypto Foundation