### PR TITLE
fix(aens): validate minus chars in name as aenode does

### DIFF
--- a/src/tx/builder/helpers.ts
+++ b/src/tx/builder/helpers.ts
@@ -70,6 +70,15 @@ export function nameToPunycode(maybeName: string): AensName {
   if (/\p{Emoji_Presentation}/u.test(name)) {
     throw new ArgumentError('aens name', 'not containing emoji', maybeName);
   }
+  if (name[2] === '-' && name[3] === '-') {
+    throw new ArgumentError('aens name', 'without "-" char in both the third and fourth positions', maybeName);
+  }
+  if (name[0] === '-') {
+    throw new ArgumentError('aens name', 'starting with no "-" char', maybeName);
+  }
+  if (name.at(-1) === '-') {
+    throw new ArgumentError('aens name', 'ending with no "-" char', maybeName);
+  }
   let punycode;
   try {
     const u = new URL(`http://${name}.${suffix}`);

--- a/test/unit/aens.ts
+++ b/test/unit/aens.ts
@@ -295,6 +295,18 @@ describe('AENS utils', () => {
       expect(() => ensureName('ldiDxa1Yxy1iiTRztYEN4F8nrnfZib3Q1MllPghmst8fjJ1sI3DXzOoAddE2ETxp.chain'))
         .to.throw(ArgumentError, 'aens name should be not too long, got ldiDxa1Yxy1iiTRztYEN4F8nrnfZib3Q1MllPghmst8fjJ1sI3DXzOoAddE2ETxp.chain instead');
     });
+
+    it('fails if name starts or ends with minus', () => {
+      expect(() => ensureName('-test.chain'))
+        .to.throw(ArgumentError, 'aens name should be starting with no "-" char, got -test.chain instead');
+      expect(() => ensureName('test-.chain'))
+        .to.throw(ArgumentError, 'aens name should be ending with no "-" char, got test-.chain instead');
+    });
+
+    it('fails if name has minus at 2, 3 chars', () => {
+      expect(() => ensureName('te--st.chain'))
+        .to.throw(ArgumentError, 'aens name should be without "-" char in both the third and fourth positions, got te--st.chain instead');
+    });
   });
 
   describe('isAuctionName', () => {


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

https://github.com/aeternity/protocol/blob/d634e7a3f3110657900759b183d0734e61e5803a/AENS.md#name
https://www.unicode.org/reports/tr46/#Validity_Criteria

https://testnet.aeternity.io/v3/names/-test.chain
https://testnet.aeternity.io/v3/names/test-.chain
https://testnet.aeternity.io/v3/names/te--st.chain