### PR TITLE
fix(aepp): don't require subscription to request addresses

### DIFF
--- a/src/AeSdkAepp.ts
+++ b/src/AeSdkAepp.ts
@@ -146,7 +146,7 @@ export default class AeSdkAepp extends AeSdkBase {
    * @returns Addresses from wallet
    */
   async askAddresses(): Promise<Encoded.AccountAddress[]> {
-    this._ensureAccountAccess();
+    this._ensureConnected();
     return this.rpcClient.request(METHODS.address, undefined);
   }
 

--- a/test/integration/rpc.ts
+++ b/test/integration/rpc.ts
@@ -27,6 +27,7 @@ import {
   UnAuthorizedAccountError,
   UnknownRpcClientError,
   UnsubscribedAccountError,
+  RpcInternalError,
   AccountBase,
   verifyMessage,
   buildTx,
@@ -182,7 +183,9 @@ describe('Aepp<->Wallet', () => {
     });
 
     it('Try to ask for address', async () => {
-      await expect(aepp.askAddresses()).to.be.rejectedWith(UnsubscribedAccountError, 'You are not subscribed for an account.');
+      await expect(aepp.askAddresses()).to.be.rejectedWith(RpcInternalError, 'The peer failed to execute your request due to unknown error');
+      wallet.onAskAccounts = () => {};
+      expect(await aepp.askAddresses()).to.be.eql(wallet.addresses());
     });
 
     it('Try to sign and send transaction to wallet without subscription', async () => {
@@ -235,7 +238,7 @@ describe('Aepp<->Wallet', () => {
       expect(aepp.address).to.be.equal(account.address);
     });
 
-    it('Ask for address: subscribed for accounts -> wallet deny', async () => {
+    it('Ask for address: exception in onAskAccounts -> wallet deny', async () => {
       wallet.onAskAccounts = () => {
         throw new RpcRejectedByUserError();
       };
@@ -243,7 +246,7 @@ describe('Aepp<->Wallet', () => {
         .rejectedWith('Operation rejected by user').with.property('code', 4);
     });
 
-    it('Ask for address: subscribed for accounts -> wallet accept', async () => {
+    it('Ask for address: no exception in onAskAccounts -> wallet accept', async () => {
       let checkPromise;
       wallet.onAskAccounts = (id, params, origin) => {
         checkPromise = Promise.resolve().then(() => {


### PR DESCRIPTION
Because it is not checked/required on the other side.

This PR is supported by the Æternity Foundation