### PR TITLE
Remove AeSdk:initializeContract

### DIFF
--- a/docs/guides/contracts.md
+++ b/docs/guides/contracts.md
@@ -53,11 +53,13 @@ Note:
 
 ## 4. Initialize the contract instance
 
+To do so, we need to prepare an options object, which can be done in multiple ways.
+
 ### By source code
 
 ```js
 const sourceCode = ... // source code of the contract
-const contract = await aeSdk.initializeContract({ sourceCode })
+const options = { sourceCode }
 ```
 
 Note:
@@ -65,14 +67,14 @@ Note:
 - If your contract includes external dependencies which are not part of the [standard library](https://docs.aeternity.com/aesophia/latest/sophia_stdlib) you should initialize the contract using:
   ```js
   const fileSystem = ... // key-value map with name of the include as key and source code of the include as value
-  const contract = await aeSdk.initializeContract({ sourceCode, fileSystem })
+  const options = { sourceCode, fileSystem }
   ```
 
 ### By path to source code (available only in Node.js)
 It can be used with both CompilerCli and CompilerHttp. This way contract imports would be handled automatically, with no need to provide `fileSystem` option.
 ```js
 const sourceCodePath = './example.aes'
-const contract = await aeSdk.initializeContract({ sourceCodePath })
+const options = { sourceCodePath }
 ```
 
 ### By ACI and bytecode
@@ -81,7 +83,7 @@ If you pre-compiled the contracts you can also initialize a contract instance by
 ```js
 const aci = ... // ACI of the contract
 const bytecode = ... // bytecode of the contract
-const contract = await aeSdk.initializeContract({ aci, bytecode })
+const options = { aci, bytecode }
 ```
 
 ### By ACI and contract address
@@ -90,12 +92,19 @@ In many cases an application doesn't need to deploy a contract or verify its byt
 ```js
 const aci = ... // ACI of the contract
 const address = ... // the address of the contract
-const contract = await aeSdk.initializeContract({ aci, address })
+const options = { aci, address }
 ```
+
+### Create contract instance
+Do it by `Contract::initialize`.
+```js
+const contract = await Contract.initialize({ ...aeSdk.getContext(), ...options })
+```
+`AeSdk:getContext` is used to get base options to instantiate contracts. These options include the current account, node, and compiler. They are referenced using Proxy class, pointing to the latest values specified in AeSdk. So, if you change the selected node in the AeSdk instance, it will be also changed in bound contract instances.
 
 ### Options
 
-- Following attributes can be provided via `options` to `initializeContract`:
+- Following attributes can be provided via `options` to `Contract::initialize`:
     - `aci` (default: obtained via `onCompiler`)
         - The Contract ACI.
     - `address`

--- a/examples/browser/aepp/src/Contracts.vue
+++ b/examples/browser/aepp/src/Contracts.vue
@@ -66,6 +66,7 @@
 <script>
 import { shallowRef } from 'vue';
 import { mapState } from 'vuex';
+import { Contract } from '@aeternity/aepp-sdk';
 import Value from './components/Value.vue';
 import FieldAction from './components/FieldAction.vue';
 
@@ -95,7 +96,9 @@ export default {
     async create() {
       // Contract instance can't be in deep reactive https://github.com/aeternity/aepp-sdk-js/blob/develop/docs/README.md#vue3
       this.contract = shallowRef(
-        await this.aeSdk.initializeContract({ sourceCode: this.contractSourceCode }),
+        await Contract.initialize({
+          ...this.aeSdk.getContext(), sourceCode: this.contractSourceCode,
+        }),
       );
     },
     async compile() {

--- a/examples/node/contract-interaction.mjs
+++ b/examples/node/contract-interaction.mjs
@@ -12,7 +12,7 @@
 //
 // You need to import `AeSdk`, `Node` and `MemoryAccount` classes from the SDK.
 import {
-  AeSdk, CompilerHttp, Node, MemoryAccount,
+  AeSdk, Contract, CompilerHttp, Node, MemoryAccount,
 } from '@aeternity/aepp-sdk';
 
 // **Note**:
@@ -55,7 +55,9 @@ const aeSdk = new AeSdk({
 // Knowing the source code allows you to initialize a contract instance and interact with the
 // contract in a convenient way.
 console.log(CONTRACT_SOURCE_CODE);
-const contract = await aeSdk.initializeContract({ sourceCode: CONTRACT_SOURCE_CODE });
+const contract = await Contract.initialize({
+  ...aeSdk.getOptions(), sourceCode: CONTRACT_SOURCE_CODE,
+});
 
 // ## 5. Compile the contract
 // The `$compile` function sends a raw Sophia contract as string

--- a/examples/node/paying-for-contract-call-tx.mjs
+++ b/examples/node/paying-for-contract-call-tx.mjs
@@ -31,7 +31,7 @@
 // You need to import `AeSdk`, `Node` and `MemoryAccount` classes from the SDK.
 // Additionally you import the `generateKeyPair` utility function to generate a new keypair.
 import {
-  AeSdk, CompilerHttp, Node, MemoryAccount, Tag,
+  AeSdk, Contract, CompilerHttp, Node, MemoryAccount, Tag,
 } from '@aeternity/aepp-sdk';
 
 // **Note**:
@@ -100,9 +100,9 @@ const aeSdk = new AeSdk({
 //  1. Sign the transaction by providing `innerTx: true` as transaction option.
 //      - The transaction will be signed in a special way that is required for inner transactions.
 //
-const contract = await aeSdk.initializeContract(
-  { sourceCode: CONTRACT_SOURCE_CODE, address: CONTRACT_ADDRESS },
-);
+const contract = await Contract.initialize({
+  ...aeSdk.getContext(), sourceCode: CONTRACT_SOURCE_CODE, address: CONTRACT_ADDRESS,
+});
 const calldata = contract._calldata.encode('PayingForTxExample', 'set_last_caller', []);
 const contractCallTx = await aeSdk.buildTx({
   tag: Tag.ContractCallTx,

--- a/src/AeSdkMethods.ts
+++ b/src/AeSdkMethods.ts
@@ -3,7 +3,6 @@ import { sendTransaction } from './send-transaction';
 import * as aensMethods from './aens';
 import * as spendMethods from './spend';
 import * as oracleMethods from './oracle';
-import Contract, { ContractMethodsBase } from './contract/Contract';
 import createDelegationSignature from './contract/delegation-signature';
 import * as contractGaMethods from './contract/ga';
 import { buildTxAsync } from './tx/builder';
@@ -92,12 +91,6 @@ class AeSdkMethods {
   // TODO: omit onNode from options, because it is already in context
   async buildTx(options: TxParamsAsync): Promise<Encoded.Transaction> {
     return buildTxAsync({ ...this.getContext(), ...options });
-  }
-
-  async initializeContract<Methods extends ContractMethodsBase>(
-    options?: Omit<Parameters<typeof Contract.initialize>[0], 'onNode'> & { onNode?: Node },
-  ): Promise<Contract<Methods>> {
-    return Contract.initialize<Methods>(this.getContext(options as AeSdkMethodsOptions));
   }
 }
 

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -119,7 +119,7 @@ interface GetCallResultByHashReturnType<M extends ContractMethodsBase, Fn extend
  * @returns JS Contract API
  * @example
  * ```js
- * const contractIns = await aeSdk.initializeContract({ sourceCode })
+ * const contractIns = await Contract.initialize({ ...aeSdk.getContext(), sourceCode })
  * await contractIns.$deploy([321]) or await contractIns.init(321)
  * const callResult = await contractIns.$call('setState', [123])
  * const staticCallResult = await contractIns.$call('setState', [123], { callStatic: true })

--- a/test/environment/browser-aepp.html
+++ b/test/environment/browser-aepp.html
@@ -8,7 +8,9 @@
 Open developer console
 <script src="../../dist/aepp-sdk.browser-script.js"></script>
 <script type="text/javascript">
-const { Node, AeSdkAepp, CompilerHttp, walletDetector, BrowserWindowMessageConnection } = Aeternity;
+const {
+  Node, AeSdkAepp, CompilerHttp, walletDetector, BrowserWindowMessageConnection, Contract,
+} = Aeternity;
 
 const contractSourceCode = `
 contract Test =
@@ -52,7 +54,9 @@ async function detectWallets() {
   console.log('Height:', await aeSdk.getHeight());
   console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map);
 
-  const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+  const contract = await Contract.initialize({
+    ...aeSdk.getContext(), sourceCode: contractSourceCode,
+  });
   const deployInfo = await contract.$deploy([]);
   console.log('Contract deployed at', deployInfo.address);
   const map = new Map([['foo', 42], ['bar', 43]]);

--- a/test/environment/browser.html
+++ b/test/environment/browser.html
@@ -8,7 +8,7 @@
 Open developer console
 <script src="../../dist/aepp-sdk.browser-script.js"></script>
 <script type="text/javascript">
-const { Node, AeSdk, MemoryAccount, CompilerHttp } = Aeternity;
+const { Node, AeSdk, MemoryAccount, CompilerHttp, Contract } = Aeternity;
 
 const contractSourceCode = `
 contract Test =
@@ -27,7 +27,9 @@ const aeSdk = new AeSdk({
   console.log('Height:', await aeSdk.getHeight());
   console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map);
 
-  const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+  const contract = await Contract.initialize({
+    ...aeSdk.getContext(), sourceCode: contractSourceCode,
+  });
   const deployInfo = await contract.$deploy([]);
   console.log('Contract deployed at', deployInfo.address);
   const map = new Map([['foo', 42], ['bar', 43]]);

--- a/test/environment/ledger/main.mjs
+++ b/test/environment/ledger/main.mjs
@@ -1,5 +1,5 @@
 import {
-  Node, AeSdk, CompilerHttp, AccountLedgerFactory,
+  Node, AeSdk, CompilerHttp, AccountLedgerFactory, Contract,
 // eslint-disable-next-line import/extensions
 } from '../../../es/index.mjs';
 
@@ -27,7 +27,9 @@ export default async function run(transport) {
 contract Test =
  entrypoint getArg(x : int) = x + 1
 `;
-  const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+  const contract = await Contract.initialize({
+    ...aeSdk.getContext(), sourceCode: contractSourceCode,
+  });
   const deployInfo = await contract.$deploy([]);
   console.log('Contract deployed at', deployInfo.address);
 

--- a/test/environment/node.js
+++ b/test/environment/node.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const {
-  Node, AeSdk, MemoryAccount, CompilerHttp,
+  Node, AeSdk, MemoryAccount, CompilerHttp, Contract,
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require('../../dist/aepp-sdk');
 
@@ -21,7 +21,9 @@ const aeSdk = new AeSdk({
   console.log('Height:', await aeSdk.getHeight());
   console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map);
 
-  const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+  const contract = await Contract.initialize({
+    ...aeSdk.getContext(), sourceCode: contractSourceCode,
+  });
   const deployInfo = await contract.$deploy([]);
   console.log('Contract deployed at', deployInfo.address);
   const map = new Map([['foo', 42], ['bar', 43]]);

--- a/test/environment/node.mjs
+++ b/test/environment/node.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import {
-  Node, AeSdk, MemoryAccount, CompilerHttp,
+  Node, AeSdk, MemoryAccount, CompilerHttp, Contract,
 // eslint-disable-next-line import/extensions
 } from '../../es/index.mjs';
 
@@ -20,7 +20,9 @@ const aeSdk = new AeSdk({
 console.log('Height:', await aeSdk.getHeight());
 console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map);
 
-const contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+const contract = await Contract.initialize({
+  ...aeSdk.getContext(), sourceCode: contractSourceCode,
+});
 const deployInfo = await contract.$deploy([]);
 console.log('Contract deployed at', deployInfo.address);
 const map = new Map([['foo', 42], ['bar', 43]]);

--- a/test/environment/node.ts
+++ b/test/environment/node.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env npx ts-node
 import {
-  Node, AeSdk, MemoryAccount, CompilerHttp,
+  Node, AeSdk, MemoryAccount, CompilerHttp, Contract,
 } from '../..';
 
 const contractSourceCode = `
@@ -20,9 +20,9 @@ const aeSdk = new AeSdk({
   console.log('Height:', await aeSdk.getHeight());
   console.log('Instanceof works correctly for nodes pool', aeSdk.pool instanceof Map);
 
-  const contract = await aeSdk.initializeContract<{
+  const contract = await Contract.initialize<{
     getArg: (x: Map<string, number | bigint | string>) => Map<string, bigint>;
-  }>({ sourceCode: contractSourceCode });
+  }>({ ...aeSdk.getContext(), sourceCode: contractSourceCode });
   const deployInfo = await contract.$deploy([]);
   console.log('Contract deployed at', deployInfo.address);
   const map = new Map([['foo', 42], ['bar', 43]]);

--- a/test/integration/AeSdkMethods.ts
+++ b/test/integration/AeSdkMethods.ts
@@ -2,7 +2,7 @@ import { describe, it, before } from 'mocha';
 import { expect } from 'chai';
 import { getSdk } from '.';
 import { assertNotNull } from '../utils';
-import { AeSdkMethods, AccountBase } from '../../src';
+import { AeSdkMethods, AccountBase, Contract } from '../../src';
 
 describe('AeSdkMethods', () => {
   let accounts: AccountBase[];
@@ -26,7 +26,8 @@ describe('AeSdkMethods', () => {
   });
 
   it('created contract remains connected to sdk', async () => {
-    const contract = await aeSdkMethods.initializeContract({
+    const contract = await Contract.initialize({
+      ...aeSdkMethods.getContext(),
       sourceCode: ''
       + 'contract Identity =\n'
       + '  entrypoint getArg(x : int) = x',

--- a/test/integration/account-generalized.ts
+++ b/test/integration/account-generalized.ts
@@ -51,7 +51,9 @@ describe('Generalized Account', () => {
     accountBeforeGa = Object.values(aeSdk.accounts)[0] as MemoryAccount;
     const { gaContractId } = await aeSdk.createGeneralizedAccount('authorize', [], { sourceCode });
     expect((await aeSdk.getAccount(gaAccountAddress)).kind).to.be.equal('generalized');
-    authContract = await aeSdk.initializeContract({ sourceCode, address: gaContractId });
+    authContract = await Contract.initialize({
+      ...aeSdk.getContext(), sourceCode, address: gaContractId,
+    });
   });
 
   it('Fail on make GA on already GA', async () => {
@@ -129,11 +131,12 @@ describe('Generalized Account', () => {
   // TODO: enable after resolving https://github.com/aeternity/aeternity/issues/4087
   // TODO: copy to examples/node/account-generalized.mjs
   it.skip('deploys and calls contract', async () => {
-    const contract = await aeSdk.initializeContract<{
+    const contract = await Contract.initialize<{
       init: (value: number) => void;
       getState: () => number;
       setState: (value: number) => void;
     }>({
+          ...aeSdk.getContext(),
           sourceCode: ''
             + 'contract Stateful =\n'
             + '  record state = { value: int }\n'

--- a/test/integration/aens.ts
+++ b/test/integration/aens.ts
@@ -5,7 +5,7 @@ import {
   assertNotNull, ensureEqual, randomName, randomString,
 } from '../utils';
 import {
-  AeSdk, generateKeyPair, buildContractId, computeBidFee, ensureName, produceNameId,
+  AeSdk, generateKeyPair, buildContractId, computeBidFee, ensureName, produceNameId, Contract,
   AensPointerContextError, encode, decode, Encoding, ContractMethodsBase, ConsensusProtocolVersion,
   unpackTx, Tag, buildTxHash,
 } from '../../src';
@@ -140,13 +140,15 @@ describe('Aens', () => {
     interface ContractApi extends ContractMethodsBase {
       getArg: (x: number) => bigint;
     }
-    let contract = await aeSdk.initializeContract<ContractApi>({ sourceCode });
+    let contract = await Contract.initialize<ContractApi>({ ...aeSdk.getContext(), sourceCode });
     await contract.$deploy([]);
     const nameObject = await aeSdk.aensQuery(name);
     assertNotNull(contract.$options.address);
     await nameObject.update({ contract_pubkey: contract.$options.address });
 
-    contract = await aeSdk.initializeContract<ContractApi>({ sourceCode, address: name });
+    contract = await Contract.initialize<ContractApi>({
+      ...aeSdk.getContext(), sourceCode, address: name,
+    });
     expect((await contract.getArg(42, { callStatic: true })).decodedResult).to.be.equal(42n);
     expect((await contract.getArg(42, { callStatic: false })).decodedResult).to.be.equal(42n);
   });

--- a/test/integration/chain.ts
+++ b/test/integration/chain.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 import { getSdk } from '.';
 import {
-  generateKeyPair, AeSdk, Tag, MemoryAccount, Encoded, Node,
+  generateKeyPair, AeSdk, Tag, MemoryAccount, Encoded, Node, Contract,
 } from '../../src';
 import { assertNotNull, bindRequestCounter } from '../utils';
 
@@ -177,7 +177,8 @@ describe('Node Chain', () => {
   it('ensure transactions mined', async () => Promise.all(transactions.map(async (hash) => aeSdkWithoutAccount.poll(hash))));
 
   it('multiple contract dry-runs calls at one request', async () => {
-    const contract = await aeSdk.initializeContract<{ foo: (x: number) => bigint }>({
+    const contract = await Contract.initialize<{ foo: (x: number) => bigint }>({
+      ...aeSdk.getContext(),
       sourceCode:
         'contract Test =\n'
         + '  entrypoint foo(x : int) = x * 100',

--- a/test/integration/channel.ts
+++ b/test/integration/channel.ts
@@ -821,7 +821,9 @@ async function waitForChannel(channel: Channel): Promise<void> {
       sign: responderSignTag,
     });
     await Promise.all([waitForChannel(initiatorCh), waitForChannel(responderCh)]);
-    contract = await aeSdkInitiatior.initializeContract({ sourceCode: contractSourceCode });
+    contract = await Contract.initialize({
+      ...aeSdkInitiatior.getContext(), sourceCode: contractSourceCode,
+    });
     const initiatorNewContract = sinon.spy();
     initiatorCh.on('newContract', initiatorNewContract);
     const responderNewContract = sinon.spy();

--- a/test/integration/contract-aci.ts
+++ b/test/integration/contract-aci.ts
@@ -207,8 +207,12 @@ describe('Contract instance', () => {
 
   it('generates by source code', async () => {
     aeSdk._options.gasPrice = 100;
-    testContract = await aeSdk.initializeContract<TestContractApi>({
-      sourceCode: testContractSourceCode, fileSystem, ttl: 0, gasLimit: 15000,
+    testContract = await Contract.initialize<TestContractApi>({
+      ...aeSdk.getContext(),
+      sourceCode: testContractSourceCode,
+      fileSystem,
+      ttl: 0,
+      gasLimit: 15000,
     });
     delete aeSdk._options.gasPrice;
     expect(testContract.$options.gasPrice).to.be.equal(100);
@@ -232,7 +236,8 @@ describe('Contract instance', () => {
   });
 
   it('compiles contract by sourceCodePath', async () => {
-    const ctr = await aeSdk.initializeContract({
+    const ctr = await Contract.initialize({
+      ...aeSdk.getContext(),
       aci: includesAci,
       sourceCodePath: './test/integration/contracts/Includes.aes',
     });
@@ -267,7 +272,8 @@ describe('Contract instance', () => {
   });
 
   it('can be deployed by source code path', async () => {
-    const contract = await aeSdk.initializeContract<{}>({
+    const contract = await Contract.initialize<{}>({
+      ...aeSdk.getContext(),
       sourceCodePath: './test/integration/contracts/Includes.aes',
     });
     await contract.$deploy([]);
@@ -316,8 +322,9 @@ describe('Contract instance', () => {
     ]);
     expect(nonce + 2).to.be.equal(nextNonce);
 
-    const contract = await sdk
-      .initializeContract({ aci: testContractAci, address: testContract.$options.address });
+    const contract = await Contract.initialize({
+      ...sdk.getContext(), aci: testContractAci, address: testContract.$options.address,
+    });
     await contract.intFn(2, { callStatic: true });
   });
 
@@ -338,28 +345,39 @@ describe('Contract instance', () => {
     aeSdk.selectAccount(address1);
   });
 
-  it('generates by aci', async () => aeSdk.initializeContract({ aci: testContractAci, address: testContractAddress }));
+  it('generates by aci', async () => Contract.initialize({
+    ...aeSdk.getContext(), aci: testContractAci, address: testContractAddress,
+  }));
 
-  it('fails on trying to generate with not existing contract address', () => expect(aeSdk.initializeContract(
-    { sourceCode: identityContractSourceCode, address: notExistingContractAddress },
-  )).to.be.rejectedWith(`v3/contracts/${notExistingContractAddress} error: Contract not found`));
+  it('fails on trying to generate with not existing contract address', () => expect(
+    Contract.initialize({
+      ...aeSdk.getContext(),
+      sourceCode: identityContractSourceCode,
+      address: notExistingContractAddress,
+    }),
+  ).to.be.rejectedWith(`v3/contracts/${notExistingContractAddress} error: Contract not found`));
 
-  it('fails on trying to generate with invalid address', () => expect(aeSdk.initializeContract(
-    { sourceCode: identityContractSourceCode, address: 'ct_asdasdasd' },
-  )).to.be.rejectedWith(InvalidAensNameError, 'Invalid name or address: ct_asdasdasd'));
+  it('fails on trying to generate with invalid address', () => expect(
+    Contract.initialize({
+      ...aeSdk.getContext(), sourceCode: identityContractSourceCode, address: 'ct_asdasdasd',
+    }),
+  ).to.be.rejectedWith(InvalidAensNameError, 'Invalid name or address: ct_asdasdasd'));
 
-  it('fails on trying to generate by aci without address', () => expect(aeSdk.initializeContract({ aci: testContractAci }))
-    .to.be.rejectedWith(MissingContractAddressError, 'Can\'t create instance by ACI without address'));
+  it('fails on trying to generate by aci without address', () => expect(
+    Contract.initialize({ ...aeSdk.getContext(), aci: testContractAci }),
+  ).to.be.rejectedWith(MissingContractAddressError, 'Can\'t create instance by ACI without address'));
 
-  it('generates by bytecode and aci', async () => aeSdk.initializeContract({ bytecode: testContractBytecode, aci: testContractAci }));
+  it('generates by bytecode and aci', async () => Contract.initialize({
+    ...aeSdk.getContext(), bytecode: testContractBytecode, aci: testContractAci,
+  }));
 
-  it('fails on generation without arguments', () => expect(aeSdk.initializeContract())
+  it('fails on generation without arguments', () => expect(Contract.initialize(aeSdk.getContext()))
     .to.be.rejectedWith(MissingContractDefError, 'Either ACI or sourceCode or sourceCodePath is required'));
 
   it('calls by aci', async () => {
-    const contract = await aeSdk.initializeContract<TestContractApi>(
-      { aci: testContractAci, address: testContract.$options.address },
-    );
+    const contract = await Contract.initialize<TestContractApi>({
+      ...aeSdk.getContext(), aci: testContractAci, address: testContract.$options.address,
+    });
     expect((await contract.intFn(3)).decodedResult).to.be.equal(3n);
   });
 
@@ -368,26 +386,27 @@ describe('Contract instance', () => {
     const fn = aci.at(-1)?.contract?.functions.find(({ name }) => name === 'intFn');
     assertNotNull(fn);
     fn.arguments.push(fn.arguments[0]);
-    const contract = await aeSdk.initializeContract<{
+    const contract = await Contract.initialize<{
       intFn: (a: InputNumber, b: InputNumber) => bigint;
-    }>({ aci, address: testContract.$options.address });
+    }>({ ...aeSdk.getContext(), aci, address: testContract.$options.address });
     await expect(contract.intFn(3, 2)).to.be
       .rejectedWith(ContractError, 'ACI doesn\'t match called contract. Error provided by node: Expected 1 arguments, got 2');
   });
 
   it('deploys and calls by bytecode and aci', async () => {
-    const contract = await aeSdk.initializeContract<TestContractApi>(
-      { bytecode: testContractBytecode, aci: testContractAci },
-    );
+    const contract = await Contract.initialize<TestContractApi>({
+      ...aeSdk.getContext(), bytecode: testContractBytecode, aci: testContractAci,
+    });
     await contract.$deploy(['test', 1]);
     expect((await contract.intFn(3)).decodedResult).to.be.equal(3n);
   });
 
   it('supports contract interfaces polymorphism', async () => {
-    const contract = await aeSdk.initializeContract<{
+    const contract = await Contract.initialize<{
       soundByDog: () => string;
       soundByCat: () => string;
     }>({
+          ...aeSdk.getContext(),
           sourceCode: ''
             + 'include "String.aes"\n'
             + '\n'
@@ -414,31 +433,37 @@ describe('Contract instance', () => {
     expect((await contract.soundByCat()).decodedResult).to.be.equal('animal sound: meow');
   });
 
-  it('accepts matching source code with enabled validation', async () => aeSdk.initializeContract({
+  it('accepts matching source code with enabled validation', async () => Contract.initialize({
+    ...aeSdk.getContext(),
     sourceCode: testContractSourceCode,
     fileSystem,
     address: testContractAddress,
     validateBytecode: true,
   }));
 
-  it('rejects not matching source code with enabled validation', () => expect(aeSdk.initializeContract({
+  it('rejects not matching source code with enabled validation', () => expect(Contract.initialize({
+    ...aeSdk.getContext(),
     sourceCode: identityContractSourceCode,
     address: testContractAddress,
     validateBytecode: true,
   })).to.be.rejectedWith(BytecodeMismatchError, 'Contract source code do not correspond to the bytecode deployed on the chain'));
 
-  it('accepts matching bytecode with enabled validation', async () => aeSdk.initializeContract({
+  it('accepts matching bytecode with enabled validation', async () => Contract.initialize({
+    ...aeSdk.getContext(),
     bytecode: testContractBytecode,
     aci: testContractAci,
     address: testContractAddress,
     validateBytecode: true,
   }));
 
-  it('rejects not matching bytecode with enabled validation', async () => expect(aeSdk.initializeContract({
-    ...await aeSdk.compilerApi.compileBySourceCode(identityContractSourceCode),
-    address: testContractAddress,
-    validateBytecode: true,
-  })).to.be.rejectedWith(BytecodeMismatchError, 'Contract bytecode do not correspond to the bytecode deployed on the chain'));
+  it('rejects not matching bytecode with enabled validation', async () => expect(
+    Contract.initialize({
+      ...aeSdk.getContext(),
+      ...await aeSdk.compilerApi.compileBySourceCode(identityContractSourceCode),
+      address: testContractAddress,
+      validateBytecode: true,
+    }),
+  ).to.be.rejectedWith(BytecodeMismatchError, 'Contract bytecode do not correspond to the bytecode deployed on the chain'));
 
   it('dry-runs init function', async () => {
     const { result, decodedResult } = await testContract
@@ -492,7 +517,8 @@ describe('Contract instance', () => {
   });
 
   it('pays to payable contract', async () => {
-    const contract = await aeSdk.initializeContract({
+    const contract = await Contract.initialize({
+      ...aeSdk.getContext(),
       sourceCode: ''
         + 'payable contract Main =\n'
         + '  record state = { key: int }\n'
@@ -549,9 +575,9 @@ describe('Contract instance', () => {
     let contract: Contract<TestContractApi>;
 
     before(async () => {
-      contract = await aeSdk.initializeContract(
-        { sourceCode: testContractSourceCode, fileSystem },
-      );
+      contract = await Contract.initialize({
+        ...aeSdk.getContext(), sourceCode: testContractSourceCode, fileSystem,
+      });
     });
 
     it('estimates gas by default for contract deployments', async () => {
@@ -562,9 +588,9 @@ describe('Contract instance', () => {
       expect(tx.gas).to.be.equal(200);
     });
 
-    it('overrides gas through initializeContract options for contract deployments', async () => {
-      const ct = await aeSdk.initializeContract<TestContractApi>({
-        sourceCode: testContractSourceCode, fileSystem, gasLimit: 300,
+    it('overrides gas through Contract options for contract deployments', async () => {
+      const ct = await Contract.initialize<TestContractApi>({
+        ...aeSdk.getContext(), sourceCode: testContractSourceCode, fileSystem, gasLimit: 300,
       });
       const { txData: { tx }, result } = await ct.$deploy(['test', 42]);
       assertNotNull(tx);
@@ -626,7 +652,8 @@ describe('Contract instance', () => {
     let eventResultLog: Events;
 
     before(async () => {
-      remoteContract = await aeSdk.initializeContract({
+      remoteContract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode: 'contract Remote =\n'
           + '  datatype event = RemoteEvent1(int) | RemoteEvent2(string, int) | Duplicate(int) | DuplicateSameType(int)\n'
           + '\n'
@@ -638,7 +665,8 @@ describe('Contract instance', () => {
       });
       await remoteContract.$deploy([]);
       assertNotNull(remoteContract.$options.address);
-      contract = await aeSdk.initializeContract({
+      contract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode: 'contract interface RemoteI =\n'
           + '  datatype event = RemoteEvent1(int) | RemoteEvent2(string, int) | Duplicate(int) | DuplicateSameType(int)\n'
           + '  entrypoint emitEvents: (bool) => unit\n'
@@ -777,7 +805,8 @@ describe('Contract instance', () => {
     });
 
     it('calls a contract that emits events with no defined events', async () => {
-      const c = await aeSdk.initializeContract<{ emitEvents: (f: boolean) => [] }>({
+      const c = await Contract.initialize<{ emitEvents: (f: boolean) => [] }>({
+        ...aeSdk.getContext(),
         sourceCode:
           'contract FooContract =\n'
           + '  entrypoint emitEvents(f: bool) = ()',

--- a/test/integration/contract.ts
+++ b/test/integration/contract.ts
@@ -27,8 +27,9 @@ describe('Contract', () => {
   });
 
   it('deploys precompiled bytecode', async () => {
-    identityContract = await aeSdk
-      .initializeContract({ bytecode, sourceCode: identitySourceCode });
+    identityContract = await Contract.initialize({
+      ...aeSdk.getContext(), bytecode, sourceCode: identitySourceCode,
+    });
     expect(await identityContract.$deploy([])).to.have.property('address');
   });
 
@@ -47,9 +48,10 @@ describe('Contract', () => {
   });
 
   it('Verify signature of 32 bytes in Sophia', async () => {
-    const signContract = await aeSdk.initializeContract<{
+    const signContract = await Contract.initialize<{
       verify: (data: Uint8Array, pub: Encoded.AccountAddress, sig: Uint8Array) => boolean;
     }>({
+          ...aeSdk.getContext(),
           sourceCode:
             'contract Sign ='
             + '\n  entrypoint verify (data: bytes(32), pub: address, sig: signature): bool ='
@@ -63,10 +65,11 @@ describe('Contract', () => {
   });
 
   it('Verify message in Sophia', async () => {
-    const signContract = await aeSdk.initializeContract<{
+    const signContract = await Contract.initialize<{
       message_to_hash: (message: string) => Uint8Array;
       verify: (message: string, pub: Encoded.AccountAddress, sig: Uint8Array) => boolean;
     }>({
+          ...aeSdk.getContext(),
           sourceCode:
             'include "String.aes"'
             + '\n'
@@ -135,7 +138,8 @@ describe('Contract', () => {
   });
 
   it('throws error on deploy', async () => {
-    const ct = await aeSdk.initializeContract({
+    const ct = await Contract.initialize({
+      ...aeSdk.getContext(),
       sourceCode:
         'contract Foo =\n'
         + '  entrypoint init() = abort("CustomErrorMessage")',
@@ -144,10 +148,11 @@ describe('Contract', () => {
   });
 
   it('throws errors on method call', async () => {
-    const ct = await aeSdk.initializeContract<{
+    const ct = await Contract.initialize<{
       failWithoutMessage: (x: Encoded.AccountAddress) => void;
       failWithMessage: () => void;
     }>({
+          ...aeSdk.getContext(),
           sourceCode:
             'contract Foo =\n'
             + '  payable stateful entrypoint failWithoutMessage(x : address) = Chain.spend(x, 1000000000)\n'
@@ -163,8 +168,8 @@ describe('Contract', () => {
 
   it('Dry-run without accounts', async () => {
     const sdk = await getSdk(0);
-    const contract = await sdk.initializeContract<IdentityContractApi>({
-      sourceCode: identitySourceCode, address: deployed.address,
+    const contract = await Contract.initialize<IdentityContractApi>({
+      ...sdk.getContext(), sourceCode: identitySourceCode, address: deployed.address,
     });
     const { result } = await contract.getArg(42);
     assertNotNull(result);
@@ -172,7 +177,8 @@ describe('Contract', () => {
   });
 
   it('Dry-run at specific height', async () => {
-    const contract = await aeSdk.initializeContract<{ call: () => void }>({
+    const contract = await Contract.initialize<{ call: () => void }>({
+      ...aeSdk.getContext(),
       sourceCode: 'contract Callable =\n'
         + '  record state = { wasCalled: bool }\n'
         + '\n'
@@ -225,10 +231,11 @@ describe('Contract', () => {
   });
 
   it('initializes contract state', async () => {
-    const contract = await aeSdk.initializeContract<{
+    const contract = await Contract.initialize<{
       init: (a: string) => void;
       retrieve: () => string;
     }>({
+          ...aeSdk.getContext(),
           sourceCode:
             'contract StateContract =\n'
             + '  record state = { value: string }\n'
@@ -250,7 +257,8 @@ describe('Contract', () => {
     let contract: Contract<{ sumNumbers: (x: number, y: number) => bigint }>;
 
     it('Can compiler contract with external deps', async () => {
-      contract = await aeSdk.initializeContract({
+      contract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode: contractWithLibSourceCode,
         fileSystem: {
           testLib:
@@ -262,8 +270,9 @@ describe('Contract', () => {
     });
 
     it('Throw error when try to compile contract without providing external deps', async () => {
-      await expect(aeSdk.initializeContract({ sourceCode: contractWithLibSourceCode }))
-        .to.be.rejectedWith('Couldn\'t find include file');
+      await expect(
+        Contract.initialize({ ...aeSdk.getContext(), sourceCode: contractWithLibSourceCode }),
+      ).to.be.rejectedWith('Couldn\'t find include file');
     });
 
     it('Can deploy contract with external deps', async () => {

--- a/test/integration/delegation.ts
+++ b/test/integration/delegation.ts
@@ -66,7 +66,8 @@ describe('Operation delegation', () => {
 
     before(async () => {
       aens = isIris ? 'AENS' : 'AENSv2';
-      contract = await aeSdk.initializeContract({
+      contract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode: `
 @compiler ${isIris ? '>= 7' : '>= 8'}
 @compiler ${isIris ? '< 8' : '< 9'}
@@ -237,7 +238,8 @@ contract DelegateTest =
     let contractAddress: Encoded.ContractAddress;
 
     before(async () => {
-      contract = await aeSdk.initializeContract({
+      contract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode:
           'contract DelegateTest =\n'
           + '  stateful payable entrypoint signedRegisterOracle(\n'

--- a/test/integration/paying-for.ts
+++ b/test/integration/paying-for.ts
@@ -64,19 +64,23 @@ describe('Paying for transaction of another account', () => {
       innerTx: true,
       ttl: 0,
     });
-    const contract: TestContract = await aeSdkNotPayingFee.initializeContract({ sourceCode });
+    const contract: TestContract = await Contract.initialize({
+      ...aeSdkNotPayingFee.getContext(), sourceCode,
+    });
     const { rawTx: contractDeployTx, address } = await contract.$deploy([42]);
     assertNotNull(address);
     contractAddress = address;
     await aeSdk.payForTransaction(contractDeployTx);
-    payingContract = await aeSdkNotPayingFee.initializeContract({ sourceCode, address });
+    payingContract = await Contract.initialize({
+      ...aeSdkNotPayingFee.getContext(), sourceCode, address,
+    });
     expect((await payingContract.getValue()).decodedResult).to.be.equal(42n);
   });
 
   it('pays for contract call', async () => {
-    const contract = await aeSdkNotPayingFee.initializeContract(
-      { sourceCode, address: contractAddress },
-    );
+    const contract = await Contract.initialize({
+      ...aeSdkNotPayingFee.getContext(), sourceCode, address: contractAddress,
+    });
     const { rawTx: contractCallTx } = await contract.setValue(43);
     await aeSdk.payForTransaction(contractCallTx);
     expect((await payingContract.getValue()).decodedResult).to.be.equal(43n);

--- a/test/integration/rpc.ts
+++ b/test/integration/rpc.ts
@@ -31,6 +31,7 @@ import {
   verifyMessage,
   buildTx,
   hashTypedData,
+  Contract,
 } from '../../src';
 import { getBufferToSign } from '../../src/account/Memory';
 import { ImplPostMessage } from '../../src/aepp-wallet-communication/connection/BrowserWindowMessage';
@@ -120,7 +121,8 @@ describe('Aepp<->Wallet', () => {
     });
 
     it('aepp can do static calls without connection to wallet', async () => {
-      const contract = await aeSdk.initializeContract({
+      const contract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode: 'contract Test =\n'
           + '  entrypoint getArg(x : int) = x',
       });
@@ -130,7 +132,8 @@ describe('Aepp<->Wallet', () => {
         nodes: [{ name: 'test', instance: node }],
         onCompiler: new CompilerHttp(compilerUrl),
       });
-      const contractAepp = await aeppSdk.initializeContract<{ getArg: (a: number) => number }>({
+      const contractAepp = await Contract.initialize<{ getArg: (a: number) => number }>({
+        ...aeppSdk.getContext(),
         aci: contract._aci,
         address: contract.$options.address,
       });

--- a/test/integration/transaction.ts
+++ b/test/integration/transaction.ts
@@ -50,7 +50,7 @@ describe('Transaction', () => {
 
   before(async () => {
     aeSdk = await getSdk(0);
-    contract = await aeSdk.initializeContract({ sourceCode: contractSourceCode });
+    contract = await Contract.initialize({ ...aeSdk.getContext(), sourceCode: contractSourceCode });
   });
 
   it('build spend tx using denomination amount', async () => {

--- a/test/integration/typed-data.ts
+++ b/test/integration/typed-data.ts
@@ -71,7 +71,8 @@ describe('typed data', () => {
       const typeJson = (canonicalize(recordAci) ?? '').replaceAll('"', '\\"');
       const isIris = (await aeSdk.api.getNodeInfo())
         .consensusProtocolVersion === ConsensusProtocolVersion.Iris;
-      contract = await aeSdk.initializeContract({
+      contract = await Contract.initialize({
+        ...aeSdk.getContext(),
         sourceCode: ''
           + '\ninclude "String.aes"'
           + '\ninclude "Option.aes"'


### PR DESCRIPTION
AeSdk:initializeContract makes AeSdk to depend on Contract, and to depend on @aeternity/aepp-calldata eventually.

closes partially https://github.com/aeternity/aepp-sdk-js/issues/1839

This PR is supported by the Æternity Crypto Foundation