### PR TITLE
feat: show function name along its hash if missed in bytecode

### DIFF
--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -190,8 +190,12 @@ class Contract<M extends ContractMethodsBase> {
       case 'error':
         message = decode(returnValue).toString();
         if (/Expected \d+ arguments, got \d+/.test(message)) {
-          throw new ContractError(
-            `ACI doesn't match called contract. Error provided by node: ${message}`,
+          throw new BytecodeMismatchError('ACI', `. Error provided by node: "${message}".`);
+        }
+        if (/Trying to call undefined function: <<\d+,\d+,\d+,\d+>>/.test(message)) {
+          throw new BytecodeMismatchError(
+            'ACI',
+            `. Error provided by node: "${message}", function name: ${fnName}.`,
           );
         }
         break;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -449,8 +449,8 @@ export class InvalidAuthDataError extends CompilerError {
  * @category exception
  */
 export class BytecodeMismatchError extends ContractError {
-  constructor(source: 'source code' | 'bytecode') {
-    super(`Contract ${source} do not correspond to the bytecode deployed on the chain`);
+  constructor(source: 'source code' | 'bytecode' | 'ACI', details: string = '') {
+    super(`Contract ${source} do not correspond to the bytecode deployed on the chain` + details);
     this.name = 'BytecodeMismatchError';
   }
 }


### PR DESCRIPTION
This PR is supported by the Æternity Foundation