### PR TITLE
fix(tx-builder): count amount in execution cost when spend to yourself

### DIFF
--- a/src/tx/execution-cost.ts
+++ b/src/tx/execution-cost.ts
@@ -69,7 +69,7 @@ export function getExecutionCost(
     if (isInitiator === false) res -= BigInt(params.responderAmountFinal);
   }
   if (
-    ((params.tag === Tag.SpendTx && params.senderId !== params.recipientId)
+    (params.tag === Tag.SpendTx
     || params.tag === Tag.ContractCreateTx || params.tag === Tag.ContractCallTx
     || params.tag === Tag.ChannelDepositTx) && innerTx !== 'fee-payer'
   ) {

--- a/test/integration/~execution-cost.ts
+++ b/test/integration/~execution-cost.ts
@@ -39,7 +39,7 @@ describe('Execution cost', () => {
 
   it('calculates execution cost for spend tx', async () => {
     const { rawTx } = await aeSdk.spend(100, aeSdk.address, { ttl: 0 });
-    const expectedCost = 16660000000000n;
+    const expectedCost = 16660000000000n + 100n;
     expect(getExecutionCostBySignedTx(rawTx, networkId)).to.equal(expectedCost);
     expect(getExecutionCost(buildTx(unpackTx(rawTx, Tag.SignedTx).encodedTx)))
       .to.equal(expectedCost);
@@ -86,6 +86,8 @@ describe('Execution cost', () => {
           // Can't detect Oracle.respond reward in contract call
           if (balanceDiff === -501000n) return;
           expect(balanceDiff).to.be.equal(0n);
+        } else if (params.tag === Tag.SpendTx && params.senderId === params.recipientId) {
+          expect(balanceDiff).to.be.equal(BigInt(-params.amount));
         } else {
           expect(balanceDiff).to.be.equal(0n);
         }


### PR DESCRIPTION
closes #2016 

This PR is supported by the Æternity Foundation

Anyway the amount needs to be on balance to mine such transaction.