### PR TITLE
Release 13.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   node:
-    image: aeternity/aeternity:v6.8.1
+    image: aeternity/aeternity:v6.11.0
     hostname: node
     ports: ["3013:3013", "3113:3113", "3014:3014", "3114:3114"]
     volumes:

--- a/docker/aeternity_node_mean16.yaml
+++ b/docker/aeternity_node_mean16.yaml
@@ -20,7 +20,7 @@ chain:
   persist: false
   hard_forks:
     "1": 0
-    "6": 1
+    "5": 1
 
 mining:
   autostart: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,7 +48,7 @@ All notable changes to this project will be documented in this file. See [standa
 * **contract:** use fallback account if `onAccount` not provided ([9033cd7](https://github.com/aeternity/aepp-sdk-js/commit/9033cd799be5974ebf28a49df181eeb63b1fce84))
 * converting proxied options to JSON ([efebbd1](https://github.com/aeternity/aepp-sdk-js/commit/efebbd139ea85c35e28bdcfe907670743f9fc1f4))
 * provide types in exports field of package.json ([dbd19e7](https://github.com/aeternity/aepp-sdk-js/commit/dbd19e70bca2d6dbc5b2392db478bb98936b63f2))
-* reject prefixes other then provided in isAddressValid ([9462add](https://github.com/aeternity/aepp-sdk-js/commit/9462adde8fab9848fca0a6d9a382dbd34f5e2b8f))
+* reject prefixes other than provided in isAddressValid ([9462add](https://github.com/aeternity/aepp-sdk-js/commit/9462adde8fab9848fca0a6d9a382dbd34f5e2b8f))
 * **tx-builder:** `buildTx` produces the same type as `unpackTx` accepts ([d3d6c88](https://github.com/aeternity/aepp-sdk-js/commit/d3d6c88607abbfb74acf016fba886540938b216d))
 * **tx-builder:** decode tag in entry error message ([db0d96f](https://github.com/aeternity/aepp-sdk-js/commit/db0d96f156f3e8cfe52c6a7d7411c359f6dae35c))
 * **wallet:** emit internal error if something broke while broadcast ([332d1b5](https://github.com/aeternity/aepp-sdk-js/commit/332d1b567f69bf6b7d3567af43fb805556ac015b))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [13.2.2](https://github.com/aeternity/aepp-sdk-js/compare/v13.2.1...v13.2.2) (2023-09-20)
+
+
+### Bug Fixes
+
+* use proper vm version in Ceres ([bcaa5cf](https://github.com/aeternity/aepp-sdk-js/commit/bcaa5cfe0f8a23a641d9db993b312e2d54cfdd60))
+* **aepp,wallet:** connect to web-extension if opened over file:/// ([da6a025](https://github.com/aeternity/aepp-sdk-js/commit/da6a0257e995db38e32888390961eb870a482777))
+* **aepp:** use complete type of WalletInfo object ([eeba565](https://github.com/aeternity/aepp-sdk-js/commit/eeba56576b97afda6739fa8cd0f9e5c6f039651f))
+* **contract:** don't mark contract as deployed if tx failed ([cc4222d](https://github.com/aeternity/aepp-sdk-js/commit/cc4222db8dc979c878e6e51bea9634484b826de7))
+* **contract:** use current nonce in static calls ([758bdfc](https://github.com/aeternity/aepp-sdk-js/commit/758bdfc75a1dd8e4ff0646ddeaa10e19b1a4d5d1))
+* **node:** don't retry 500 code responses ([696e7db](https://github.com/aeternity/aepp-sdk-js/commit/696e7db88605a385789d741f2704aba2c1cee972))
+* **node:** throw clear error message if unsupported protocol ([21dfe34](https://github.com/aeternity/aepp-sdk-js/commit/21dfe34b3645d95b4c54d99e8517a33634b3751f))
+* **node:** uncatchable exception if request failed in queue ([dec62a4](https://github.com/aeternity/aepp-sdk-js/commit/dec62a474cad4639b81cbef46ff606c384f7ab53))
+* typos in error messages and docs ([5c84671](https://github.com/aeternity/aepp-sdk-js/commit/5c846712a32a110e1a5df25d5c4366046d9558f5))
+
 ### [13.2.1](https://github.com/aeternity/aepp-sdk-js/compare/v13.2.0...v13.2.1) (2023-07-28)
 
 

--- a/docs/guides/address-length.md
+++ b/docs/guides/address-length.md
@@ -81,5 +81,5 @@ Running the above code you would get output like
 Therefore the minimum address length is 41 chars. All these addresses valid, for example
 `ak_11111111111111111111111111111111273Yts` [used] to collect AENS name fees.
 
-[isAddressValid]: https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/functions/isAddressValid.html
+[isAddressValid]: https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/functions/isAddressValid.html
 [used]: https://mainnet.aeternity.io/v3/accounts/ak_11111111111111111111111111111111273Yts

--- a/docs/guides/address-length.md
+++ b/docs/guides/address-length.md
@@ -81,5 +81,5 @@ Running the above code you would get output like
 Therefore the minimum address length is 41 chars. All these addresses valid, for example
 `ak_11111111111111111111111111111111273Yts` [used] to collect AENS name fees.
 
-[isAddressValid]: https://docs.aeternity.com/aepp-sdk-js/v13.1.0/api/functions/isAddressValid.html
+[isAddressValid]: https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/functions/isAddressValid.html
 [used]: https://mainnet.aeternity.io/v3/accounts/ak_11111111111111111111111111111111273Yts

--- a/docs/guides/contracts.md
+++ b/docs/guides/contracts.md
@@ -17,7 +17,7 @@ import { AeSdk, MemoryAccount, Node } from '@aeternity/aepp-sdk'
 ## 2. Setup compiler
 Compiler primarily used to generate bytecode to deploy a contract.
 Skip this step if you have a contract bytecode or need to interact with an already deployed contract.
-Out-of-the-box SDK supports [aesophia_cli](https://github.com/aeternity/aesophia_cli) and [aesophia_http](https://github.com/aeternity/aesophia_http) implemented in [CompilerCli](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerCli.html) and [CompilerHttp](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerHttp.html) respectively.
+Out-of-the-box SDK supports [aesophia_cli](https://github.com/aeternity/aesophia_cli) and [aesophia_http](https://github.com/aeternity/aesophia_http) implemented in [CompilerCli](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/classes/CompilerCli.html) and [CompilerHttp](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/classes/CompilerHttp.html) respectively.
 
 CompilerCli is available only in Node.js and requires Erlang installed (`escript` available in `$PATH`), Windows is supported.
 ```js
@@ -29,7 +29,7 @@ CompilerHttp requires a hosted compiler service. Preferable to host your own com
 const compiler = new CompilerHttp('https://v7.compiler.aepps.com') // host your own compiler
 ```
 
-Both compiler classes implement the [same interface](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerBase.html) that can be used to generate bytecode and ACI without a Contract instance.
+Both compiler classes implement the [same interface](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/classes/CompilerBase.html) that can be used to generate bytecode and ACI without a Contract instance.
 
 ## 3. Create an instance of the SDK
 When creating an instance of the SDK you need to provide an account which will be used to sign transactions like `ContractCreateTx` and `ContractCallTx` that will be broadcasted to the network.
@@ -212,8 +212,8 @@ The conversion between JS and Sophia values is handled by aepp-calldata library.
 Refer to [its documentation](https://www.npmjs.com/package/@aeternity/aepp-calldata#data-types) to find the right type to use.
 
 ## Generate file system object in Node.js
-To do so you can use [getFileSystem](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/functions/getFileSystem.html) function.
+To do so you can use [getFileSystem](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/functions/getFileSystem.html) function.
 In most cases, you don't need to do it explicitly. Prefer to use `sourceCodePath` instead `sourceCode` in
-[Contract::initialize](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/_internal_.Contract.html#initialize),
-and [compile](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerBase.html#compile)
-instead [compileBySourceCode](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerBase.html#compileBySourceCode) in CompilerBase.
+[Contract::initialize](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/classes/_internal_.Contract.html#initialize),
+and [compile](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/classes/CompilerBase.html#compile)
+instead [compileBySourceCode](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/classes/CompilerBase.html#compileBySourceCode) in CompilerBase.

--- a/docs/guides/contracts.md
+++ b/docs/guides/contracts.md
@@ -5,24 +5,33 @@ The smart contract language of the æternity blockchain is [Sophia](https://docs
 
 Before interacting with contracts using the SDK you should get familiar with Sophia itself first. Have a look into [aepp-sophia-examples](https://github.com/aeternity/aepp-sophia-examples) and start rapid prototyping using [AEstudio](https://studio.aepps.com).
 
-The SDK needs to interact with following components in order to enable smart contract interactions on the æternity blockchain:
-
-- [æternity](https://github.com/aeternity/aeternity) (host your own one or use the public testnet node at `https://testnet.aeternity.io`)
-- [aesophia_http](https://github.com/aeternity/aesophia_http) (host your own one or use the public compiler at `https://v7.compiler.aepps.com`)
-
-Note:
-
-- For production deployments you should ***always*** host these services by yourself.
-
 ## 1. Specify imports
 ```js
 // node.js import
-const { AeSdk, MemoryAccount, Node, CompilerHttp } = require('@aeternity/aepp-sdk')
+const { AeSdk, MemoryAccount, Node } = require('@aeternity/aepp-sdk')
 // ES import
-import { AeSdk, MemoryAccount, Node, CompilerHttp } from '@aeternity/aepp-sdk'
+import { AeSdk, MemoryAccount, Node } from '@aeternity/aepp-sdk'
+// additionally you may need to import CompilerCli or CompilerHttp
 ```
 
-## 2. Create an instance of the SDK
+## 2. Setup compiler
+Compiler primarily used to generate bytecode to deploy a contract.
+Skip this step if you have a contract bytecode or need to interact with an already deployed contract.
+Out-of-the-box SDK supports [aesophia_cli](https://github.com/aeternity/aesophia_cli) and [aesophia_http](https://github.com/aeternity/aesophia_http) implemented in [CompilerCli](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerCli.html) and [CompilerHttp](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerHttp.html) respectively.
+
+CompilerCli is available only in Node.js and requires Erlang installed (`escript` available in `$PATH`), Windows is supported.
+```js
+const compiler = new CompilerCli()
+```
+
+CompilerHttp requires a hosted compiler service. Preferable to host your own compiler service since [compiler.aepps.com](https://v7.compiler.aepps.com/api) is planned to be decommissioned. An example of how to run it using [docker-compose](https://github.com/aeternity/aepp-sdk-js/blob/cd8dd7f76a6323383349b48400af0d69c2cfd88e/docker-compose.yml#L11-L14).
+```js
+const compiler = new CompilerHttp('https://v7.compiler.aepps.com') // host your own compiler
+```
+
+Both compiler classes implement the [same interface](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerBase.html) that can be used to generate bytecode and ACI without a Contract instance.
+
+## 3. Create an instance of the SDK
 When creating an instance of the SDK you need to provide an account which will be used to sign transactions like `ContractCreateTx` and `ContractCallTx` that will be broadcasted to the network.
 
 ```js
@@ -32,7 +41,7 @@ const account = new MemoryAccount(SECRET_KEY)
 const aeSdk = new AeSdk({
   nodes: [{ name: 'testnet', instance: node }],
   accounts: [account],
-  onCompiler: new CompilerHttp('https://v7.compiler.aepps.com'), // ideally host your own compiler
+  onCompiler: compiler, // remove if step #2 skipped
 })
 ```
 
@@ -42,7 +51,7 @@ Note:
 - For each transaction you can choose a specific account to use for signing (by default the first account will be used), see [transaction options](../transaction-options.md).
     - This is specifically important and useful for writing tests.
 
-## 3. Initialize the contract instance
+## 4. Initialize the contract instance
 
 ### By source code
 
@@ -58,6 +67,13 @@ Note:
   const fileSystem = ... // key-value map with name of the include as key and source code of the include as value
   const contract = await aeSdk.initializeContract({ sourceCode, fileSystem })
   ```
+
+### By path to source code (available only in Node.js)
+It can be used with both CompilerCli and CompilerHttp. This way contract imports would be handled automatically, with no need to provide `fileSystem` option.
+```js
+const sourceCodePath = './example.aes'
+const contract = await aeSdk.initializeContract({ sourceCodePath })
+```
 
 ### By ACI and bytecode
 If you pre-compiled the contracts you can also initialize a contract instance by providing ACI and bytecode:
@@ -80,7 +96,7 @@ const contract = await aeSdk.initializeContract({ aci, address })
 ### Options
 
 - Following attributes can be provided via `options` to `initializeContract`:
-    - `aci` (default: obtained via http compiler)
+    - `aci` (default: obtained via `onCompiler`)
         - The Contract ACI.
     - `address`
         - The address where the contract is located at.
@@ -94,7 +110,11 @@ const contract = await aeSdk.initializeContract({ aci, address })
         - You wouldn't want to provide an `amount` to each transaction or use the same `nonce` which would result in invalid transactions.
         - For options like `ttl` or `gasPrice` it does absolutely make sense to set this on contract instance level.
 
-## 4. Deploy the contract
+### Keep bytecode and ACI for future use
+After the contract is initialized you can persist values of `contract._aci` and `contract.$options.bytecode`.
+They can be provided for subsequent contract initializations to don't depend on a compiler.
+
+## 5. Deploy the contract
 
 If you have a Sophia contract source code that looks like this:
 ```sophia
@@ -131,7 +151,7 @@ Note:
 - In Sophia all `public functions` are called `entrypoints` and need to be declared as `stateful`
 if they should produce changes to the state of the smart contract, see `increment(value: int)`.
 
-## 5. Call contract entrypoints
+## 6. Call contract entrypoints
 
 ### a) Stateful entrypoints
 According to the example above you can call the `stateful` entrypoint `increment` by using one of the following lines:
@@ -187,21 +207,13 @@ const tx = await contract.$call('fund_project', [1], { amount: 50 })
 As already stated various times in the guide it is possible to provide [transaction options](../transaction-options.md) as object to a function of the SDK that builds and potentially broadcasts a transaction. This object can be passed as additional param to each of these functions and overrides the default settings.
 
 ## Sophia datatype cheatsheet
-Sometimes you might wonder how to pass params to the JavaScript method that calls an entrypoint of your Sophia smart contract. The following table may help you out.
+Sometimes you might wonder how to pass params to the JavaScript method that calls an entrypoint of your Sophia smart contract.
+The conversion between JS and Sophia values is handled by aepp-calldata library.
+Refer to [its documentation](https://www.npmjs.com/package/@aeternity/aepp-calldata#data-types) to find the right type to use.
 
-| Type      | Sophia entrypoint definition      | JavaScript method call                           |
-|-----------|-----------------------------------|--------------------------------------------------|
-| int       | `add_two(one: int, two: int)`     | `add_two(1 , 2)`                                 |
-| address   | `set_owner(owner: address)`       | `set_owner('ak_1337...')`                        |
-| bool      | `is_it_true(answer: bool)`        | `is_it_true(true)`                               |
-| bits      | `give_me_bits(input: bits)`       | `give_me_bits(0b10110n)`                         |
-| bytes     | `get_bytes(test: bytes(3))`       | `get_bytes(new Uint8Array([0x1, 0x1f, 0x10]))`   |
-| string    | `hello_world(say_hello: string)`  | `hello_world('Hello!')`                          |
-| list      | `have_a_few(candy: list(string))` | `have_a_few(['Skittles', 'M&Ms', 'JellyBelly'])` |
-| tuple     | `a_few_things(things: (string * int * map(address, bool)))` | `a_few_things(['hola', 3, new Map([['ak_1337...', true]])])` |
-| record    | `record user = {`<br />&nbsp; &nbsp; &nbsp; &nbsp; `firstname: string,` <br /> &nbsp; &nbsp; &nbsp; &nbsp; `lastname: string` <br /> `}` <br />  <br />  `get_firstname(input: user): string`    |  `get_firstname({'firstname': 'Alfred', 'lastname': 'Mustermann'})`  |
-| map       | `balances(values: map(address, int))`      |  `balances(new Map([['ak_1337...', 123], ['ak_FCKGW...', 321], ['ak_Rm5U...', 999]]))`  |
-| option()  | `number_defined(value: option(int)): bool = `<br />  &nbsp; &nbsp; &nbsp; &nbsp; `Option.is_some(value)`       |  `// the datatype in the option()` <br /> `number_defined(1337) // int in this case`  |
-| hash      | `a_gram(of: hash)`      | `// 32 bytes signature` <br />  `a_gram('af01...490f')`  |
-| signature | `one_signature(sig: signature)`      |  `// 64 bytes signature` <br />  `one_signature('af01...490f')`  |
-| functions | (Higher order) functions are not allowed in `entrypoint` params     |    |
+## Generate file system object in Node.js
+To do so you can use [getFileSystem](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/functions/getFileSystem.html) function.
+In most cases, you don't need to do it explicitly. Prefer to use `sourceCodePath` instead `sourceCode` in
+[Contract::initialize](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/_internal_.Contract.html#initialize),
+and [compile](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerBase.html#compile)
+instead [compileBySourceCode](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/classes/CompilerBase.html#compileBySourceCode) in CompilerBase.

--- a/docs/guides/paying-for-tx.md
+++ b/docs/guides/paying-for-tx.md
@@ -13,8 +13,8 @@ You can then collect the signed inner transaction, wrap it into a `PayingForTx` 
 ## Usage examples
 We provided following two NodeJS examples which you can take a look at:
 
-- [InnerTx: ContractCallTx](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/examples/node/paying-for-contract-call-tx/)
-- [InnerTx: SpendTx](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/examples/node/paying-for-spend-tx/)
+- [InnerTx: ContractCallTx](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/examples/node/paying-for-contract-call-tx/)
+- [InnerTx: SpendTx](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/examples/node/paying-for-spend-tx/)
 
 Note:
 

--- a/docs/guides/paying-for-tx.md
+++ b/docs/guides/paying-for-tx.md
@@ -13,8 +13,8 @@ You can then collect the signed inner transaction, wrap it into a `PayingForTx` 
 ## Usage examples
 We provided following two NodeJS examples which you can take a look at:
 
-- [InnerTx: ContractCallTx](https://docs.aeternity.com/aepp-sdk-js/v13.1.0/examples/node/paying-for-contract-call-tx/)
-- [InnerTx: SpendTx](https://docs.aeternity.com/aepp-sdk-js/v13.1.0/examples/node/paying-for-spend-tx/)
+- [InnerTx: ContractCallTx](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/examples/node/paying-for-contract-call-tx/)
+- [InnerTx: SpendTx](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/examples/node/paying-for-spend-tx/)
 
 Note:
 

--- a/docs/guides/typed-data.md
+++ b/docs/guides/typed-data.md
@@ -30,10 +30,8 @@ corresponds to the data
 
 ## Implementation
 
-- [encodeFateValue](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/utils/typed-data.ts#L44-L52) — use to generate the first argument for `signTypedData`;
-- [AccountBase::signTypedData](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/account/Base.ts#L63-L70) — calculates signature, supported in MemoryAccount and in aepp-wallet connection;
+- [AccountBase:signTypedData](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/account/Base.ts#L63-L70) — calculates signature, supported in MemoryAccount and in aepp-wallet connection;
 - [hashTypedData](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/utils/typed-data.ts#L87-L95) — calculates the overall hash of typed data to sign;
-- [decodeFateValue](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/utils/typed-data.ts#L55-L63) — use to preview data to sign on wallet side;
 - [hashJson](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/utils/typed-data.ts#L16-L18) — deterministic hashing of an arbitrary JS value, used to calculate `hash(aci)`;
 - [hashDomain](https://github.com/aeternity/aepp-sdk-js/blob/5952a7b9f4d0cf30ad7caa0831dfb974d1e91afc/src/utils/typed-data.ts#L68-L85) — use for debugging or to prepare the hash value for smart contract.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,5 +1,6 @@
 # Quick Start
-In this example we will send 1 _AE_ coin from one account to another
+In this example we will send 1 _AE_ coin from one account to another.
+For more specific information on setups with Frameworks and TypeScript, please refer to the [installation instructions](./README.md).
 
 ## 1. Specify imports
 For the following snippets in the guide you need to specify multiple imports.

--- a/examples/browser/aepp/package.json
+++ b/examples/browser/aepp/package.json
@@ -7,6 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
+    "@aeternity/aepp-calldata": "^1.5.1",
     "@aeternity/aepp-sdk": "file:../../..",
     "buffer": "^6.0.3",
     "core-js": "^3.32.1",

--- a/examples/browser/aepp/package.json
+++ b/examples/browser/aepp/package.json
@@ -9,16 +9,16 @@
   "dependencies": {
     "@aeternity/aepp-sdk": "file:../../..",
     "buffer": "^6.0.3",
-    "core-js": "^3.22.6",
+    "core-js": "^3.32.1",
     "tailwindcss": "^2.2.19",
-    "vue": "^3.2.36",
-    "vuex": "^4.0.2"
+    "vue": "^3.3.4",
+    "vuex": "^4.1.0"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~5.0.4",
-    "@vue/cli-service": "~5.0.4",
-    "sass": "^1.52.1",
-    "sass-loader": "^13.0.0"
+    "@vue/cli-plugin-babel": "~5.0.8",
+    "@vue/cli-service": "~5.0.8",
+    "sass": "^1.66.1",
+    "sass-loader": "^13.3.2"
   },
   "browserslist": [
     "> 1%",

--- a/examples/browser/aepp/src/Connect.vue
+++ b/examples/browser/aepp/src/Connect.vue
@@ -67,7 +67,7 @@ export default {
     walletConnected: false,
     walletConnecting: null,
     reverseIframe: null,
-    reverseIframeWalletUrl: process.env.VUE_APP_WALLET_URL ?? 'http://localhost:9000',
+    reverseIframeWalletUrl: process.env.VUE_APP_WALLET_URL ?? `http://${location.hostname}:9000`,
     walletInfo: null,
     cancelWalletDetection: null,
   }),

--- a/examples/browser/aepp/src/Contracts.vue
+++ b/examples/browser/aepp/src/Contracts.vue
@@ -10,7 +10,7 @@
         />
       </div>
     </div>
-    <button @click="createPromise = create()">
+    <button @click="() => { createPromise = create(); }">
       Create
     </button>
     <div v-if="createPromise">
@@ -20,60 +20,46 @@
   </div>
 
   <template v-if="contract">
-    <h2>Compile Contract</h2>
-    <div class="group">
-      <button @click="compilePromise = compile()">
-        Compile
-      </button>
-      <div v-if="compilePromise">
-        <div>Bytecode</div>
-        <Value :value="compilePromise" />
-      </div>
-    </div>
+    <FieldAction
+      title="Compile Contract"
+      action-title="Compile"
+      :action-handler="compile"
+      result-title="Bytecode"
+    />
   </template>
 
   <template v-if="contract">
-    <h2>Deploy Contract</h2>
-    <div class="group">
-      <div>
-        <div>Deploy argument</div>
-        <div>
-          <input
-            v-model="deployArg"
-            placeholder="Deploy argument"
-          >
-        </div>
-      </div>
-      <button @click="deployPromise = deploy()">
-        Deploy
-      </button>
-      <div v-if="deployPromise">
-        <div>Deployed Contract</div>
-        <Value :value="deployPromise" />
-      </div>
-    </div>
+    <FieldAction
+      title="Deploy Contract"
+      arg-title="Deploy argument"
+      arg-placeholder="Deploy argument"
+      arg-default-value="5"
+      action-title="Deploy"
+      :action-handler="deploy"
+      result-title="Deployed Contract"
+    />
   </template>
 
   <template v-if="deployPromise">
-    <h2>Call Contract</h2>
-    <div class="group">
-      <div>
-        <div>Call argument</div>
-        <div>
-          <input
-            v-model="callArg"
-            placeholder="Call argument"
-          >
-        </div>
-      </div>
-      <button @click="callPromise = call()">
-        Call
-      </button>
-      <div v-if="callPromise">
-        <div>Call Result</div>
-        <Value :value="callPromise" />
-      </div>
-    </div>
+    <FieldAction
+      title="Call Contract on chain"
+      arg-title="Call argument"
+      arg-placeholder="Call argument"
+      arg-default-value="7"
+      action-title="Call"
+      :action-handler="callOnChain"
+      result-title="Call Result"
+    />
+
+    <FieldAction
+      title="Call Contract using dry-run (static)"
+      arg-title="Call argument"
+      arg-placeholder="Call argument"
+      arg-default-value="8"
+      action-title="Call"
+      :action-handler="callStatic"
+      result-title="Call Result"
+    />
   </template>
 </template>
 
@@ -81,25 +67,28 @@
 import { shallowRef } from 'vue';
 import { mapState } from 'vuex';
 import Value from './components/Value.vue';
+import FieldAction from './components/FieldAction.vue';
 
 const contractSourceCode = `
 contract Multiplier =
   record state = { factor: int }
-  entrypoint init(f : int) : state = { factor = f }
-  entrypoint calc(x : int) = x * state.factor
+
+  entrypoint init(f : int) = { factor = f }
+
+  stateful entrypoint setFactor(f : int) =
+    put(state{ factor = f })
+
+  entrypoint multiplyByFactor(x : int) =
+    x * state.factor
 `.trim();
 
 export default {
-  components: { Value },
+  components: { Value, FieldAction },
   data: () => ({
     contractSourceCode,
-    deployArg: 5,
-    callArg: 7,
     createPromise: null,
     contract: null,
-    compilePromise: null,
     deployPromise: null,
-    callPromise: null,
   }),
   computed: mapState(['aeSdk']),
   methods: {
@@ -112,11 +101,15 @@ export default {
     async compile() {
       return this.contract.$compile();
     },
-    async deploy() {
-      return this.contract.$deploy([this.deployArg]);
+    async deploy(arg) {
+      this.deployPromise = this.contract.$deploy([arg]);
+      return this.deployPromise;
     },
-    async call() {
-      return this.contract.calc(this.callArg);
+    async callOnChain(arg) {
+      return this.contract.setFactor(arg);
+    },
+    async callStatic(arg) {
+      return this.contract.multiplyByFactor(arg);
     },
   },
 };

--- a/examples/browser/aepp/src/DelegationSignature.vue
+++ b/examples/browser/aepp/src/DelegationSignature.vue
@@ -25,7 +25,7 @@
       </label>
       <div><input v-model="oracleQueryId"></div>
     </div>
-    <button @click="signPromise = sign()">
+    <button @click="() => { signPromise = sign(); }">
       Sign
     </button>
     <div v-if="signPromise">

--- a/examples/browser/aepp/src/PayForTx.vue
+++ b/examples/browser/aepp/src/PayForTx.vue
@@ -1,71 +1,43 @@
 <template>
   <GenerateSpendTx />
 
-  <h2>Sign inner transaction</h2>
-  <div class="group">
-    <div>
-      <div>Transaction</div>
-      <div>
-        <input
-          v-model="txToPayFor"
-          placeholder="tx_..."
-        >
-      </div>
-    </div>
-    <button @click="signInnerTxPromise = signInnerTx()">
-      Sign
-    </button>
-    <div v-if="signInnerTxPromise">
-      <div>Signed inner transaction</div>
-      <Value :value="signInnerTxPromise" />
-    </div>
-  </div>
+  <FieldAction
+    title="Sign inner transaction"
+    arg-title="Transaction"
+    arg-placeholder="tx_..."
+    action-title="Sign"
+    :action-handler="signInnerTx"
+    result-title="Signed inner transaction"
+  />
 
-  <h2>Pay for transaction</h2>
-  <div class="group">
-    <div>
-      <div>Signed inner transaction</div>
-      <div>
-        <input
-          v-model="innerTx"
-          placeholder="tx_..."
-        >
-      </div>
-    </div>
-    <button @click="payForTxPromise = payForTx()">
-      Pay for transaction
-    </button>
-    <div v-if="payForTxPromise">
-      <div>Result</div>
-      <Value :value="payForTxPromise" />
-    </div>
-  </div>
+  <FieldAction
+    title="Pay for transaction"
+    arg-title="Signed inner transaction"
+    arg-placeholder="tx_..."
+    action-title="Pay for transaction"
+    :action-handler="payForTx"
+    result-title="Result"
+  />
 </template>
 
 <script>
 import { mapState } from 'vuex';
-import Value from './components/Value.vue';
+import FieldAction from './components/FieldAction.vue';
 import SpendCoins from './components/SpendCoins.vue';
 import MessageSign from './components/MessageSign.vue';
 import GenerateSpendTx from './components/GenerateSpendTx.vue';
 
 export default {
   components: {
-    Value, SpendCoins, MessageSign, GenerateSpendTx,
+    FieldAction, SpendCoins, MessageSign, GenerateSpendTx,
   },
-  data: () => ({
-    innerTx: '',
-    txToPayFor: '',
-    signInnerTxPromise: null,
-    payForTxPromise: null,
-  }),
   computed: mapState(['aeSdk']),
   methods: {
-    signInnerTx() {
-      return this.aeSdk.signTransaction(this.txToPayFor, { innerTx: true });
+    signInnerTx(txToPayFor) {
+      return this.aeSdk.signTransaction(txToPayFor, { innerTx: true });
     },
-    payForTx() {
-      return this.aeSdk.payForTransaction(this.innerTx);
+    payForTx(innerTx) {
+      return this.aeSdk.payForTransaction(innerTx);
     },
   },
 };

--- a/examples/browser/aepp/src/TypedData.vue
+++ b/examples/browser/aepp/src/TypedData.vue
@@ -66,16 +66,12 @@
     </div>
   </div>
 
-  <h2>Sign</h2>
-  <div class="group">
-    <button @click="signPromise = signTypedData()">
-      Sign
-    </button>
-    <div v-if="signPromise">
-      <div>Signature</div>
-      <Value :value="signPromise" />
-    </div>
-  </div>
+  <FieldAction
+    title="Sign"
+    action-title="Sign"
+    :action-handler="signTypedData"
+    result-title="Signature"
+  />
 
   <h2>Verify</h2>
   <div class="group">
@@ -97,7 +93,7 @@
         >
       </div>
     </div>
-    <button @click="verifyPromise = verifyTypedData()">
+    <button @click="() => { verifyPromise = verifyTypedData(); }">
       Verify
     </button>
     <div v-if="verifyPromise">
@@ -113,10 +109,11 @@ import {
   hashTypedData, encodeFateValue, verify, decode,
 } from '@aeternity/aepp-sdk';
 import Value from './components/Value.vue';
+import FieldAction from './components/FieldAction.vue';
 
 export default {
   components: {
-    Value,
+    Value, FieldAction,
   },
   data: () => ({
     domain: {
@@ -135,7 +132,6 @@ export default {
       operation: 'test',
       parameter: 42,
     }),
-    signPromise: null,
     verifySignature: null,
     verifyAddress: null,
     verifyPromise: null,

--- a/examples/browser/aepp/src/TypedData.vue
+++ b/examples/browser/aepp/src/TypedData.vue
@@ -105,9 +105,8 @@
 
 <script>
 import { mapState } from 'vuex';
-import {
-  hashTypedData, encodeFateValue, verify, decode,
-} from '@aeternity/aepp-sdk';
+import { hashTypedData, verify, decode } from '@aeternity/aepp-sdk';
+import { TypeResolver, ContractByteArrayEncoder } from '@aeternity/aepp-calldata';
 import Value from './components/Value.vue';
 import FieldAction from './components/FieldAction.vue';
 
@@ -145,7 +144,8 @@ export default {
       return JSON.parse(this.aci);
     },
     dataEncoded() {
-      return encodeFateValue(this.dataParsed, this.aciParsed);
+      const dataType = new TypeResolver().resolveType(this.aciParsed);
+      return new ContractByteArrayEncoder().encodeWithType(this.dataParsed, dataType);
     },
     hash() {
       return hashTypedData(this.dataEncoded, this.aciParsed, this.domain);

--- a/examples/browser/aepp/src/components/FieldAction.vue
+++ b/examples/browser/aepp/src/components/FieldAction.vue
@@ -1,0 +1,44 @@
+<template>
+  <h2>{{ title }}</h2>
+  <div class="group">
+    <div v-if="argTitle">
+      <div>{{ argTitle }}</div>
+      <div>
+        <input
+          v-model="argValue"
+          :placeholder="argPlaceholder"
+        >
+      </div>
+    </div>
+    <button @click="() => { promise = actionHandler(argValue); }">
+      {{ actionTitle }}
+    </button>
+    <div v-if="promise">
+      <div>{{ resultTitle }}</div>
+      <Value :value="promise" />
+    </div>
+  </div>
+</template>
+
+<script>
+import Value from './Value.vue';
+
+export default {
+  components: { Value },
+  props: {
+    title: { type: String, required: true },
+    argTitle: { type: String, required: false },
+    argPlaceholder: { type: String, required: false },
+    argDefaultValue: { type: String, required: false },
+    actionTitle: { type: String, required: true },
+    actionHandler: { type: Function, required: true },
+    resultTitle: { type: String, required: true },
+  },
+  data() {
+    return {
+      argValue: this.argDefaultValue,
+      promise: null,
+    };
+  },
+};
+</script>

--- a/examples/browser/aepp/src/components/GenerateSpendTx.vue
+++ b/examples/browser/aepp/src/components/GenerateSpendTx.vue
@@ -28,7 +28,7 @@
         (only if you want to pay for this transaction yourself)
       </div>
     </div>
-    <button @click="generatePromise = generate()">
+    <button @click="() => { generatePromise = generate(); }">
       Generate
     </button>
     <div v-if="generatePromise">

--- a/examples/browser/aepp/src/components/MessageSign.vue
+++ b/examples/browser/aepp/src/components/MessageSign.vue
@@ -1,39 +1,24 @@
 <template>
-  <h2>Sign a message</h2>
-  <div class="group">
-    <div>
-      <div>Message to sign</div>
-      <div>
-        <input
-          v-model="messageToSign"
-          placeholder="I want to <action name> at <time> on <network name>"
-        >
-      </div>
-    </div>
-    <button @click="messageSignPromise = messageSign()">
-      Sign message
-    </button>
-    <div v-if="messageSignPromise">
-      <div>Message sign result</div>
-      <Value :value="messageSignPromise" />
-    </div>
-  </div>
+  <FieldAction
+    title="Sign a message"
+    arg-title="Message to sign"
+    arg-placeholder="I want to <action name> at <time> on <network name>"
+    action-title="Sign message"
+    :action-handler="messageSign"
+    result-title="Message sign result"
+  />
 </template>
 
 <script>
 import { mapState } from 'vuex';
-import Value from './Value.vue';
+import FieldAction from './FieldAction.vue';
 
 export default {
-  components: { Value },
-  data: () => ({
-    messageToSign: '',
-    messageSignPromise: null,
-  }),
+  components: { FieldAction },
   computed: mapState(['aeSdk']),
   methods: {
-    messageSign() {
-      return this.aeSdk.signMessage(this.messageToSign);
+    messageSign(messageToSign) {
+      return this.aeSdk.signMessage(messageToSign);
     },
   },
 };

--- a/examples/browser/aepp/src/components/SpendCoins.vue
+++ b/examples/browser/aepp/src/components/SpendCoins.vue
@@ -18,7 +18,7 @@
       <div>Payload</div>
       <div><input v-model="spendPayload"></div>
     </div>
-    <button @click="spendPromise = spend()">
+    <button @click="() => { spendPromise = spend(); }">
       Spend
     </button>
     <div v-if="spendPromise">

--- a/examples/browser/wallet-iframe/package.json
+++ b/examples/browser/wallet-iframe/package.json
@@ -7,6 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
+    "@aeternity/aepp-calldata": "^1.5.1",
     "@aeternity/aepp-sdk": "file:../../..",
     "buffer": "^6.0.3",
     "core-js": "^3.32.1",

--- a/examples/browser/wallet-iframe/package.json
+++ b/examples/browser/wallet-iframe/package.json
@@ -9,15 +9,15 @@
   "dependencies": {
     "@aeternity/aepp-sdk": "file:../../..",
     "buffer": "^6.0.3",
-    "core-js": "^3.22.6",
+    "core-js": "^3.32.1",
     "tailwindcss": "^2.2.19",
-    "vue": "^3.2.36"
+    "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~5.0.4",
-    "@vue/cli-service": "~5.0.4",
-    "sass": "^1.52.1",
-    "sass-loader": "^13.0.0"
+    "@vue/cli-plugin-babel": "~5.0.8",
+    "@vue/cli-service": "~5.0.8",
+    "sass": "^1.66.1",
+    "sass-loader": "^13.3.2"
   },
   "browserslist": [
     "> 1%",

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -1,7 +1,24 @@
 <template>
-  <h2>Wallet Iframe</h2>
+  <input id="toggle-aepp" type="checkbox" />
+  <h2>
+    Wallet Iframe
+    <label for="toggle-aepp" />
+  </h2>
 
   <div class="group">
+    <div>
+      <div>Aepp URL</div>
+      <form
+        novalidate
+        @submit.prevent="navigate"
+      >
+        <input
+          type="url"
+          v-model="nextAeppUrl"
+          @focus="$event.target.select()"
+        >
+      </form>
+    </div>
     <div>
       <div>Address</div>
       <div>{{ address }}</div>
@@ -54,7 +71,8 @@ import Value from './Value.vue';
 export default {
   components: { Value },
   data: () => ({
-    aeppUrl: process.env.VUE_APP_AEPP_URL ?? 'http://localhost:9001',
+    nextAeppUrl: process.env.VUE_APP_AEPP_URL ?? `http://${location.hostname}:9001`,
+    aeppUrl: '',
     runningInFrame: window.parent !== window,
     nodeName: '',
     address: '',
@@ -64,6 +82,13 @@ export default {
     stopSharingWalletInfo: null,
   }),
   methods: {
+    navigate() {
+      if (!/^https?:\/\//.test(this.nextAeppUrl)) this.nextAeppUrl = 'http://' + this.nextAeppUrl;
+      this.aeppUrl = '';
+      this.$nextTick(() => {
+        this.aeppUrl = this.nextAeppUrl;
+      });
+    },
     shareWalletInfo({ interval = 5000, attempts = 5 } = {}) {
       const target = this.runningInFrame ? window.parent : this.$refs.aepp.contentWindow;
       const connection = new BrowserWindowMessageConnection({ target });
@@ -116,6 +141,8 @@ export default {
     },
   },
   mounted() {
+    this.navigate();
+
     const aeppInfo = {};
     const genConfirmCallback = (actionName) => (aeppId, parameters, origin) => {
       if (!confirm([
@@ -242,3 +269,40 @@ export default {
 </script>
 
 <style lang="scss" src="./styles.scss" />
+
+<style lang="scss" scoped>
+input[id=toggle-aepp] {
+  display: none;
+}
+
+label[for=toggle-aepp]::after {
+  font-size: initial;
+  font-weight: initial;
+  text-decoration: underline dotted;
+  cursor: pointer;
+}
+
+@media (max-width: 450px), (max-height: 650px) {
+  input[id=toggle-aepp] {
+    &:checked ~ {
+      h2 label[for=toggle-aepp]::after {
+        content: 'Hide aepp';
+      }
+
+      .group {
+        display: none;
+      }
+    }
+
+    &:not(:checked) ~ {
+      h2 label[for=toggle-aepp]::after {
+        content: 'Show aepp';
+      }
+
+      iframe {
+        display: none;
+      }
+    }
+  }
+}
+</style>

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -84,7 +84,9 @@ export default {
   }),
   methods: {
     navigate() {
-      if (!/^https?:\/\//.test(this.nextAeppUrl)) this.nextAeppUrl = 'http://' + this.nextAeppUrl;
+      if (!/^https?:\/\//.test(this.nextAeppUrl) && !this.nextAeppUrl.startsWith('.')) {
+        this.nextAeppUrl = 'http://' + this.nextAeppUrl;
+      }
       this.aeppUrl = '';
       this.$nextTick(() => {
         this.aeppUrl = this.nextAeppUrl;

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -64,8 +64,9 @@
 import {
   MemoryAccount, generateKeyPair, AeSdkWallet, Node, CompilerHttp,
   BrowserWindowMessageConnection, METHODS, WALLET_TYPE, RPC_STATUS,
-  RpcConnectionDenyError, RpcRejectedByUserError, unpackTx, decodeFateValue,
+  RpcConnectionDenyError, RpcRejectedByUserError, unpackTx,
 } from '@aeternity/aepp-sdk';
+import { TypeResolver, ContractByteArrayEncoder } from '@aeternity/aepp-calldata';
 import Value from './Value.vue';
 
 export default {
@@ -173,7 +174,9 @@ export default {
 
       async signTypedData(data, aci, { aeppRpcClientId: id, aeppOrigin, ...options }) {
         if (id != null) {
-          const opt = { ...options, aci, decodedData: decodeFateValue(data, aci) };
+          const dataType = new TypeResolver().resolveType(aci);
+          const decodedData = new ContractByteArrayEncoder().decodeWithType(data, dataType);
+          const opt = { ...options, aci, decodedData };
           genConfirmCallback(`sign typed data ${data}`)(id, opt, aeppOrigin);
         }
         return super.signTypedData(data, aci, options);

--- a/examples/browser/wallet-iframe/src/styles.scss
+++ b/examples/browser/wallet-iframe/src/styles.scss
@@ -6,7 +6,7 @@ body {
   @extend .bg-gray-300;
 
   #app {
-    @extend .p-4, .flex, .flex-col, .w-full, .h-screen;
+    @extend .p-4, .flex, .flex-col, .w-full, .min-h-screen;
 
     iframe {
       @extend .flex-grow, .mt-4, .bg-white, .border, .border-black, .border-dashed;
@@ -24,6 +24,10 @@ button {
 
 h2 {
   @extend .mt-2, .font-bold, .text-2xl;
+}
+
+input:not([type=radio]):not([type=checkbox]), textarea {
+  @extend .bg-gray-900, .text-white, .p-2, .w-full;
 }
 
 .group {

--- a/examples/browser/wallet-web-extension/package.json
+++ b/examples/browser/wallet-web-extension/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@aeternity/aepp-sdk": "file:../../..",
-    "core-js": "^3.22.6",
+    "core-js": "^3.32.1",
     "tailwindcss": "^2.2.19",
     "vue": "^2.6.14",
     "webextension-polyfill": "^0.9.0"
@@ -16,10 +16,10 @@
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.5.17",
     "@vue/cli-service": "^4.5.17",
-    "sass": "^1.52.1",
+    "sass": "^1.66.1",
     "sass-loader": "^8.0.2",
     "vue-cli-plugin-browser-extension": "^0.25.2",
-    "vue-template-compiler": "^2.6.14"
+    "vue-template-compiler": "^2.7.14"
   },
   "browserslist": [
     "> 1%",

--- a/examples/browser/wallet-web-extension/package.json
+++ b/examples/browser/wallet-web-extension/package.json
@@ -7,6 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
+    "@aeternity/aepp-calldata": "^1.5.1",
     "@aeternity/aepp-sdk": "file:../../..",
     "core-js": "^3.32.1",
     "tailwindcss": "^2.2.19",

--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -1,8 +1,9 @@
 import browser from 'webextension-polyfill';
 import {
   AeSdkWallet, CompilerHttp, Node, MemoryAccount, generateKeyPair, BrowserRuntimeConnection,
-  WALLET_TYPE, RpcConnectionDenyError, RpcRejectedByUserError, unpackTx, decodeFateValue,
+  WALLET_TYPE, RpcConnectionDenyError, RpcRejectedByUserError, unpackTx,
 } from '@aeternity/aepp-sdk';
+import { TypeResolver, ContractByteArrayEncoder } from '@aeternity/aepp-calldata';
 
 function stringifyBigint(value) {
   return JSON.stringify(
@@ -67,8 +68,10 @@ class AccountMemoryProtected extends MemoryAccount {
 
   async signTypedData(data, aci, { aeppRpcClientId: id, aeppOrigin, ...options }) {
     if (id != null) {
+      const dataType = new TypeResolver().resolveType(aci);
+      const decodedData = new ContractByteArrayEncoder().decodeWithType(data, dataType);
       const opt = {
-        ...options, aci, data, decodedData: decodeFateValue(data, aci),
+        ...options, aci, data, decodedData,
       };
       await genConfirmCallback('sign typed data')(id, opt, aeppOrigin);
     }

--- a/examples/browser/wallet-web-extension/src/content-script.js
+++ b/examples/browser/wallet-web-extension/src/content-script.js
@@ -19,7 +19,7 @@ import {
   const extConnection = new BrowserRuntimeConnection({ port });
   const pageConnection = new BrowserWindowMessageConnection({
     target: window,
-    origin: window.origin,
+    ...window.origin !== 'null' && { origin: window.origin },
     sendDirection: MESSAGE_DIRECTION.to_aepp,
     receiveDirection: MESSAGE_DIRECTION.to_waellet,
   });

--- a/examples/browser/wallet-web-extension/src/manifest.json
+++ b/examples/browser/wallet-web-extension/src/manifest.json
@@ -27,7 +27,8 @@
   "content_scripts": [{
     "matches": [
       "https://*/*",
-      "http://*/*"
+      "http://*/*",
+      "file:///*"
     ],
     "js": [
       "js/content-script.js"

--- a/examples/node/transfer-ae.mjs
+++ b/examples/node/transfer-ae.mjs
@@ -53,7 +53,7 @@ console.log(`Balance of ${recipient} (before): ${balanceBefore} aettos`);
 // Calling the `spend` function will create, sign and broadcast a `SpendTx` to the network.
 const tx = await aeSdk.spend(amount, recipient);
 console.log('Transaction mined', tx);
-// Alternatively, you can use [transferFunds](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/functions/transferFunds.html)
+// Alternatively, you can use [transferFunds](https://docs.aeternity.com/aepp-sdk-js/v13.2.2/api/functions/transferFunds.html)
 // method to transfer a fraction of your AE to another account.
 
 // ## 6. Get AE balance of recipient (after transfer)

--- a/examples/node/transfer-ae.mjs
+++ b/examples/node/transfer-ae.mjs
@@ -53,7 +53,7 @@ console.log(`Balance of ${recipient} (before): ${balanceBefore} aettos`);
 // Calling the `spend` function will create, sign and broadcast a `SpendTx` to the network.
 const tx = await aeSdk.spend(amount, recipient);
 console.log('Transaction mined', tx);
-// Alternatively, you can use [transferFunds](https://docs.aeternity.com/aepp-sdk-js/v13.1.0/api/functions/transferFunds.html)
+// Alternatively, you can use [transferFunds](https://docs.aeternity.com/aepp-sdk-js/v13.2.1/api/functions/transferFunds.html)
 // method to transfer a fraction of your AE to another account.
 
 // ## 6. Get AE balance of recipient (after transfer)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "13.2.1",
+  "version": "13.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "13.2.1",
       "license": "ISC",
       "dependencies": {
-        "@aeternity/aepp-calldata": "^1.4.0",
+        "@aeternity/aepp-calldata": "^1.5.1",
         "@aeternity/argon2": "^0.0.1",
         "@aeternity/uuid": "^0.0.1",
         "@azure/core-client": "1.6.0",
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@aeternity/aepp-calldata": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/aepp-calldata/-/aepp-calldata-1.4.0.tgz",
-      "integrity": "sha512-hDhLALqIaoFp20jXK2SBgUqfEkqlBDXdThdnGw47C0EQdNjaawb0vUeHnB4Y7cWXFKHaH5qkJwL2bYmmXg3AtA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@aeternity/aepp-calldata/-/aepp-calldata-1.5.1.tgz",
+      "integrity": "sha512-D477egpY0ErwquDOhLfCozCRaEDwRE8Vtrc2DR92dU7dkGHGp5zSikZU+cy060UaDmV4eXbU9oV8ch4ryFDqBw==",
       "dependencies": {
         "blakejs": "^1.2.1",
         "bs58": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/aepp-sdk",
-  "version": "13.2.1",
+  "version": "13.2.2",
   "description": "SDK for the æternity blockchain",
   "main": "dist/aepp-sdk.js",
   "types": "es/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "SDK"
   ],
   "dependencies": {
-    "@aeternity/aepp-calldata": "^1.4.0",
+    "@aeternity/aepp-calldata": "^1.5.1",
     "@aeternity/argon2": "^0.0.1",
     "@aeternity/uuid": "^0.0.1",
     "@azure/core-client": "1.6.0",

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -105,7 +105,7 @@ export default class Middleware
   /**
    * @param url - Url for middleware API
    * @param options - Options
-   * @param options.ignoreVersion - Don't check node version
+   * @param options.ignoreVersion - Don't ensure that the middleware is supported
    * @param options.retryCount - Amount of extra requests to do in case of failure
    * @param options.retryOverallDelay - Time in ms to wait between all retries
    */

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -117,7 +117,7 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
   /**
    * @param url - Url for node API
    * @param options - Options
-   * @param options.ignoreVersion - Don't check node version
+   * @param options.ignoreVersion - Don't ensure that the node is supported
    * @param options.retryCount - Amount of extra requests to do in case of failure
    * @param options.retryOverallDelay - Time in ms to wait between all retries
    */

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -7,6 +7,7 @@ import {
 } from './utils/autorest';
 import { Node as NodeApi, NodeOptionalParams, ErrorModel } from './apis/node';
 import { mapObject } from './utils/other';
+import { UnsupportedVersionError } from './utils/errors';
 import { Encoded } from './utils/encoder';
 import { ConsensusProtocolVersion } from './tx/builder/constants';
 
@@ -161,11 +162,12 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
 
   async getNodeInfo(): Promise<NodeInfo> {
     const {
-      nodeVersion: version,
+      nodeVersion,
       networkId: nodeNetworkId,
       protocols,
       topBlockHeight,
     } = await this.getStatus();
+
     const consensusProtocolVersion = protocols
       .filter(({ effectiveAtHeight }) => topBlockHeight >= effectiveAtHeight)
       .reduce(
@@ -173,10 +175,19 @@ export default class Node extends (NodeTransformed as unknown as NodeTransformed
         { effectiveAtHeight: -1, version: 0 },
       )
       .version;
+    if (ConsensusProtocolVersion[consensusProtocolVersion] == null) {
+      const version = consensusProtocolVersion.toString();
+      const versions = Object.values(ConsensusProtocolVersion)
+        .filter((el) => typeof el === 'number').map((el) => +el);
+      const geVersion = Math.min(...versions).toString();
+      const ltVersion = (Math.max(...versions) + 1).toString();
+      throw new UnsupportedVersionError('consensus protocol', version, geVersion, ltVersion);
+    }
+
     return {
       url: this.$host,
       nodeNetworkId,
-      version,
+      version: nodeVersion,
       consensusProtocolVersion,
     };
   }

--- a/src/aepp-wallet-communication/rpc/types.ts
+++ b/src/aepp-wallet-communication/rpc/types.ts
@@ -9,7 +9,7 @@ export interface WalletInfo {
   id: string;
   name: string;
   networkId: string;
-  origin: string;
+  origin: string; // TODO: origin needs to be provided by transport
   type: WALLET_TYPE;
 }
 

--- a/src/aepp-wallet-communication/wallet-detector.ts
+++ b/src/aepp-wallet-communication/wallet-detector.ts
@@ -34,12 +34,15 @@ export default (
     const wallet = {
       info: params,
       getConnection() {
-        const isExtension = params.type === 'extension';
         return new BrowserWindowMessageConnection({
-          sendDirection: isExtension ? MESSAGE_DIRECTION.to_waellet : undefined,
-          receiveDirection: isExtension ? MESSAGE_DIRECTION.to_aepp : undefined,
           target: source,
-          origin: isExtension ? window.origin : params.origin,
+          ...params.type === 'extension' ? {
+            sendDirection: MESSAGE_DIRECTION.to_waellet,
+            receiveDirection: MESSAGE_DIRECTION.to_aepp,
+            ...window.origin !== 'null' && { origin: window.origin },
+          } : {
+            origin: params.origin,
+          },
         });
       },
     };

--- a/src/aepp-wallet-communication/wallet-detector.ts
+++ b/src/aepp-wallet-communication/wallet-detector.ts
@@ -1,14 +1,11 @@
 import BrowserConnection from './connection/Browser';
 import BrowserWindowMessageConnection from './connection/BrowserWindowMessage';
 import { MESSAGE_DIRECTION, METHODS } from './schema';
+import { WalletInfo } from './rpc/types';
 import { UnsupportedPlatformError } from '../utils/errors';
 
 interface Wallet {
-  info: {
-    id: string;
-    type: string;
-    origin: string;
-  };
+  info: WalletInfo;
   getConnection: () => BrowserWindowMessageConnection;
 }
 interface Wallets { [key: string]: Wallet }
@@ -28,7 +25,7 @@ export default (
   const wallets: Wallets = {};
 
   connection.connect((
-    { method, params }: { method: string; params: Wallet['info'] },
+    { method, params }: { method: string; params: WalletInfo },
     origin: string,
     source: Window,
   ) => {

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -252,12 +252,12 @@ class Contract<M extends ContractMethodsBase> {
       code: this.$options.bytecode,
       ownerId,
     });
-    this.$options.address = buildContractIdByContractTx(tx);
     const { hash, ...other } = await this.#sendAndProcess(
       tx,
       'init',
       { ...opt, onAccount: opt.onAccount },
     );
+    this.$options.address = buildContractIdByContractTx(tx);
     return {
       ...other,
       ...other.result?.log != null && {

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -122,7 +122,7 @@ interface GetCallResultByHashReturnType<M extends ContractMethodsBase, Fn extend
  * const staticCallResult = await contractIns.$call('setState', [123], { callStatic: true })
  * ```
  * Also you can call contract like: `await contractIns.setState(123, options)`
- * Then sdk decide to make on-chain or static call(dry-run API) transaction based on function is
+ * Then sdk decide to make on-chain or static call (dry-run API) transaction based on function is
  * stateful or not
  */
 class Contract<M extends ContractMethodsBase> {

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -44,6 +44,7 @@ import {
 } from '../chain';
 import AccountBase from '../account/Base';
 import { TxUnpacked } from '../tx/builder/schema.generated';
+import { isAccountNotFoundError } from '../utils/other';
 
 type ContractAci = NonNullable<Aci[0]['contract']>;
 type FunctionAci = ContractAci['functions'][0];
@@ -332,10 +333,15 @@ class Contract<M extends ContractMethodsBase> {
     const callData = this._calldata.encode(this._name, fn, params);
 
     if (callStatic === true) {
-      if (opt.nonce == null && top != null) {
-        const topKey = typeof top === 'number' ? 'height' : 'hash';
-        opt.nonce = (await getAccount(callerId, { [topKey]: top, onNode })).nonce + 1;
+      if (opt.nonce == null) {
+        const topOption = top != null && { [typeof top === 'number' ? 'height' : 'hash']: top };
+        const account = await getAccount(callerId, { ...topOption, onNode }).catch((error) => {
+          if (!isAccountNotFoundError(error)) throw error;
+          return { kind: 'basic', nonce: 0 };
+        });
+        opt.nonce = account.kind === 'generalized' ? 0 : account.nonce + 1;
       }
+
       const txOpt = { ...opt, onNode, callData };
       let tx;
       if (fn === 'init') {

--- a/src/contract/compiler/Cli.ts
+++ b/src/contract/compiler/Cli.ts
@@ -17,14 +17,19 @@ const getPackagePath = (): string => {
 };
 
 /**
- * A wrapper around aesophia_cli, available only in Node.js
- * Assumes that `escript` is available in PATH.
+ * A wrapper around aesophia_cli, available only in Node.js.
+ * Requires Erlang installed, assumes that `escript` is available in PATH.
  */
 export default class CompilerCli extends CompilerBase {
   #path: string;
 
   #ensureCompatibleVersion = Promise.resolve();
 
+  /**
+   * @param compilerPath - A path to aesophia_cli binary, by default uses the integrated one
+   * @param options - Options
+   * @param options.ignoreVersion - Don't ensure that the compiler is supported
+   */
   constructor(
     compilerPath = resolve(getPackagePath(), './bin/aesophia_cli'),
     { ignoreVersion }: { ignoreVersion?: boolean } = {},

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -1,3 +1,6 @@
+import { TypeResolver, ContractByteArrayEncoder } from '@aeternity/aepp-calldata';
+import { AciValue } from './utils/typed-data';
+import { Encoded } from './utils/encoder';
 import { RpcError } from './aepp-wallet-communication/schema';
 
 /**
@@ -21,3 +24,19 @@ export class RpcBroadcastError extends RpcError {
  * @deprecated use isAuctionName instead
  */
 export const NAME_BID_MAX_LENGTH = 12; // # this is the max length for a domain to be part of a bid
+
+/**
+ * @deprecated use ContractByteArrayEncoder:encodeWithType from \@aeternity/aepp-calldata
+ */
+export function encodeFateValue(value: unknown, aci: AciValue): Encoded.ContractBytearray {
+  const valueType = new TypeResolver().resolveType(aci, {});
+  return new ContractByteArrayEncoder().encodeWithType(value, valueType);
+}
+
+/**
+ * @deprecated use ContractByteArrayEncoder:decodeWithType from \@aeternity/aepp-calldata
+ */
+export function decodeFateValue(value: Encoded.ContractBytearray, aci: AciValue): any {
+  const valueType = new TypeResolver().resolveType(aci, {});
+  return new ContractByteArrayEncoder().decodeWithType(value, valueType);
+}

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -7,7 +7,6 @@ import { RpcError } from './aepp-wallet-communication/schema';
  * @category exception
  * @deprecated this exception is not thrown anymore
  */
-// eslint-disable-next-line import/prefer-default-export
 export class RpcBroadcastError extends RpcError {
   static override code = 3;
 

--- a/src/index-browser.ts
+++ b/src/index-browser.ts
@@ -43,9 +43,7 @@ export {
 export {
   encode, decode, Encoding, Encoded,
 } from './utils/encoder';
-export {
-  encodeFateValue, decodeFateValue, hashTypedData, hashDomain, hashJson,
-} from './utils/typed-data';
+export { hashTypedData, hashDomain, hashJson } from './utils/typed-data';
 export {
   aensRevoke, aensUpdate, aensTransfer, aensQuery, aensClaim, aensPreclaim, aensBid,
 } from './aens';
@@ -111,4 +109,6 @@ export {
   TagNotFoundError, TxNotInChainError, AlreadyConnectedError, NoWalletConnectedError,
   RpcConnectionError,
 } from './utils/errors';
-export { RpcBroadcastError, NAME_BID_MAX_LENGTH } from './deprecated';
+export {
+  RpcBroadcastError, NAME_BID_MAX_LENGTH, encodeFateValue, decodeFateValue,
+} from './deprecated';

--- a/src/tx/builder/constants.ts
+++ b/src/tx/builder/constants.ts
@@ -74,6 +74,7 @@ export enum VmVersion {
   Fate = 5,
   SophiaImprovementsLima = 6,
   Fate2 = 7,
+  Fate3 = 8,
 }
 
 /**

--- a/src/tx/builder/field-types/ct-version.ts
+++ b/src/tx/builder/field-types/ct-version.ts
@@ -19,7 +19,7 @@ export const ProtocolToVmAbi = {
   },
   [ConsensusProtocolVersion.Ceres]: {
     'contract-create': {
-      vmVersion: [VmVersion.Fate2], abiVersion: [AbiVersion.Fate],
+      vmVersion: [VmVersion.Fate3], abiVersion: [AbiVersion.Fate],
     },
     'contract-call': {
       vmVersion: [], abiVersion: [AbiVersion.Fate],

--- a/src/tx/builder/field-types/fee.ts
+++ b/src/tx/builder/field-types/fee.ts
@@ -156,7 +156,7 @@ export default {
     const value = new BigNumber(_value ?? minFee);
     if (minFee.gt(value)) {
       if (_pickBiggerFee === true) return minFee.toFixed();
-      throw new IllegalArgumentError(`Fee ${value.toString()} must be bigger then ${minFee}`);
+      throw new IllegalArgumentError(`Fee ${value.toString()} must be bigger than ${minFee}`);
     }
     return value.toFixed();
   },

--- a/src/tx/builder/field-types/gas-price.ts
+++ b/src/tx/builder/field-types/gas-price.ts
@@ -7,7 +7,7 @@ export default {
 
   serializeAettos(value: string | undefined = MIN_GAS_PRICE.toString()): string {
     if (+value < MIN_GAS_PRICE) {
-      throw new IllegalArgumentError(`Gas price ${value.toString()} must be bigger then ${MIN_GAS_PRICE}`);
+      throw new IllegalArgumentError(`Gas price ${value.toString()} must be bigger than ${MIN_GAS_PRICE}`);
     }
     return value;
   },

--- a/src/utils/autorest.ts
+++ b/src/utils/autorest.ts
@@ -15,10 +15,10 @@ export const genRequestQueuesPolicy = (): AdditionalPolicyConfig => {
         request.headers.delete('__queue');
         const getResponse = async (): Promise<PipelineResponse> => next(request);
         if (key == null) return getResponse();
-        const req = (requestQueues.get(key) ?? Promise.resolve()).then(getResponse, getResponse);
-        // TODO: remove after fixing https://github.com/aeternity/aeternity/issues/3803
+        const req = (requestQueues.get(key) ?? Promise.resolve()).then(getResponse);
+        // TODO: remove pause after fixing https://github.com/aeternity/aeternity/issues/3803
         // gap to ensure that node won't reject the nonce
-        requestQueues.set(key, req.then(async () => pause(750)));
+        requestQueues.set(key, req.then(async () => pause(750), () => {}));
         return req;
       },
     },

--- a/src/utils/autorest.ts
+++ b/src/utils/autorest.ts
@@ -119,7 +119,7 @@ export const genRetryOnFailurePolicy = (
   policy: {
     name: 'retry-on-failure',
     async sendRequest(request, next) {
-      const statusesToNotRetry = [200, 400, 403];
+      const statusesToNotRetry = [200, 400, 403, 500];
 
       const intervals = new Array(retryCount).fill(0)
         .map((_, idx) => ((idx + 1) / retryCount) ** 2);

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -190,7 +190,7 @@ export function verifyMessage(
 /**
  * Check key pair for validity
  *
- * Sign a message, and then verifying that signature
+ * Signs a message, and then verifies that signature
  * @param privateKey - Private key to verify
  * @param publicKey - Public key to verify as hex string
  * @returns Valid?

--- a/test/environment/browser-aepp.html
+++ b/test/environment/browser-aepp.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SDK test in browser</title>
+</head>
+<body>
+Open developer console
+<script src="../../dist/aepp-sdk.browser-script.js"></script>
+<script type="text/javascript">
+const { Node, AeSdkAepp, CompilerHttp, walletDetector, BrowserWindowMessageConnection } = Aeternity;
+
+const contractSourceCode = `
+contract Test =
+ entrypoint getArg(x : map(string, int)) = x
+`;
+const aeSdk = new AeSdkAepp({
+  name: 'Simple æpp',
+  nodes: [
+    { name: 'testnet', instance: new Node('https://testnet.aeternity.io') },
+    { name: 'mainnet', instance: new Node('https://mainnet.aeternity.io') },
+  ],
+  onCompiler: new CompilerHttp('https://v7.compiler.aepps.com'),
+  async onNetworkChange({ networkId }) {
+    const [{ name }] = (await this.getNodesInPool())
+      .filter((node) => node.nodeNetworkId === networkId);
+    this.selectNode(name);
+  },
+});
+
+async function detectWallets() {
+  const connection = new BrowserWindowMessageConnection();
+  return new Promise((resolve, reject) => {
+    const stopDetection = walletDetector(connection, async ({ newWallet }) => {
+      if (confirm(`Do you want to connect to wallet ${newWallet.info.name} with id ${newWallet.info.id}`)) {
+        stopDetection();
+        resolve(newWallet.getConnection());
+      }
+    });
+  });
+}
+
+(async () => {
+  console.log('Looking for a wallet');
+  const connection = await detectWallets();
+  const walletInfo = await aeSdk.connectToWallet(connection);
+  console.log('Connected to', walletInfo);
+  const { address: { current } } = await aeSdk.subscribeAddress('subscribe', 'connected');
+  console.log('Address from wallet', current);
+
+  console.log('Height:', await aeSdk.getHeight());
+  console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map);
+
+  const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+  const deployInfo = await contract.$deploy([]);
+  console.log('Contract deployed at', deployInfo.address);
+  const map = new Map([['foo', 42], ['bar', 43]]);
+  const { decodedResult } = await contract.getArg(map);
+  console.log('Call result', decodedResult);
+  console.log('Instanceof works correctly for returned map', decodedResult instanceof Map);
+})();
+</script>
+</body>
+</html>

--- a/test/integration/node.ts
+++ b/test/integration/node.ts
@@ -1,8 +1,11 @@
 import { describe, it, before } from 'mocha';
 import { expect } from 'chai';
+import { createSandbox } from 'sinon';
 import { PipelineRequest, PipelineResponse, SendRequest } from '@azure/core-rest-pipeline';
 import { url, ignoreVersion } from '.';
-import { AeSdkBase, Node, NodeNotFoundError } from '../../src';
+import {
+  AeSdkBase, Node, NodeNotFoundError, ConsensusProtocolVersion,
+} from '../../src';
 
 describe('Node client', () => {
   let node: Node;
@@ -47,6 +50,15 @@ describe('Node client', () => {
     node.pipeline.removePolicy({ name: 'counter' });
     expect(counter).to.be.equal(requestCount);
   }, Promise.resolve()));
+
+  it('throws exception if unsupported protocol', async () => {
+    const sandbox = createSandbox();
+    sandbox.stub(ConsensusProtocolVersion, 'Iris').value(undefined);
+    sandbox.stub(ConsensusProtocolVersion, '5' as 'Iris').value(undefined);
+    await expect(node.getNodeInfo()).to.be
+      .rejectedWith('Unsupported consensus protocol version 5. Supported: >= 6 < 7');
+    sandbox.restore();
+  });
 
   describe('Node Pool', () => {
     it('Throw error on using API without node', () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -12,8 +12,7 @@ export function randomString(len: number): string {
   return string;
 }
 
-// eslint-disable-next-line import/prefer-default-export
-export function randomName(length: number): AensName {
+export function randomName(length: number = 15): AensName {
   return `${randomString(length)}.chain`;
 }
 


### PR DESCRIPTION
## [13.2.2](https://github.com/aeternity/aepp-sdk-js/compare/v13.2.1...v13.2.2) (2023-09-20)


### Bug Fixes

* use proper vm version in Ceres ([bcaa5cf](https://github.com/aeternity/aepp-sdk-js/commit/bcaa5cfe0f8a23a641d9db993b312e2d54cfdd60))
* **aepp,wallet:** connect to web-extension if opened over file:/// ([da6a025](https://github.com/aeternity/aepp-sdk-js/commit/da6a0257e995db38e32888390961eb870a482777))
* **aepp:** use complete type of WalletInfo object ([eeba565](https://github.com/aeternity/aepp-sdk-js/commit/eeba56576b97afda6739fa8cd0f9e5c6f039651f))
* **contract:** don't mark contract as deployed if tx failed ([cc4222d](https://github.com/aeternity/aepp-sdk-js/commit/cc4222db8dc979c878e6e51bea9634484b826de7))
* **contract:** use current nonce in static calls ([758bdfc](https://github.com/aeternity/aepp-sdk-js/commit/758bdfc75a1dd8e4ff0646ddeaa10e19b1a4d5d1))
* **node:** don't retry 500 code responses ([696e7db](https://github.com/aeternity/aepp-sdk-js/commit/696e7db88605a385789d741f2704aba2c1cee972))
* **node:** throw clear error message if unsupported protocol ([21dfe34](https://github.com/aeternity/aepp-sdk-js/commit/21dfe34b3645d95b4c54d99e8517a33634b3751f))
* **node:** uncatchable exception if request failed in queue ([dec62a4](https://github.com/aeternity/aepp-sdk-js/commit/dec62a474cad4639b81cbef46ff606c384f7ab53))
* typos in error messages and docs ([5c84671](https://github.com/aeternity/aepp-sdk-js/commit/5c846712a32a110e1a5df25d5c4366046d9558f5))

This PR is supported by the Æternity Crypto Foundation