### PR TITLE
feat(aepp,wallet): allow raw data sign

### DIFF
--- a/docker/aeternity.yaml
+++ b/docker/aeternity.yaml
@@ -19,3 +19,6 @@ websocket:
 
 chain:
   persist: false
+  hard_forks:
+    "1": 0
+    "6": 1

--- a/examples/browser/aepp/src/Basic.vue
+++ b/examples/browser/aepp/src/Basic.vue
@@ -26,6 +26,8 @@
   <SpendCoins />
 
   <MessageSign />
+
+  <DataSign />
 </template>
 
 <script>
@@ -33,9 +35,12 @@ import { mapState } from 'vuex';
 import Value from './components/Value.vue';
 import SpendCoins from './components/SpendCoins.vue';
 import MessageSign from './components/MessageSign.vue';
+import DataSign from './components/DataSign.vue';
 
 export default {
-  components: { Value, SpendCoins, MessageSign },
+  components: {
+    Value, SpendCoins, MessageSign, DataSign,
+  },
   data: () => ({
     balancePromise: null,
     heightPromise: null,

--- a/examples/browser/aepp/src/components/DataSign.vue
+++ b/examples/browser/aepp/src/components/DataSign.vue
@@ -1,0 +1,76 @@
+<template>
+  <h2>Sign raw data (unsafe)</h2>
+  <div class="group">
+    <div>
+      <div>Data as text</div>
+      <div>
+        <input
+          :value="dataBuffer.toString()"
+          @input="setData($event.target.value)"
+          placeholder="Plain text"
+        >
+      </div>
+    </div>
+    <div>
+      <div>Data as hex</div>
+      <div>
+        <input
+          :value="dataBuffer.toString('hex')"
+          @input="setData($event.target.value, 'hex')"
+          placeholder="hex-encoded data"
+        >
+      </div>
+    </div>
+    <div>
+      <div>Data encoded</div>
+      <div>
+        <input
+          v-model="data"
+          placeholder="ba_-encoded data"
+        >
+      </div>
+    </div>
+    <button @click="() => { promise = dataSign(); }">
+      Sign data
+    </button>
+    <div v-if="promise">
+      <div>Data sign result</div>
+      <Value :value="promise" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { Buffer } from 'buffer';
+import { decode, encode, Encoding } from '@aeternity/aepp-sdk';
+import Value from './Value.vue';
+
+const emptyData = encode(Buffer.from([]), Encoding.Bytearray);
+
+export default {
+  components: { Value },
+  computed: {
+    ...mapState(['aeSdk']),
+    dataBuffer() {
+      try {
+        return Buffer.from(decode(this.data || emptyData));
+      } catch (error) {
+        return Buffer.from([]);
+      }
+    },
+  },
+  data: () => ({
+    data: '',
+    promise: null,
+  }),
+  methods: {
+    setData(data, type) {
+      this.data = encode(Buffer.from(data, type), Encoding.Bytearray);
+    },
+    dataSign() {
+      return this.aeSdk.sign(decode(this.data || emptyData));
+    },
+  },
+};
+</script>

--- a/examples/browser/wallet-iframe/src/App.vue
+++ b/examples/browser/wallet-iframe/src/App.vue
@@ -230,6 +230,13 @@ export default {
         return super.signOracleQueryDelegationToContract(contractAddress, oracleQueryId, options);
       }
 
+      async sign(data, { aeppRpcClientId: id, aeppOrigin, ...options } = {}) {
+        if (id != null) {
+          genConfirmCallback(`sign raw data ${data}`)(id, options, aeppOrigin);
+        }
+        return super.sign(data, options);
+      }
+
       async signDelegation(delegation, { aeppRpcClientId: id, aeppOrigin, ...options }) {
         if (id != null) {
           const opt = { ...options, ...unpackDelegation(delegation) };

--- a/examples/browser/wallet-web-extension/src/background.js
+++ b/examples/browser/wallet-web-extension/src/background.js
@@ -107,7 +107,7 @@ class AccountMemoryProtected extends MemoryAccount {
   ) {
     if (id != null) {
       const opt = { ...options, contractAddress };
-      genConfirmCallback('sign delegation of all names to contract')(id, opt, aeppOrigin);
+      await genConfirmCallback('sign delegation of all names to contract')(id, opt, aeppOrigin);
     }
     return super.signAllNamesDelegationToContract(contractAddress, options);
   }
@@ -122,6 +122,13 @@ class AccountMemoryProtected extends MemoryAccount {
       await genConfirmCallback('sign delegation of oracle query to contract')(id, opt, aeppOrigin);
     }
     return super.signOracleQueryDelegationToContract(contractAddress, oracleQueryId, options);
+  }
+
+  async sign(data, { aeppRpcClientId: id, aeppOrigin, ...options } = {}) {
+    if (id != null) {
+      await genConfirmCallback(`sign raw data ${data}`)(id, options, aeppOrigin);
+    }
+    return super.sign(data, options);
   }
 
   async signDelegation(delegation, { aeppRpcClientId: id, aeppOrigin, ...options }) {

--- a/src/AeSdkWallet.ts
+++ b/src/AeSdkWallet.ts
@@ -18,7 +18,9 @@ import {
   WalletApi,
   WalletInfo,
 } from './aepp-wallet-communication/rpc/types';
-import { Encoded } from './utils/encoder';
+import {
+  Encoded, Encoding, encode, decode,
+} from './utils/encoder';
 import jsonBig from './utils/json-big';
 
 type RpcClientWallet = RpcClient<AeppApi, WalletApi>;
@@ -320,6 +322,13 @@ export default class AeSdkWallet extends AeSdk {
                 .signAllNamesDelegationToContract(contractAddress, parameters))
               ?? this.signDelegationToContract(contractAddress, { ...parameters, isOracle })
             );
+            return { signature };
+          },
+          [METHODS.unsafeSign]: async ({ data, onAccount = this.address }, origin) => {
+            if (!this._isRpcClientConnected(id)) throw new RpcNotAuthorizeError();
+            if (!this.addresses().includes(onAccount)) throw new RpcPermissionDenyError(onAccount);
+            const parameters = { onAccount, aeppOrigin: origin, aeppRpcClientId: id };
+            const signature = encode(await this.sign(decode(data), parameters), Encoding.Signature);
             return { signature };
           },
           [METHODS.signDelegation]: async ({ delegation, onAccount = this.address }, origin) => {

--- a/src/account/Base.ts
+++ b/src/account/Base.ts
@@ -188,7 +188,13 @@ export default abstract class AccountBase {
    * @param options - Options
    * @returns Signature
    */
-  abstract sign(data: string | Uint8Array, options?: any): Promise<Uint8Array>;
+  abstract sign(
+    data: string | Uint8Array,
+    options?: {
+      aeppOrigin?: string;
+      aeppRpcClientId?: string;
+    },
+  ): Promise<Uint8Array>;
 
   /**
    * Account address

--- a/src/account/Rpc.ts
+++ b/src/account/Rpc.ts
@@ -1,7 +1,9 @@
 import AccountBase from './Base';
 import { METHODS } from '../aepp-wallet-communication/schema';
-import { ArgumentError, NotImplementedError, UnsupportedProtocolError } from '../utils/errors';
-import { Encoded } from '../utils/encoder';
+import { ArgumentError, UnsupportedProtocolError } from '../utils/errors';
+import {
+  Encoded, Encoding, decode, encode,
+} from '../utils/encoder';
 import RpcClient from '../aepp-wallet-communication/rpc/RpcClient';
 import { AeppApi, WalletApi } from '../aepp-wallet-communication/rpc/types';
 import { AensName, ConsensusProtocolVersion } from '../tx/builder/constants';
@@ -26,9 +28,11 @@ export default class AccountRpc extends AccountBase {
     this.address = address;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  async sign(): Promise<Uint8Array> {
-    throw new NotImplementedError('RAW signing using wallet');
+  async sign(dataRaw: string | Uint8Array): Promise<Uint8Array> {
+    const data = encode(Buffer.from(dataRaw), Encoding.Bytearray);
+    const { signature } = await this._rpcClient
+      .request(METHODS.unsafeSign, { onAccount: this.address, data });
+    return decode(signature);
   }
 
   override async signTransaction(

--- a/src/aepp-wallet-communication/rpc/types.ts
+++ b/src/aepp-wallet-communication/rpc/types.ts
@@ -46,6 +46,10 @@ export interface WalletApi {
 
   [METHODS.address]: () => Promise<Encoded.AccountAddress[]>;
 
+  [METHODS.unsafeSign]: (
+    p: { data: Encoded.Bytearray; onAccount: Encoded.AccountAddress }
+  ) => Promise<{ signature: Encoded.Signature }>;
+
   [METHODS.sign]: ((
     p: {
       tx: Encoded.Transaction;

--- a/src/aepp-wallet-communication/schema.ts
+++ b/src/aepp-wallet-communication/schema.ts
@@ -34,6 +34,7 @@ export const enum METHODS {
   updateAddress = 'address.update',
   address = 'address.get',
   connect = 'connection.open',
+  unsafeSign = 'data.unsafeSign',
   sign = 'transaction.sign',
   signMessage = 'message.sign',
   signTypedData = 'typedData.sign',

--- a/test/integration/chain.ts
+++ b/test/integration/chain.ts
@@ -50,7 +50,7 @@ describe('Node Chain', () => {
 
     it('uses correct cache key if node changed while doing request', async () => {
       const heightPromise = aeSdk.getHeight();
-      aeSdk.addNode('test-2', new Node('http://example.com'), true);
+      aeSdk.addNode('test-2', new Node('https://test.stg.aepps.com'), true);
       await heightPromise;
       await expect(aeSdk.getHeight({ cached: true }))
         .to.be.rejectedWith('v3/status error: 404 status code');

--- a/test/integration/node.ts
+++ b/test/integration/node.ts
@@ -103,7 +103,7 @@ describe('Node client', () => {
   });
 
   it('doesn\'t remember failed version request', async () => {
-    const n = new Node('http://example.com');
+    const n = new Node('https://test.stg.aepps.com');
     await expect(n.getTopHeader()).to.be.rejectedWith('v3/status error: 404 status code');
     n.$host = url;
     expect(await n.getTopHeader()).to.be.an('object');

--- a/test/unit/ledger.ts
+++ b/test/unit/ledger.ts
@@ -113,7 +113,7 @@ describe('Ledger HW', () => {
       addresses: Encoded.AccountAddress[] = [];
 
       constructor() {
-        super('http://example.com', { ignoreVersion: true });
+        super('https://test.stg.aepps.com', { ignoreVersion: true });
       }
 
       // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
The ability to sign raw data implemented as a fallback in case the payload that aepp needs to sign is not compatible with existing methods.

Wallet needs to warn user if it can't parse the data to sign. Or wallet can disable this method, to work only with a known payloads.

This PR is supported by the Æternity Foundation