### PR TITLE
ci: use `docker-compose --wait` instead of custom script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,16 +27,11 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
         run: npx commitlint --from $BASE --to $HEAD --verbose
       - run: npm run lint
-      - run: docker-compose up -d
-      - name: Ensure that node is running
-        run: |
-          while [[ `curl -s -o /dev/null -w %{http_code} localhost:3013/api` != 200 ]]; do
-            sleep 0.2;
-          done
+      - run: docker compose up -d --wait
       - run: npx nyc npm run test
       - run: npx nyc report --reporter=text-lcov > coverage.lcov
       - uses: codecov/codecov-action@v3
         with:
           files: coverage.lcov
-      - run: docker-compose logs
+      - run: docker compose logs
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./docker/aeternity_node_mean16.yaml:/home/aeternity/node/aeternity.yaml
       - ./docker/accounts_test.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json
+    stop_grace_period: 0s
 
   compiler:
     image: aeternity/aesophia_http:v7.6.0

--- a/test/integration/Middleware.ts
+++ b/test/integration/Middleware.ts
@@ -25,9 +25,9 @@ describe('Middleware API', () => {
       mdwVersion: res.mdwVersion,
       nodeHeight: res.nodeHeight,
       nodeProgress: 100,
-      nodeRevision: '4d9fd25ad9d449c6e9805cd46a3cb8150fc4b6c1',
+      nodeRevision: res.nodeRevision,
       nodeSyncing: false,
-      nodeVersion: '6.11.0',
+      nodeVersion: res.nodeVersion,
     };
     expect(res).to.be.eql(expectedRes);
   });


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation