### PR TITLE
docs: fix example generation by doing files match in js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:api:middleware": "node tooling/autorest/middleware-prepare.js && autorest tooling/autorest/middleware.yaml && node tooling/autorest/postprocessing.js middleware",
     "build:generate": "tsx tooling/generate-schema.ts",
     "build": "run-p build:api:* build:assets build:generate && run-p build:dist build:es build:types",
-    "docs:examples": "node tooling/docs/examples-to-md.js examples/node/[^_]*.js",
+    "docs:examples": "node tooling/docs/examples-to-md.js examples/node",
     "docs:api": "typedoc",
     "commitlint": "commitlint --from develop",
     "lint": "run-p lint:*",

--- a/tooling/autorest/compiler.yaml
+++ b/tooling/autorest/compiler.yaml
@@ -17,7 +17,7 @@ directive:
 
 version: ^3.7.1
 use-extension:
-  '@autorest/typescript': ^6.0.23
+  '@autorest/typescript': ^6.0.39
   '@autorest/modelerfour': ^4.27.0
 # replace with a link to https://github.com/aeternity/aesophia_http/blob/master/config/swagger.yaml
 # at specific version after fixing https://github.com/aeternity/aesophia_http/issues/87

--- a/tooling/autorest/middleware.yaml
+++ b/tooling/autorest/middleware.yaml
@@ -186,7 +186,7 @@ directive:
 
 version: ^3.7.1
 use-extension:
-  '@autorest/typescript': ^6.0.23
+  '@autorest/typescript': ^6.0.39
   '@autorest/modelerfour': ^4.27.0
 input-file: middleware-openapi.yaml
 output-folder: ../../src/apis/middleware

--- a/tooling/autorest/node.yaml
+++ b/tooling/autorest/node.yaml
@@ -150,7 +150,7 @@ directive:
 
 version: ^3.7.1
 use-extension:
-  '@autorest/typescript': ^6.0.23
+  '@autorest/typescript': ^6.0.39
   '@autorest/modelerfour': ^4.27.0
 input-file: https://raw.githubusercontent.com/aeternity/aeternity/v7.3.0-rc5/apps/aehttp/priv/oas3.yaml
 output-folder: ../../src/apis/node

--- a/tooling/autorest/postprocessing.js
+++ b/tooling/autorest/postprocessing.js
@@ -81,10 +81,6 @@ await Promise.all(
       throw error;
     }
 
-    // TODO: remove after solving https://github.com/Azure/autorest.typescript/issues/1955
-    content = content.replaceAll(/ from "\.(.*)\/models";/g, ' from ".$1/models/index";');
-    content = content.replaceAll(/ from "\.(.+)";/g, ' from ".$1.js";');
-
     if (name === module) {
       content = content.replace(/ {2}\$host: string;/, '  readonly $host: string;');
 


### PR DESCRIPTION
In Ubuntu:
```
sh -c "echo [^b]*"
```
does the same as
```
sh -c "echo b*"
```

This PR is supported by the Æternity Foundation