### PR TITLE
ci: set `healthcheck.interval` to run containers faster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: aeternity/aeternity:master@sha256:824d40d60fcf4a07d805bba6b6880e182331a971bb8e4793d45d66eaa5e568fa
     hostname: node
     ports: ["3013:3013", "3113:3113", "3014:3014", "3114:3114"]
+    # TODO: remove after releasing https://github.com/aeternity/aeternity/pull/4292
+    healthcheck:
+      interval: 2s
     volumes:
       - ./docker/aeternity_node_mean16.yaml:/home/aeternity/node/aeternity.yaml
       - ./docker/accounts_test.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json
@@ -13,8 +16,14 @@ services:
     image: aeternity/aesophia_http:v8.0.0-rc1
     hostname: compiler
     ports: ["3080:3080"]
+    # TODO: remove after releasing https://github.com/aeternity/aesophia_http/pull/133
+    healthcheck:
+      interval: 2s
 
   compiler-7:
     image: aeternity/aesophia_http:v7.6.1
     hostname: compiler-7
     ports: ["3081:3080"]
+    # TODO: remove after releasing https://github.com/aeternity/aesophia_http/pull/133
+    healthcheck:
+      interval: 2s


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

related https://github.com/aeternity/aeternity/pull/4292 https://github.com/aeternity/aesophia_http/pull/133